### PR TITLE
Mark up names for Chapter 1 until l.1000, for issue #37

### DIFF
--- a/portrait.xml
+++ b/portrait.xml
@@ -127,7 +127,7 @@
 		<p>His father told him that story: his father looked at him 
 			through a glass: he had a hairy face. </p>
 		<p>He was baby tuckoo. The moocow came down the road 
-			where Betty Byrne lived: she sold lemon platt. </p>
+			where <persName>Betty Byrne</persName> lived: she sold lemon platt. </p>
 
 		<lg type="song">
 			<l>O, the wild rose blossoms</l> 
@@ -152,17 +152,17 @@
 			<l>Tralala lala.</l> 
 		</lg>
 
-		<p>Uncle Charles and Dante clapped. They were older than his 
-			father and mother but uncle Charles was older than Dante. </p>
+		<p><persName>Uncle Charles</persName> and <persName>Dante</persName> clapped. They were older than his 
+			father and mother but <persName>uncle Charles</persName> was older than <persName>Dante</persName>. </p>
 		<p>Dante had two brushes in her press. The brush with the 
-			maroon velvet back was for Michael Davitt and the brush with 
-			the green velvet back was for Parnell. Dante gave him a cachou 
+			maroon velvet back was for <persName>Michael Davitt</persName> and the brush with 
+			the green velvet back was for <persName>Parnell</persName>. <persName>Dante</persName> gave him a cachou 
 			every time he brought her a piece of tissue paper. </p>
-		<p>The Vances lived in number seven. They had a different 
-			father and mother. They were Eileen's father and mother. 
-			When they were grown up he was going to marry Eileen. He 
+		<p>The <persName>Vances</persName> lived in number seven. They had a different 
+			father and mother. They were <persName>Eileen</persName>'s father and mother. 
+			When they were grown up he was going to marry <persName>Eileen</persName>. He 
 			hid under the table. His mother said: </p>
-		<p><said who="Mary Dedalus">—O, Stephen will apologise. </said></p>
+		<p><said who="Mary Dedalus">—O, <persName>Stephen</persName> will apologise. </said></p>
 		<p>Dante said: </p>
 		<p><said who="Dante">—O, if not, the eagles will come and pull out his eyes. </said></p>
 
@@ -191,33 +191,33 @@
 			out of sight of his prefect, out of the reach of the rude feet, 
 			feigning to run now and then. He felt his body small and weak 
 			amid the throng of players and his eyes were weak and watery. 
-			Rody Kickham was not like that: he would be captain of the 
+			<persName>Rody Kickham</persName> was not like that: he would be captain of the 
 			third line all the fellows said. </p>
-		<p>Rody Kickham was a decent fellow but Nasty Roche was a 
-			stink. Rody Kickham had greaves in his number and a hamper 
-			in the refectory. Nasty Roche had big hands. He called the 
+		<p><persName>Rody Kickham</persName> was a decent fellow but <persName>Nasty Roche</persName> was a 
+			stink. <persName>Rody Kickham</persName> had greaves in his number and a hamper 
+			in the refectory. <persName>Nasty Roche</persName> had big hands. He called the 
 			Friday pudding dog-in-the-blanket. And one day he had 
 			asked: </p>
 		<p><said who="Nasty Roche">—What is your name? </said></p>
 		<p>Stephen had answered: </p>
-		<p><said who="Stephen">—Stephen Dedalus. </said></p>
-		<p>Then Nasty Roche had said: </p>
+		<p><said who="Stephen">—<persName>Stephen Dedalus</persName>. </said></p>
+		<p>Then <persName>Nasty Roche</persName> had said: </p>
 		<p><said who="Nasty Roche">—What kind of a name is that? </said></p>
-		<p>And when Stephen had not been able to answer Nasty 
-			Roche had asked: </p>
+		<p>And when <persName>Stephen</persName> had not been able to answer <persName>Nasty 
+			Roche</persName> had asked: </p>
 		<p><said who="Nasty Roche">—What is your father? </said></p>
-		<p>Stephen had answered: </p>
+		<p><persName>Stephen</persName> had answered: </p>
 		<p><said who="Stephen">—A gentleman. </said></p>
-		<p>Then Nasty Roche had asked: </p>
+		<p>Then <persName>Nasty Roche</persName> had asked: </p>
 		<p><said who="Nasty Roche">—Is he a magistrate? </said></p>
 		<p>He crept about from point to point on the fringe of his line, 
 			making little runs now and then. But his hands were bluish 
 			with cold. He kept his hands in the sidepockets of his belted 
 			grey suit. That was a belt round his pocket. And belt was also 
-			to give a fellow a belt. One day a fellow had said to Cantwell: </p>
+			to give a fellow a belt. One day a fellow had said to <persName>Cantwell</persName>: </p>
 		<p><said who="a fellow">—I'd give you such a belt in a second. </said></p>
-		<p>Cantwell had answered: </p>
-		<p><said who="Cantwell">—Go and fight your match. Give Cecil Thunder a belt. I'd 
+		<p><persName>Cantwell</persName> had answered: </p>
+		<p><said who="Cantwell">—Go and fight your match. Give <persName>Cecil Thunder</persName> a belt. I'd 
 				like to see you. He'd give you a toe in the rump for yourself.</said></p>
 		<p>That was not a nice expression. His mother had told him 
 			not to speak with the rough boys in the college. Nice mother! 
@@ -235,14 +235,14 @@
 			him from the car, waving their hands: </p>
 
 		<said who="Mary Dedalus, Simon Dedalus"> 
-			<p>—Goodbye, Stephen, goodbye! </p>
-			<p>—Goodbye, Stephen, goodbye! </p>
+			<p>—Goodbye, <persName>Stephen</persName>, goodbye! </p>
+			<p>—Goodbye, <persName>Stephen</persName>, goodbye! </p>
 		</said>
 
 		<p>He was caught in the whirl of a scrimmage and, fearful of 
 			the flashing eyes and muddy boots, bent down to look through 
 			the legs. The fellows were struggling and groaning and their 
-			legs were rubbing and kicking and stamping. Then Jack Lawton's 
+			legs were rubbing and kicking and stamping. Then <persName>Jack Lawton</persName>'s 
 			yellow boots dodged out the ball and all the other boots 
 			and legs ran after. He ran after them a little way and then 
 			stopped. It was useless to run on. Soon they would be going 
@@ -251,7 +251,7 @@
 			to seventysix. </p>
 		<p>It would be better to be in the studyhall than out there in 
 			the cold. The sky was pale and cold but there were lights in 
-			the castle. He wondered from which window Hamilton Rowan 
+			the castle. He wondered from which window <persName>Hamilton Rowan</persName> 
 			had thrown his hat on the haha and had there been flowerbeds 
 			at that time under the windows. One day when he had been 
 			called to the castle the butler had shown him the marks of the 
@@ -259,12 +259,12 @@
 			piece of shortbread that the community ate. It was nice and 
 			warm to see the lights in the castle. It was like something in a 
 			book. Perhaps <place><location><geo>52.640379 -1.132563</geo></location><placeName>Leicester Abbey</placeName></place> was like that. And there were 
-			nice sentences in Doctor Cornwell's Spelling Book. They were 
+			nice sentences in <persName>Doctor Cornwell</persName>'s Spelling Book. They were 
 			like poetry but they were only sentences to learn the spelling 
 			from. </p>
 
 		<lg>
-			<l>Wolsey died in <place><location><geo>52.640379 -1.132563</geo></location><placeName>Leicester Abbey</placeName></place></l> 
+			<l><persName>Wolsey</persName> died in <place><location><geo>52.640379 -1.132563</geo></location><placeName>Leicester Abbey</placeName></place></l> 
 			<l>Where the abbots buried him.</l> 
 			<l>Canker is a disease of plants,</l> 
 			<l>Cancer one of animals.</l> 
@@ -273,20 +273,20 @@
 		<p>It would be nice to lie on the hearthrug before the fire, 
 			leaning his head upon his hands, and think on those sentences. 
 			He shivered as if he had cold slimy water next his skin. That 
-			was mean of Wells to shoulder him into the square ditch 
-			because he would not swop his little snuffbox for Wells's 
+			was mean of <persName>Wells</persName> to shoulder him into the square ditch 
+			because he would not swop his little snuffbox for <persName>Wells</persName>'s 
 			seasoned hacking chestnut, the conqueror of forty. How cold 
 			and slimy the water had been! A fellow had once seen a big rat 
-			jump into the scum. Mother was sitting at the fire with Dante 
-			waiting for Brigid to bring in the tea. She had her feet on the 
+			jump into the scum. Mother was sitting at the fire with <persName>Dante</persName> 
+			waiting for <persName>Brigid</persName> to bring in the tea. She had her feet on the 
 			fender and her jewelly slippers were so hot and they had such 
-			a lovely warm smell! Dante knew a lot of things. She had 
+			a lovely warm smell! <persName>Dante</persName> knew a lot of things. She had 
 			taught him where the <place><location><geo>-18.615949 41.280858</geo></location><placeName>Mozambique Channel</placeName></place> was and what was 
 			<place><location><geo>38.627003 -90.199404</geo></location><placeName>the longest river in America</placeName></place> and what was the name of the 
-			highest mountain in the moon. Father Arnall knew more than 
-			Dante because he was a priest but both his father and uncle 
-			Charles said that Dante was a clever woman and a wellread 
-			woman. And when Dante made that noise after dinner and 
+			highest mountain in the moon. <persName>Father Arnall</persName> knew more than 
+			<persName>Dante</persName> because he was a priest but both his father and <persName>uncle 
+			Charles</persName> said that <persName>Dante</persName> was a clever woman and a wellread 
+			woman. And when <persName>Dante</persName> made that noise after dinner and 
 			then put up her hand to her mouth: that was heartburn. </p>
 		<p>A voice cried far out on the playground: </p>
 
@@ -301,14 +301,14 @@
 		</said>
 
 		<p>The players closed around, flushed and muddy, and he went 
-			among them, glad to go in. Rody Kickham held the ball by its 
+			among them, glad to go in. <persName>Rody Kickham</persName> held the ball by its 
 			greasy lace. A fellow asked him to give it one last: but he 
-			walked on without even answering the fellow. Simon Moonan 
+			walked on without even answering the fellow. <persName>Simon Moonan</persName> 
 			told him not to because the prefect was looking. The fellow 
-			turned to Simon Moonan and said: </p>
-		<p><said who="a fellow">—We all know why you speak. You are McGlade's suck.</said></p>
-		<p>Suck was a queer word. The fellow called Simon Moonan 
-			that name because Simon Moonan used to tie the prefect's 
+			turned to <persName>Simon Moonan</persName> and said: </p>
+		<p><said who="a fellow">—We all know why you speak. You are <persName>McGlade</persName>'s suck.</said></p>
+		<p>Suck was a queer word. The fellow called <persName>Simon Moonan</persName> 
+			that name because <persName>Simon Moonan</persName> used to tie the prefect's 
 			false sleeves behind his back and the prefect used to let on to 
 			be angry. But the sound was ugly. Once he had washed his 
 			hands in the lavatory of the <place><location><geo>53.342872 -6.260651</geo></location><placeName>Wicklow Hotel</placeName></place> and his father 
@@ -325,27 +325,27 @@
 			wettish. But soon the gas would be lit and in burning it made a 
 			light noise like a little song. Always the same: and when the 
 			fellows stopped talking in the playroom you could hear it. </p>
-		<p>It was the hour for sums. Father Arnall wrote a hard sum 
+		<p>It was the hour for sums. <persName>Father Arnall</persName> wrote a hard sum 
 			on the board and then said: </p>
 		<p><said who="Father Arnall">—Now then, who will win? Go ahead, York! Go ahead, 
-				Lancaster!</said></p>
-		<p>Stephen tried his best but the sum was too hard and he felt 
+			Lancaster!</said></p>
+		<p><persName>Stephen</persName> tried his best but the sum was too hard and he felt 
 			confused. The little silk badge with the white rose on it that 
 			was pinned on the breast of his jacket began to flutter. He was 
 			no good at sums but he tried his best so that York might not 
-			lose. Father Arnall's face looked very black but he was not in 
-			a wax: he was laughing. Then Jack Lawton cracked his fingers 
-			and Father Arnall looked at his copybook and said: </p>
+			lose. <persName>Father Arnall</persName>'s face looked very black but he was not in 
+			a wax: he was laughing. Then <persName>Jack Lawton</persName> cracked his fingers 
+			and <persName>Father Arnall</persName> looked at his copybook and said: </p>
 		<p><said who="Father Arnall">—Right. Bravo Lancaster! The red rose wins. Come on 
 				now, York! Forge ahead!</said></p>
-		<p>Jack Lawton looked over from his side. The little silk badge 
+		<p><persName>Jack Lawton</persName> looked over from his side. The little silk badge 
 			with the red rose on it looked very rich because he had a blue 
-			sailor top on.  Stephen felt his own face red too, thinking of all 
-			the bets about who would get first place in elements, Jack 
-			Lawton or he. Some weeks Jack Lawton got the card for first 
+			sailor top on.  <persName>Stephen</persName> felt his own face red too, thinking of all 
+			the bets about who would get first place in elements, <persName>Jack 
+			Lawton</persName> or he. Some weeks <persName>Jack Lawton</persName> got the card for first 
 			and some weeks he got the card for first. His white silk badge 
 			fluttered and fluttered as he worked at the next sum and heard 
-			Father Arnall's voice. Then all his eagerness passed away and 
+			<persName>Father Arnall</persName>'s voice. Then all his eagerness passed away and 
 			he felt his face quite cool. He thought his face must be white 
 			because it felt so cool. He could not get out the answer for the 
 			sum but it did not matter. White roses and red roses: those 
@@ -363,7 +363,7 @@
 			he drank off the hot weak tea which the clumsy scullion, girt 
 			with a white apron, poured into his cup. He wondered 
 			whether the scullion's apron was damp too or whether all 
-			white things were cold and damp. Nasty Roche and Saurin 
+			white things were cold and damp. <persName>Nasty Roche</persName> and <persName>Saurin</persName> 
 			drank cocoa that their people sent them in tins. They said they 
 			could not drink the tea; that it was hogwash. Their fathers 
 			were magistrates, the fellows said. </p>
@@ -372,14 +372,14 @@
 			longed to be at home and lay his head on his mother's lap. But 
 			he could not: and so he longed for the play and study and 
 			prayers to be over and to be in bed. </p>
-		<p>He drank another cup of hot tea and Fleming said: </p>
+		<p>He drank another cup of hot tea and <persName>Fleming</persName> said: </p>
 		<p><said who="Fleming">—What's up? Have you a pain or what's up with you? </said></p>
-		<p><said who="Stephen">—I don't know, Stephen said. </said></p>
-		<p><said who="Fleming">—Sick in your breadbasket, Fleming said, because your 
+		<p><said who="Stephen">—I don't know, <persName>Stephen</persName> said. </said></p>
+		<p><said who="Fleming">—Sick in your breadbasket, <persName>Fleming</persName> said, because your 
 				face looks white. It will go away. </said></p>
-		<p><said who="Stephen">—O yes, Stephen said. </said></p>
+		<p><said who="Stephen">—O yes, <persName>Stephen</persName> said. </said></p>
 		<p>But he was not sick there. He thought that he was sick in 
-			his heart if you could be sick in that place. Fleming was very 
+			his heart if you could be sick in that place. <persName>Fleming</persName> was very 
 			decent to ask him. He wanted to cry. He leaned his elbows on 
 			the table and shut and opened the flaps of his ears. Then he 
 			heard the noise of the refectory every time he opened the flaps 
@@ -391,40 +391,40 @@
 			roaring again, stopping. It was nice to hear it roar and stop 
 			and then roar out of the tunnel again and then stop. </p>
 		<p>Then the higher line fellows began to come down along the 
-			matting in the middle of the refectory, Paddy Rath and Jimmy 
-			Magee and the Spaniard who was allowed to smoke cigars and 
+			matting in the middle of the refectory, <persName>Paddy Rath</persName> and <persName>Jimmy 
+			Magee</persName> and the Spaniard who was allowed to smoke cigars and 
 			the little Portuguese who wore the woolly cap. And then the 
 			lower line tables and the tables of the third line. And every 
 			single fellow had a different way of walking. </p>
 		<p>He sat in a corner of the playroom pretending to watch a 
 			game of dominos and once or twice he was able to hear for an 
 			instant the little song of the gas. The prefect was at the door 
-			with some boys and Simon Moonan was knotting his false 
+			with some boys and <persName>Simon Moonan</persName> was knotting his false 
 			sleeves. He was telling them something about <place><location><geo>52.888640 -8.428450</geo></location><placeName>Tullabeg</placeName></place>. </p>
-		<p>Then he went away from the door and Wells came over to 
-			Stephen and said: </p>
-		<p><said who="Wells">—Tell us, Dedalus, do you kiss your mother before you go 
+		<p>Then he went away from the door and <persName>Wells</persName> came over to 
+			<persName>Stephen</persName> and said: </p>
+		<p><said who="Wells">—Tell us, <persName>Dedalus</persName>, do you kiss your mother before you go 
 				to bed? </said></p>
-		<p>Stephen answered: </p>
+		<p><persName>Stephen</persName> answered: </p>
 		<p><said who="Stephen">—I do. </said></p>
-		<p>Wells turned to the other fellows and said: </p>
+		<p><persName>Wells</persName> turned to the other fellows and said: </p>
 		<p><said who="Wells">—O, I say, here's a fellow says he kisses his mother every 
 				night before he goes to bed. </said></p>
 		<p>The other fellows stopped their game and turned round, 
-			laughing. Stephen blushed under their eyes and said: </p>
+			laughing. <persName>Stephen</persName> blushed under their eyes and said: </p>
 		<p><said who="Stephen">—I do not. </said></p>
-		<p>Wells said: </p>
+		<p><persName>Wells</persName> said: </p>
 		<p><said who="Wells">—O, I say, here's a fellow says he doesn't kiss his mother 
 				before he goes to bed. </said></p>
-		<p>They all laughed again. Stephen tried to laugh with them. 
+		<p>They all laughed again. <persName>Stephen</persName> tried to laugh with them. 
 			He felt his whole body hot and confused in a moment. What 
 			was the right answer to the question? He had given two and 
-			still Wells laughed. But Wells must know the right answer for 
-			he was in third of grammar. He tried to think of Wells's 
-			mother but he did not dare to raise his eyes to Wells's face. He 
-			did not like Wells's face. It was Wells who had shouldered him 
+			still <persName>Wells</persName> laughed. But <persName>Wells</persName> must know the right answer for 
+			he was in third of grammar. He tried to think of <persName>Wells</persName>'s 
+			mother but he did not dare to raise his eyes to <persName>Wells</persName>'s face. He 
+			did not like <persName>Wells</persName>'s face. It was <persName>Wells</persName> who had shouldered him 
 			into the square ditch the day before because he would not 
-			swop his little snuffbox for Wells's seasoned hacking chestnut, 
+			swop his little snuffbox for <persName>Wells</persName>'s seasoned hacking chestnut, 
 			the conqueror of forty. It was a mean thing to do; all the 
 			fellows said it was. And how cold and slimy the water had 
 			been! And a fellow had once seen a big rat jump plop into the 
@@ -445,15 +445,15 @@
 			seventysix. But the Christmas vacation was very far away: but 
 			one time it would come because the earth moved round always. </p>
 		<p>There was a picture of the earth on the first page of his 
-			geography: a big ball in the middle of clouds. Fleming had a 
+			geography: a big ball in the middle of clouds. <persName>Fleming</persName> had a 
 			box of crayons and one night during free study he had coloured 
 			the earth green and the clouds maroon. That was like 
-			the two brushes in Dante's press, the brush with the green 
-			velvet back for Parnell and the brush with the maroon velvet 
-			back for Michael Davitt. But he had not told Fleming to 
-			colour them those colours. Fleming had done it himself. </p>
+			the two brushes in <persName>Dante</persName>'s press, the brush with the green 
+			velvet back for <persName>Parnell</persName> and the brush with the maroon velvet 
+			back for <persName>Michael Davitt</persName>. But he had not told <persName>Fleming</persName> to 
+			colour them those colours. <persName>Fleming</persName> had done it himself. </p>
 		<p>He opened the geography to study the lesson; but he could 
-			not learn the names of places in America. Still they were all 
+			not learn the names of places in <placeName>America</placeName>. Still they were all 
 			different places that had those different names. They were all 
 			in different countries and the countries were in continents and 
 			the continents were in the world and the world was in the 
@@ -462,22 +462,22 @@
 			had written there: himself, his name and where he was. </p>
 
 		<lg>
-			<l>Stephen Dedalus</l> 
+			<l><persName>Stephen Dedalus</persName></l> 
 			<l>Class of Elements</l> 
 			<l><place><location><geo>53.310769 -6.684716</geo></location><placeName>Clongowes Wood College</placeName></place></l> 
 			<l><place><location><geo>53.251067 -6.665231 </geo></location><placeName>Sallins</placeName></place></l> 
-			<l>County Kildare</l> 
-			<l>Ireland</l> 
-			<l>Europe</l> 
-			<l>The World</l> 
-			<l>The Universe</l> 
+			<l><placeName>County Kildare</placeName></l> 
+			<l><placeName>Ireland</placeName></l> 
+			<l><placeName>Europe</placeName></l> 
+			<l><placeName>The World</placeName></l> 
+			<l><placeName>The Universe</placeName></l> 
 		</lg>
 
-		<p>That was in his writing: and Fleming one night for a cod 
+		<p>That was in his writing: and <persName>Fleming</persName> one night for a cod 
 			had written on the opposite page: </p>
 		<lg>
-			<l>Stephen Dedalus is my name,</l> 
-			<l>Ireland is my nation.</l> 
+			<l><persName>Stephen Dedalus</persName> is my name,</l> 
+			<l><placeName>Ireland</placeName> is my nation.</l> 
 			<l><place><location><geo>53.310769 -6.684716</geo></location><placeName>Clongowes</placeName></place>is my dwellingplace</l> 
 			<l>And heaven my expectation.</l> 
 		</lg>
@@ -485,14 +485,14 @@
 		<p>He read the verses backwards but then they were not poetry. 
 			Then he read the flyleaf from the bottom to the top till he 
 			came to his own name. That was he: and he read down the 
-			page again. What was after the universe? Nothing. But was 
-			there anything round the universe to show where it stopped 
+			page again. What was after <placeName>the universe</placeName>? Nothing. But was 
+			there anything round <placeName>the universe</placeName> to show where it stopped 
 			before the nothing place began? It could not be a wall but 
 			there could be a thin thin line there all round everything. It 
 			was very big to think about everything and everywhere. Only 
 			God could do that. He tried to think what a big thought that 
 			must be but he could think only of God. God was God's name 
-			just as his name was Stephen. <emph>Dieu</emph> was the French for God 
+			just as his name was <persName>Stephen</persName>. <emph>Dieu</emph> was the French for God 
 			and that was God's name too; and when anyone prayed to 
 			God and said <emph>Dieu</emph> then God knew at once that it was a 
 			French person that was praying. But though there were 
@@ -504,13 +504,13 @@
 			his head very big. He turned over the flyleaf and looked 
 			wearily at the green round earth in the middle of the maroon 
 			clouds. He wondered which was right, to be for the green or 
-			for the maroon, because Dante had ripped the green velvet 
-			back off the brush that was for Parnell one day with her scissors 
-			and had told him that Parnell was a bad man. He wondered 
+			for the maroon, because <persName>Dante</persName> had ripped the green velvet 
+			back off the brush that was for <persName>Parnell</persName> one day with her scissors 
+			and had told him that <persName>Parnell</persName> was a bad man. He wondered 
 			if they were arguing at home about that. That was called 
-			politics. There were two sides in it: Dante was on one side and 
-			his father and Mr Casey were on the other side but his mother 
-			and uncle Charles were on no side. Every day there was 
+			politics. There were two sides in it: <persName>Dante</persName> was on one side and 
+			his father and <persName>Mr Casey</persName> were on the other side but his mother 
+			and <persName>uncle Charles</persName> were on no side. Every day there was 
 			something in the paper about it. </p>
 		<p>It pained him that he did not know well what politics meant 
 			and that he did not know where the universe ended. He felt 
@@ -592,7 +592,7 @@
 		<lg type="prayer">
 			<l>God bless my father and my mother and spare them to me!</l> 
 			<l>God bless my little brothers and sisters and spare them to me!</l> 
-			<l>God bless Dante and uncle Charles and spare them to me!</l> 
+			<l>God bless <persName>Dante</persName> and <persName>uncle Charles</persName> and spare them to me!</l> 
 		</lg>
 
 		<p>He blessed himself and climbed quickly into bed and, 
@@ -664,10 +664,10 @@
 			and green ivy round the old portraits on the walls. Holly and 
 			ivy for him and for Christmas. </p>
 		<p>Lovely ... </p>
-		<p>All the people. Welcome home, Stephen! Noises of welcome. 
+		<p>All the people. Welcome home, <persName>Stephen</persName>! Noises of welcome. 
 			His mother kissed him. Was that right? His father was a 
 			marshal now: higher than a magistrate. Welcome home, 
-			Stephen! </p>
+			<persName>Stephen</persName>! </p>
 		<p>Noises ... </p>
 		<p>There was a noise of curtainrings running back along the 
 			rods, of water being splashed in the basins. There was a noise 
@@ -679,13 +679,13 @@
 		<p>He got up and sat on the side of his bed. He was weak. He 
 			tried to pull on his stocking. It had a horrid rough feel. The 
 			sunlight was queer and cold. </p>
-		<p>Fleming said: </p>
+		<p><persName>Fleming</persName> said: </p>
 		<p><said who="Fleming">—Are you not well? </said></p>
-		<p>He did not know; and Fleming said: </p>
-		<p><said who="Fleming">—Get back into bed. I'll tell McGlade you're not well. </said></p>
+		<p>He did not know; and <persName>Fleming</persName> said: </p>
+		<p><said who="Fleming">—Get back into bed. I'll tell <persName>McGlade</persName> you're not well. </said></p>
 		<p><said who="Fleming">—He's sick. </said></p>
 		<p><said who="">—Who is? </said></p>
-		<p><said who="Fleming">—Tell McGlade. </said></p>
+		<p><said who="Fleming">—Tell <persName>McGlade</persName>. </said></p>
 		<p><said who="">—Get back into bed. </said></p>
 		<p><said who="">—Is he sick? </said></p>
 		<p>A fellow held his arms while he loosened the stocking 
@@ -696,13 +696,13 @@
 			him into the square ditch, they were saying. </p>
 		<p>Then their voices ceased; they had gone. A voice at his bed 
 			said: </p>
-		<p><said who="Wells">—Dedalus, don't spy on us, sure you won't? </said></p>
-		<p>Wells's face was there. He looked at it and saw that Wells 
+		<p><said who="Wells">—<persName>Dedalus</persName>, don't spy on us, sure you won't? </said></p>
+		<p><persName>Wells</persName>'s face was there. He looked at it and saw that <persName>Wells</persName> 
 			was afraid. </p>
 		<p><said who="Wells">—I didn't mean to. Sure you won't? </said></p>
 		<p>His father had told him, whatever he did, never to peach on 
 			a fellow. He shook his head and answered no and felt glad. 
-			Wells said: </p>
+			<persName>Wells</persName> said: </p>
 		<p><said who="Wells">—I didn't mean to, honour bright. It was only for cod. I'm 
 				sorry. </said></p>
 		<p>The face and the voice went away. Sorry because he was 
@@ -710,10 +710,10 @@
 			of plants and cancer one of animals: or another different. That 
 			was a long time ago then out on the playgrounds in the evening 
 			light, creeping from point to point on the fringe of his 
-			line, a heavy bird flying low through the grey light. Leicester 
-			Abbey lit up. Wolsey died there. The abbots buried him 
+			line, a heavy bird flying low through the grey light. <placeName>Leicester 
+			Abbey</placeName> lit up. <persName>Wolsey</persName> died there. The abbots buried him 
 			themselves. </p>
-		<p>It was not Wells's face, it was the prefect's. He was not 
+		<p>It was not <persName>Wells</persName>'s face, it was the prefect's. He was not 
 			foxing. No, no: he was sick really. He was not foxing. And he 
 			felt the prefect's hand on his forehead; and he felt his forehead 
 			warm and damp against the prefect's cold damp hand. That 
@@ -725,10 +725,10 @@
 			their sides. Their coats dried then. They were only dead 
 			things. </p>
 		<p>The prefect was there again and it was his voice that was 
-			saying that he was to get up, that Father Minister had said he 
+			saying that he was to get up, that <persName>Father Minister</persName> had said he 
 			was to get up and dress and go to the infirmary. And while he 
 			was dressing himself as quickly as he could the prefect said: </p>
-		<p><said who="the prefect">—We must pack off to Brother Michael because we have 
+		<p><said who="the prefect">—We must pack off to <persName>Brother Michael</persName> because we have 
 			the collywobbles! Terrible thing to have the collywobbles! 
 			How we wobble when we have the collywobbles! </said></p>
 		<p>He was very decent to say that. That was all to make him 
@@ -741,11 +741,11 @@
 			with a vague fear the warm turfcoloured bogwater, the warm 
 			moist air, the noise of plunges, the smell of the towels, like 
 			medicine. </p>
-		<p>Brother Michael was standing at the door of the infirmary 
+		<p><persName>Brother Michael</persName> was standing at the door of the infirmary 
 			and from the door of the dark cabinet on his right came a 
 			smell like medicine. That came from the bottles on the 
-			shelves. The prefect spoke to Brother Michael and Brother 
-			Michael answered and called the prefect sir. He had reddish 
+			shelves. The prefect spoke to <persName>Brother Michael</persName> and <persName>Brother 
+			Michael</persName> answered and called the prefect sir. He had reddish 
 			hair mixed with grey and a queer look. It was queer that he 
 			would always be a brother. It was queer too that you could 
 			not call him sir because he was a brother and had a different 
@@ -753,21 +753,21 @@
 			catch up on the others? </p>
 		<p>There were two beds in the room and in one bed there was 
 			a fellow: and when they went in he called out: </p>
-		<p><said who="Athy">—Hello! It's young Dedalus! What's up? </said></p>
-		<p><said who="Brother Michael">—The sky is up, Brother Michael said. </said></p>
+		<p><said who="Athy">—Hello! It's young <persName>Dedalus</persName>! What's up? </said></p>
+		<p><said who="Brother Michael">—The sky is up, <persName>Brother Michael</persName> said. </said></p>
 		<p>He was a fellow out of the third of grammar and, while 
-			Stephen was undressing, he asked Brother Michael to bring 
+			<persName>Stephen</persName> was undressing, he asked <persName>Brother Michael</persName> to bring 
 			him a round of buttered toast. </p>
 		<p><said who="Athy">—Ah, do! he said. </said></p>
-		<p><said who="Brother Michael">—Butter you up! said Brother Michael. You'll get your 
+		<p><said who="Brother Michael">—Butter you up! said <persName>Brother Michael</persName>. You'll get your 
 				walking papers in the morning when the doctor comes. </said></p>
 		<p><said who="Athy">—Will I? the fellow said. I'm not well yet. </said></p>
-		<p>Brother Michael repeated: </p>
+		<p><persName>Brother Michael</persName> repeated: </p>
 		<p><said who="Athy">—You'll get your walking papers, I tell you. </said></p>
 		<p>He bent down to rake the fire. He had a long back like the 
 			long back of a tramhorse. He shook the poker gravely and 
 			nodded his head at the fellow out of third of grammar. </p>
-		<p>Then Brother Michael went away and after a while the 
+		<p>Then <persName>Brother Michael</persName> went away and after a while the 
 			fellow out of third of grammar turned in towards the wall and 
 			fell asleep. </p>
 		<p>That was the infirmary. He was sick then. Had they written 
@@ -780,25 +780,25 @@
 			<l>I am sick. I want to go home. Please come and take me
 			home. I am in the infirmary.</l>
 			<l>Your fond son,</l> 
-			<l>Stephen</l> 
+			<l><persName>Stephen</persName></l> 
 		</lg>
 
 		<p>How far away they were! There was cold sunlight outside 
 			the window. He wondered if he would die. You could die just 
 			the same on a sunny day. He might die before his mother 
 			came. Then he would have a dead mass in the chapel like the 
-			way the fellows had told him it was when Little had died. All 
+			way the fellows had told him it was when <persName>Little</persName> had died. All 
 			the fellows would be at the mass, dressed in black, all with sad 
-			faces. Wells too would be there but no fellow would look at 
+			faces. <persName>Wells</persName> too would be there but no fellow would look at 
 			him. The rector would be there in a cope of black and gold 
 			and there would be tall yellow candles on the altar and round 
 			the catafalque. And they would carry the coffin out of the 
 			chapel slowly and he would be buried in the little graveyard of 
-			the community off the main avenue of limes. And Wells would 
+			the community off the main avenue of limes. And <persName>Wells</persName> would 
 			be sorry then for what he had done. And the bell would toll 
 			slowly. </p>
 		<p>He could hear the tolling. He said over to himself the song 
-			that Brigid had taught him. </p>
+			that <persName>Brigid</persName> had taught him. </p>
 
 		<lg type="song">
 			<l>Dingdong! The castle bell!</l> 
@@ -817,58 +817,58 @@
 			wanted to cry quietly but not for himself: for the words, so 
 			beautiful and sad, like music. The bell! The bell! Farewell! O 
 			farewell! </p>
-		<p>The cold sunlight was weaker and Brother Michael was 
+		<p>The cold sunlight was weaker and <persName>Brother Michael</persName> was 
 			standing at his bedside with a bowl of beeftea. He was glad for 
 			his mouth was hot and dry. He could hear them playing on the 
 			playgrounds. And the day was going on in the college just as if 
 			he were there. </p>
-		<p>Then Brother Michael was going away and the fellow out of 
+		<p>Then <persName>Brother Michael</persName> was going away and the fellow out of 
 			third of grammar told him to be sure and come back and tell 
-			him all the news in the paper. He told Stephen that his name 
-			was Athy and that his father kept a lot of racehorses that were 
+			him all the news in the paper. He told <persName>Stephen</persName> that his name 
+			was <persName>Athy</persName> and that his father kept a lot of racehorses that were 
 			spiffing jumpers and that his father would give a good tip to 
-			Brother Michael any time he wanted it because Brother Michael 
+			<persName>Brother Michael</persName> any time he wanted it because <persName>Brother Michael</persName> 
 			was very decent and always told him the news out of the 
 			paper they got every day up in the castle. There was every 
 			kind of news in the paper: accidents, shipwrecks, sports and 
 			politics. </p>
 		<p><said who="Athy">—Now it is all about politics in the paper, he said. Do your 
 				people talk about that too? </said></p>
-		<p><said who="Stephen">—Yes, Stephen said. </said></p>
+		<p><said who="Stephen">—Yes, <persName>Stephen</persName> said. </said></p>
 		<p><said who="Athy">—Mine too, he said. </said></p>
 		<p>Then he thought for a moment and said: </p>
-		<p><said who="Athy">—You have a queer name, Dedalus, and I have a queer 
-			name too, <place><location><geo>52.991834 -6.985728</geo></location><placeName>Athy</placeName></place>. My name is the name of a town. Your name 
+		<p><said who="Athy">—You have a queer name, <persName>Dedalus</persName>, and I have a queer 
+			name too, <place><location><geo>52.991834 -6.985728</geo></location><placeName><persName>Athy</persName></placeName></place>. My name is the name of a town. Your name 
 			is like Latin. </said></p>
 		<p>Then he asked: </p>
 		<p><said who="Athy">—Are you good at riddles? </said></p>
-		<p>Stephen answered: </p>
+		<p><persName>Stephen</persName> answered: </p>
 		<p><said who="Stephen">—Not very good. </said></p>
 		<p>Then he said: </p>
-		<p><said who="Athy">—Can you answer me this one? Why is the county Kildare 
+		<p><said who="Athy">—Can you answer me this one? Why is the county <placeName>Kildare</placeName> 
 				like the leg of a fellow's breeches? </said></p>
-		<p>Stephen thought what could be the answer and then said: </p>
+		<p><persName>Stephen</persName> thought what could be the answer and then said: </p>
 		<p><said who="Stephen">—I give it up. </said></p>
 		<p><said who="Athy">—Because there is a thigh in it, he said. Do you see the 
-			joke? Athy is the town in the county Kildare and a thigh is the 
+			joke? <placeName><persName>Athy</persName></placeName> is the town in the county <placeName>Kildare<placeName> and a thigh is the 
 			other thigh. </said></p>
-		<p><said who="Stephen">—O, I see, Stephen said. </said></p>
+		<p><said who="Stephen">—O, I see, <persName>Stephen</persName> said. </said></p>
 		<p><said who="Athy">—That's an old riddle, he said. </said></p>
 		<p>After a moment he said: </p>
 		<p><said who="Athy">—I say! </said></p>
-		<p><said who="Stephen">—What? asked Stephen. </said></p>
+		<p><said who="Stephen">—What? asked <persName>Stephen</persName>. </said></p>
 		<p><said who="Athy">—You know, he said, you can ask that riddle another way? </said></p>
-		<p><said who="Stephen">—Can you? said Stephen. </said></p>
+		<p><said who="Stephen">—Can you? said <persName>Stephen</persName>. </said></p>
 		<p><said who="Athy">—The same riddle, he said. Do you know the other way to 
 				ask it? </said></p>
-		<p><said who="Stephen">—No, said Stephen. </said></p>
+		<p><said who="Stephen">—No, said <persName>Stephen</persName>. </said></p>
 		<p><said who="Athy">—Can you not think of the other way? he said. </said></p>
-		<p>He looked at Stephen over the bedclothes as he spoke. 
+		<p>He looked at <persName>Stephen</persName> over the bedclothes as he spoke. 
 			Then he lay back on the pillow and said: </p>
 		<p><said who="Athy">—There is another way but I won't tell you what it is. </said></p>
 		<p>Why did he not tell it? His father, who kept the racehorses, 
-			must be a magistrate too like Saurin's father and Nasty 
-			Roche's father. He thought of his own father, of how he sang 
+			must be a magistrate too like <persName>Saurin</persName>'s father and <persName>Nasty 
+			Roche</persName>'s father. He thought of his own father, of how he sang 
 			songs while his mother played and of how he always gave him 
 			a shilling when he asked for sixpence and he felt sorry for him 
 			that he was not a magistrate like the other boys' fathers. Then 
@@ -877,21 +877,21 @@
 			had presented an address to the liberator there fifty 
 			years before. You could know the people of that time by their 
 			old dress. It seemed to him a solemn time: and he wondered if 
-			that was the time when the fellows in Clongowes wore blue 
+			that was the time when the fellows in <placeName>Clongowes</placeName> wore blue 
 			coats with brass buttons and yellow waistcoats and caps of 
 			rabbitskin and drank beer like grownup people and kept 
 			greyhounds of their own to course the hares with. </p>
 		<p>He looked at the window and saw that the daylight had 
 			grown weaker. There would be cloudy grey light over the 
 			playgrounds. There was no noise on the playgrounds. The 
-			class must be doing the themes or perhaps Father Arnall was 
+			class must be doing the themes or perhaps <persName>Father Arnall</persName> was 
 			reading a legend out of the book. </p>
 		<p>It was queer that they had not given him any medicine. 
-			Perhaps Brother Michael would bring it back when he came. 
+			Perhaps <persName>Brother Michael</persName> would bring it back when he came. 
 			They said you got stinking stuff to drink when you were in the 
 			infirmary. But he felt better now than before. It would be nice 
 			getting better slowly. You could get a book then. There was a 
-			book in the library about Holland. There were lovely foreign 
+			book in the library about <placeName>Holland</placeName>. There were lovely foreign 
 			names in it and pictures of strangelooking cities and ships. It 
 			made you feel so happy. </p>
 		<p>How pale the light was at the window! But that was nice. 
@@ -905,15 +905,15 @@
 			of people gathered by the waters' edge to see the ship that 
 			was entering their harbour. A tall man stood on the deck, 
 			looking out towards the flat dark land: and by the light at 
-			the pierhead he saw his face, the sorrowful face of Brother 
-			Michael. </p>
+			the pierhead he saw his face, the sorrowful face of <persName>Brother 
+			Michael</persName>. </p>
 		<p>He saw him lift his hand towards the people and heard him 
 			say in a loud voice of sorrow over the waters: </p>
 		<p><said who="Brother Michael">—He is dead. We saw him lying upon the catafalque. </said></p>
 		<p>A wail of sorrow went up from the people. </p>
-		<p><said who="the people">—Parnell! Parnell! He is dead! </said></p>
+		<p><said who="the people">—<persName>Parnell</persName>! <persName>Parnell</persName>! He is dead! </said></p>
 		<p>They fell upon their knees, moaning in sorrow. </p>
-		<p>And he saw Dante in a maroon velvet dress and with a 
+		<p>And he saw <persName>Dante</persName> in a maroon velvet dress and with a 
 			green velvet mantle hanging from her shoulders walking 
 			proudly and silently past the people who knelt by the waters' 
 			edge. </p>
@@ -931,75 +931,75 @@
 			mother had said. They were waiting for the door to open and 
 			for the servants to come in, holding the big dishes covered 
 			with their heavy metal covers. </p>
-		<p>All were waiting: uncle Charles, who sat far away in the 
-			shadow of the window, Dante and Mr Casey, who sat in the 
-			easychairs at either side of the hearth, Stephen, seated on a 
-			chair between them, his feet resting on the toasted boss. Mr 
-			Dedalus looked at himself in the pierglass above the mantelpiece, 
+		<p>All were waiting: <persName>uncle Charles</persName>, who sat far away in the 
+			shadow of the window, <persName>Dante</persName> and <persName>Mr Casey</persName>, who sat in the 
+			easychairs at either side of the hearth, <persName>Stephen</persName>, seated on a 
+			chair between them, his feet resting on the toasted boss. <persName>Mr 
+			Dedalus</persName> looked at himself in the pierglass above the mantelpiece, 
 			waxed out his moustache-ends and then, parting his 
 			coattails, stood with his back to the glowing fire: and still, 
 			from time to time, he withdrew a hand from his coattail to 
-			wax out one of his moustache-ends. Mr Casey leaned his 
+			wax out one of his moustache-ends. <persName>Mr Casey</persName> leaned his 
 			head to one side and, smiling, tapped the gland of his neck 
-			with his fingers. And Stephen smiled too for he knew now that 
-			it was not true that Mr Casey had a purse of silver in his 
-			throat. He smiled to think how the silvery noise which Mr 
-			Casey used to make had deceived him. And when he had tried 
-			to open Mr Casey's hand to see if the purse of silver was 
+			with his fingers. And <persName>Stephen</persName> smiled too for he knew now that 
+			it was not true that <persName>Mr Casey</persName> had a purse of silver in his 
+			throat. He smiled to think how the silvery noise which <persName>Mr 
+			Casey</persName> used to make had deceived him. And when he had tried 
+			to open <persName>Mr Casey</persName>'s hand to see if the purse of silver was 
 			hidden there he had seen that the fingers could not be straightened 
-			out: and Mr Casey had told him that he had got those 
-			three cramped fingers making a birthday present for Queen 
-			Victoria. </p>
-		<p>Mr Casey tapped the gland of his neck and smiled at Stephen 
-			with sleepy eyes: and Mr Dedalus said to him: </p>
+			out: and <persName>Mr Casey</persName> had told him that he had got those 
+			three cramped fingers making a birthday present for <persName>Queen 
+			Victoria</persName>. </p>
+		<p><persName>Mr Casey</persName> tapped the gland of his neck and smiled at <persName>Stephen</persName> 
+			with sleepy eyes: and <persName>Mr Dedalus</persName> said to him: </p>
 		<p><said who="Simon Dedalus">—Yes. Well now, that's all right. O, we had a good walk, 
-			hadn't we, John? Yes ...  I wonder if there's any likelihood 
+			hadn't we, <persName>John</persName>? Yes ...  I wonder if there's any likelihood 
 			of dinner this evening. Yes ....  O, well now, we got a good 
 			breath of ozone round <place><location><geo>53.190760 -6.089490</geo></location><placeName>the Head</placeName></place> today. Ay, bedad. </said></p>
-		<p>He turned to Dante and said: </p>
-		<p><said who="John Casey">—You didn't stir out at all, Mrs Riordan? </said></p>
-		<p>Dante frowned and said shortly: </p>
+		<p>He turned to <persName>Dante</persName> and said: </p>
+		<p><said who="John Casey">—You didn't stir out at all, <persName>Mrs Riordan</persName>? </said></p>
+		<p><persName>Dante</persName> frowned and said shortly: </p>
 		<p><said who="Dante">—No. </said></p>
-		<p>Mr Dedalus dropped his coattails and went over to the 
+		<p><persName>Mr Dedalus</persName> dropped his coattails and went over to the 
 			sideboard. He brought forth a great stone jar of whisky from 
 			the locker and filled the decanter slowly, bending now and 
 			then to see how much he had poured in. Then replacing the 
 			jar in the locker he poured a little of the whisky into two 
 			glasses, added a little water and came back with them to the 
 			fireplace. </p>
-		<p><said who="Simon Dedalus">—A thimbleful, John, he said, just to whet your appetite. </said></p>
-		<p>Mr Casey took the glass, drank, and placed it near him on 
+		<p><said who="Simon Dedalus">—A thimbleful, <persName>John</persName>, he said, just to whet your appetite. </said></p>
+		<p><persName>Mr Casey</persName> took the glass, drank, and placed it near him on 
 			the mantelpiece. Then he said: </p>
-		<p><said who="John Casey">—Well, I can't help thinking of our friend Christopher 
+		<p><said who="John Casey">—Well, I can't help thinking of our friend <persName>Christopher</persName> 
 				manufacturing ... </said></p>
 		<p>He broke into a fit of laughter and coughing and added: </p>
 		<p><said who="John Casey">—... manufacturing that champagne for those fellows. </said></p>
-		<p>Mr Dedalus laughed loudly. </p>
-		<p><said who="Simon Dedalus">—Is it Christy? he said. There's more cunning in one of 
+		<p><persName>Mr Dedalus</persName> laughed loudly. </p>
+		<p><said who="Simon Dedalus">—Is it <persName>Christy</persName>? he said. There's more cunning in one of 
 				those warts on his bald head than in a pack of jack foxes. </said></p>
 		<p>He inclined his head, closed his eyes, and, licking his lips 
 			profusely, began to speak with the voice of the hotelkeeper. </p>
 		<p><said who="Simon Dedalus">—And he has such a soft mouth when he's speaking to you, 
 			don't you know. He's very moist and watery about the dewlaps, 
 			God bless him. </said></p>
-		<p>Mr Casey was still struggling through his fit of coughing and 
-			laughter. Stephen, seeing and hearing the hotelkeeper through 
+		<p><persName>Mr Casey</persName> was still struggling through his fit of coughing and 
+			laughter. <persName>Stephen</persName>, seeing and hearing the hotelkeeper through 
 			his father's face and voice, laughed. </p>
-		<p>Mr Dedalus put up his eyeglass and, staring down at him, 
+		<p><persName>Mr Dedalus</persName> put up his eyeglass and, staring down at him, 
 			said quietly and kindly: </p>
 		<p><said who="Simon Dedalus">—What are you laughing at, you little puppy, you? </said></p>
 		<p>The servants entered and placed the dishes on the table. 
-			Mrs Dedalus followed and the places were arranged. </p>
+			<persName>Mrs Dedalus</persName> followed and the places were arranged. </p>
 		<p><said who="Mary Dedalus">—Sit over, she said. </said></p>
-		<p>Mr Dedalus went to the end of the table and said: </p>
-		<p><said who="Simon Dedalus">—Now, Mrs Riordan, sit over. John, sit you down, my 
+		<p><persName>Mr Dedalus</persName> went to the end of the table and said: </p>
+		<p><said who="Simon Dedalus">—Now, <persName>Mrs Riordan</persName>, sit over. <persName>John</persName>, sit you down, my 
 				hearty. </said></p>
-		<p>He looked round to where uncle Charles sat and said: </p>
+		<p>He looked round to where <persName>uncle Charles</persName> sat and said: </p>
 		<p><said who="Simon Dedalus">—Now then, sir, there's a bird here waiting for you. </said></p>
 		<p>When all had taken their seats he laid his hand on the cover 
 			and then said quickly, withdrawing it: </p>
-		<p><said who="Simon Dedalus">—Now, Stephen. </said></p>
-		<p>Stephen stood up in his place to say the grace before meals: </p>
+		<p><said who="Simon Dedalus">—Now, <persName>Stephen</persName>. </said></p>
+		<p><persName>Stephen</persName> stood up in his place to say the grace before meals: </p>
 
 		<p>
 		<seg type="prayer"> 
@@ -1149,7 +1149,7 @@
 				house where there is no respect for the pastors of the church. </said></p>
 		<p>Mr Dedalus threw his knife and fork noisily on his plate. </p>
 		<p><said who="Simon Dedalus">—Respect! he said. Is it for Billy with the lip or for the tub 
-			of guts up in <place><location><geo>54.350280 -6.652792</geo></location><placeMane>Armagh</placeName></place>? Respect! </said></p>
+			of guts up in <place><location><geo>54.350280 -6.652792</geo></location><placeName>Armagh</placeName></place>? Respect! </said></p>
 		<p><said who="John Casey">—Princes of the church, said Mr Casey with slow scorn. </said></p>
 		<p><said who="Simon Dedalus">—Lord Leitrim's coachman, yes, said Mr Dedalus. </said></p>
 		<p><said who="Dante">—They are the Lord's anointed, Dante said. They are an 

--- a/portrait.xml
+++ b/portrait.xml
@@ -490,16 +490,16 @@
 			before the nothing place began? It could not be a wall but 
 			there could be a thin thin line there all round everything. It 
 			was very big to think about everything and everywhere. Only 
-			God could do that. He tried to think what a big thought that 
-			must be but he could think only of God. God was God's name 
-			just as his name was <persName>Stephen</persName>. <emph>Dieu</emph> was the French for God 
-			and that was God's name too; and when anyone prayed to 
-			God and said <emph>Dieu</emph> then God knew at once that it was a 
+			<persName>God</persName> could do that. He tried to think what a big thought that 
+			must be but he could think only of <persName>God</persName>. <persName>God</persName> was <persName>God</persName>'s name 
+			just as his name was <persName>Stephen</persName>. <persName><emph>Dieu</emph></persName> was the French for <persName>God</persName> 
+			and that was <persName>God</persName>'s name too; and when anyone prayed to 
+			<persName>God</persName> and said <persName><emph>Dieu</emph></persName> then <persName>God</persName> knew at once that it was a 
 			French person that was praying. But though there were 
-			different names for God in all the different languages in the 
-			world and God understood what all the people who prayed 
-			said in their different languages still God remained always the 
-			same God and God's real name was God. </p>
+			different names for <persName>God</persName> in all the different languages in the 
+			world and <persName>God</persName> understood what all the people who prayed 
+			said in their different languages still <persName>God</persName> remained always the 
+			same <persName>God</persName> and <persName>God</persName>'s real name was <persName>God</persName>. </p>
 		<p>It made him very tired to think that way. It made him feel 
 			his head very big. He turned over the flyleaf and looked 
 			wearily at the green round earth in the middle of the maroon 


### PR DESCRIPTION
**The changes I have done are:** marking up the names of persons and of places. Persons in that sense are names, e.g. "Stephen" or "Mr Dedalus". Places, I interpreted to be specific names places, e.g. "Conglowes" or "Dublin". 
**Specific issues** 
I decided to mark up uncle Charles as Uncle Charles, instead of just Charles, as Stephen kept referring to him as Uncle Charles, as if Uncle was his title, like Father Arnell or Brother Michael, which I thought was quite interesting. 
I also decided to mark up the world and the universe as place names in the passage where Stephen situates himself in the universe, going from Conglowes to "The Universe", as it seemed significant as a named place to the passage. 
Additionally, I did not only mark up the names of characters, but also other people, e.g. Parnell, as I thought they were still persons of importance to the novel.
Also, I marked up "Father Minister" as a personal name, because Stephen used it in that way, instead of saying "the Minister" or " Father x, the Minister". 
Finally, I decided to mark up "God" as a personal name in the paragraph where Stephen thinks about how "God" is the name of God, even thought it is not a personal name in general. In that paragraph, however, God becomes a person with a name, which could be interesting to analyse for anyone using the mark ups of names for their analysis of Portrait.
**Interesting things I noticed** 
Before the Christmas Dinner Mr and Mrs Dedalus are only mentioned as "mother" and "father", while during the dinner they are "Mr/Mrs Dedalus" 
Most of Stephen's classmates call him "Dedalus", while his parents always call him "Stephen". 
People are often referred to by their name, rather than a personal pronoun, e.g. "Wells", "Uncle Charles", "Dante", which gives the narrative a sound of a young child that is still figuring out names and relations. (this might be just a personal opinion or feeling)
