### PR TITLE
Add dialog attribution to Chapter 3, for issue #7

### DIFF
--- a/portrait.xml
+++ b/portrait.xml
@@ -3796,7 +3796,7 @@
 			began to hum tunelessly. </p>
 		<l><emph>My excellent friend Bombados.</emph> </l>
 		<p>Ennis, who had gone to the yard, came back, saying: </p>
-		<p>—The boy from the house is coming up for the rector. </p>
+		<p><said who="Ennis">—The boy from the house is coming up for the rector. </p>
 		<p>A tall boy behind Stephen rubbed his hands and said: </p>
 		<p>—That's game ball. We can scut the whole hour. He won't 
 			be in till after half two. Then you can ask him questions on the 
@@ -3804,7 +3804,7 @@
 		<p>Stephen, leaning back and drawing idly on his scribbler, 
 			listened to the talk about him which Heron checked from time 
 			to time by saying: </p>
-		<p>—Shut up, will you. Don't make such a bally racket! </p>
+		<p><said who="Vincent Heron">—Shut up, will you. Don't make such a bally racket! </p>
 		<p>It was strange too that he found an arid pleasure in following 
 			up to the end the rigid lines of the doctrines of the church 
 			and penetrating into obscure silences  only to hear and feel the 
@@ -3848,7 +3848,7 @@
 			bench behind urged Stephen to ask a difficult question. </p>
 		<p>The rector did not ask for a catechism to hear the lesson 
 			from. He clasped his hands on the desk and said: </p>
-		<p>—The retreat will begin on Wednesday afternoon in honour 
+		<p><said who="Father Conmee">—The retreat will begin on Wednesday afternoon in honour 
 			of saint Francis Xavier whose feast day is Saturday. The 
 			retreat will go on from Wednesday to Friday. On Friday 
 			confession will be heard all the afternoon after beads. If any 
@@ -3859,12 +3859,12 @@
 			Sunday being free days some boys might be inclined to think 
 			that Monday is a free day also. Beware of making that mistake. 
 			I think you, Lawless, are likely to make that mistake. </p>
-		<p>—I, sir? Why,  sir? </p>
+		<p><said who="Lawless">—I, sir? Why,  sir? </p>
 		<p>A little wave of quiet mirth broke forth over the class of 
 			boys from the rector's grim smile. Stephen's heart began 
 			slowly to fold and fade with fear like a withering flower. </p>
 		<p>The rector went on gravely: </p>
-		<p>—You are all familiar with the story of the life of saint 
+		<p><said who="Father Conmee">—You are all familiar with the story of the life of saint 
 			Francis Xavier, I suppose, the patron of your college. He 
 			came of an old and illustrious Spanish family and you remember 
 			that he was one of the first followers of saint Ignatius. 
@@ -3884,7 +3884,7 @@
 			Francis Xavier! A great soldier of God! </p>
 		<p>The rector paused and then, shaking his clasped hands 
 			before him, went on: </p>
-		<p>—He had the faith in him that moves mountains. Ten 
+		<p><said who="Father Conmee">—He had the faith in him that moves mountains. Ten 
 			thousand souls won for God in a single month! That is a true 
 			conqueror, true to the motto of our order: <seg xml:lang="la">ad majorem Dei 
 				gloriam</seg>! A saint who has great power in heaven, remember: 
@@ -3905,7 +3905,7 @@
 
 	<div n="3.2" type="section"> 
 
-		<p>—<emph>Remember only thy last things and thou shalt not sin for 
+		<p><said who="Father Arnall">—<emph>Remember only thy last things and thou shalt not sin for 
 			ever</emph> -  words taken, my dear little brothers in Christ, from the 
 			book of Ecclesiastes, seventh chapter, fortieth verse. In the 
 			name of the Father and of the Son and of the Holy Ghost. 
@@ -3921,7 +3921,7 @@
 			infirmary where he lay sick, the sorrowful face of Brother 
 			Michael. His soul, as these memories came back to him, 
 			became again a child's soul. </p>
-		<p>—We are assembled here today, my dear little brothers in 
+		<p><said who="Father Arnall">—We are assembled here today, my dear little brothers in 
 			Christ, for one brief moment far away from the busy bustle of 
 			the outer world to celebrate and to honour one of the greatest 
 			of  saints, the apostle of the Indies, the patron saint also of 
@@ -3943,7 +3943,7 @@
 			preceding the feast day set apart by our holy mother  the 
 			church to transmit to all the ages the name and fame of one of 
 			the greatest sons of catholic Spain. </p>
-		<p>—Now what is the meaning of this word <emph>retreat</emph> and why is 
+		<p><said who="Father Arnall">—Now what is the meaning of this word <emph>retreat</emph> and why is 
 			it allowed on all hands to be a most salutary practice for all 
 			who desire to lead before God and in the eyes of men a truly 
 			christian life? A retreat, my dear boys, signifies a withdrawal 
@@ -3963,7 +3963,7 @@
 			profit a man to gain the whole world if he suffer the loss of his 
 			immortal soul? Ah, my dear boys, believe me there is nothing 
 			in this wretched world that can make up for such a loss. </p>
-		<p>—I will ask you therefore, my dear boys, to put away from 
+		<p><said who="Father Arnall">—I will ask you therefore, my dear boys, to put away from 
 			your minds during these few days all worldly thoughts, 
 			whether of study or pleasure or ambition, and to give all your 
 			attention to the state of your souls. I need hardly remind you 
@@ -3974,7 +3974,7 @@
 			and officers of the sodality of Our Blessed Lady and of the 
 			sodality of the holy angels to set a good example to their 
 			fellowstudents. </p>
-		<p>—Let us try therefore to make this retreat in honour of 
+		<p><said who="Father Arnall">—Let us try therefore to make this retreat in honour of 
 			saint Francis with our whole heart and our whole mind. God's 
 			blessing will then be upon all your year's studies. But, above 
 			and beyond all, let this retreat be one to which you can look 
@@ -3993,7 +3993,7 @@
 			this year may be a lasting covenant between God and that 
 			soul. For just and unjust, for saint and sinner alike, may this 
 			retreat be a memorable one. </p>
-		<p>—Help me, my dear little brothers in Christ. Help me by 
+		<p><said who="Father Arnall">—Help me, my dear little brothers in Christ. Help me by 
 			your pious attention, by your own devotion, by your outward 
 			demeanour. Banish from your minds all worldly thoughts and 
 			think only of the last things, death, judgment, hell and heaven. 
@@ -4195,7 +4195,7 @@
 			offended which she turned upon them nor reproachful. She 
 			placed their hands together, hand in hand, and said, speaking 
 			to their hearts: </p>
-		<p>—Take hands, Stephen and Emma. It is a beautiful evening 
+		<p><said who="Virgin Mary">—Take hands, Stephen and Emma. It is a beautiful evening 
 			now in heaven. You have erred but you are always my children. 
 			It is one heart that loves another heart. Take hands 
 			together,  my  dear children, and you  will  be happy together 
@@ -4215,7 +4215,7 @@
 			litter of the wreckage of the world. Forty days and forty nights 
 			the rain would fall till the waters covered the face of the earth. </p>
 		<p>It might be. Why not? </p>
-		<p>—<emph>Hell has enlarged its soul and opened its mouth without 
+		<p><said who="Father Arnall">—<emph>Hell has enlarged its soul and opened its mouth without 
 			any limits</emph> - words taken, my dear little brothers in Christ 
 			Jesus, from the book of Isaias, fifth chapter, fourteenth verse. 
 			In the name of the Father and of the Son and of the Holy 
@@ -4224,7 +4224,7 @@
 			his soutane and, having considered its dial for a moment in 
 			silence, placed it silently before him on the table. </p>
 		<p>He began  to speak in a quiet tone. </p>
-		<p>—Adam  and Eve, my dear boys, were, as you know, our 
+		<p><said who="Father Arnall">—Adam  and Eve, my dear boys, were, as you know, our 
 			first parents and you will remember that they were created by 
 			God in order that the seats in heaven left vacant by the fall of 
 			Lucifer and his rebellious angels might be filled again. Lucifer, 
@@ -4237,7 +4237,7 @@
 			instant was his ruin. He offended the majesty of God by the 
 			sinful thought of one instant and God cast him out of heaven 
 			into hell for ever. </p>
-		<p>—Adam and Eve were then created by God and placed in 
+		<p><said who "Father Arnall">—Adam and Eve were then created by God and placed in 
 			Eden, in the plain of Damascus, that lovely garden resplendent 
 			with sunlight and colour, teeming with luxuriant vegetation. 
 			The fruitful earth gave them her bounty: beasts and birds 
@@ -4246,7 +4246,7 @@
 			generous God could do for them was done. But there was one 
 			condition imposed on them by God: obedience to His word. 
 			They were not to eat of the fruit of the forbidden tree. </p>
-		<p>—Alas, my dear little boys, they too fell. The devil, once a 
+		<p><said who="Father Arnall">—Alas, my dear little boys, they too fell. The devil, once a 
 			shining angel, a son of the morning, now a foul fiend, came in 
 			the shape of a serpent, the subtlest of all the beasts of the field. 
 			He envied them. He, the fallen great one, could not bear to 
@@ -4259,7 +4259,7 @@
 			to the wiles of the archtempter. She ate the apple and gave it 
 			also to Adam who had not the moral courage to resist her. 
 			The poison tongue of Satan had done its work. They fell. </p>
-		<p>—And then the voice of God was heard in that garden, 
+		<p><said who="Father Arnall">—And then the voice of God was heard in that garden, 
 			calling His creature man to account: and Michael, prince of 
 			the heavenly host, with a sword of flame in his hand appeared 
 			before the guilty pair and drove them forth from Eden into the 
@@ -4273,12 +4273,12 @@
 			Redeemer of fallen man, was to be God's onlybegotten  Son, 
 			the Second Person of the Most Blessed Trinity, the Eternal 
 			Word. </p>
-		<p>—He came. He was born of a virgin pure, Mary the virgin 
+		<p><said who="Father Arnall">—He came. He was born of a virgin pure, Mary the virgin 
 			mother. He was born in a poor cowhouse in Judea and lived 
 			as a humble carpenter for thirty years until the hour of His 
 			mission had come. And then, filled with love for men, He went 
 			forth and called to men to hear the new gospel. </p>
-		<p>—Did they listen? Yes, they listened but would not hear. 
+		<p><said who="Father Arnall">—Did they listen? Yes, they listened but would not hear. 
 			He was seized and bound like a common criminal, mocked at 
 			as a fool, set aside to give place to a public robber, scourged 
 			with five thousand lashes, crowned with a crown of thorns, 
@@ -4286,7 +4286,7 @@
 			soldiery, stripped of his garments and hanged upon a 
 			gibbet and His side was pierced with a lance and from the 
 			wounded body of Our Lord water and blood issued continually. </p>
-		<p>—Yet even then, in that hour of supreme agony, Our 
+		<p><said who="Father Arnall">—Yet even then, in that hour of supreme agony, Our 
 			Merciful Redeemer had pity for mankind. Yet even there, on 
 			the hill of Calvary, He founded the holy catholic church 
 			against which, it is promised, the gates of hell shall not prevail. 
@@ -4298,7 +4298,7 @@
 			eternity of torment: hell. </p>
 		<p>The preacher's voice sank. He paused, joined his palms for 
 			an instant, parted them. Then he resumed: </p>
-		<p>—Now let us try for a moment to realise, as far as we can, 
+		<p><said who="Father Arnall">—Now let us try for a moment to realise, as far as we can, 
 			the nature of that abode of the damned which the justice of an 
 			offended God has called into existence for the eternal punishment 
 			of sinners. Hell is a strait and dark and foulsmelling 
@@ -4314,7 +4314,7 @@
 			damned are so utterly bound and helpless that, as a blessed 
 			saint, saint Anselm, writes in his book on similitudes, they are 
 			not even able to remove from the eye a worm that gnaws it. </p>
-		<p>—They lie in exterior darkness. For, remember, the fire of 
+		<p><said who="Father Arnall">—They lie in exterior darkness. For, remember, the fire of 
 			hell gives forth no light. As, at the command of God, the fire 
 			of the Babylonian furnace lost its heat but not its light so, at 
 			the command of God, the fire of hell, while retaining the 
@@ -4326,7 +4326,7 @@
 			alone, that of darkness, was called horrible. What name, then, 
 			shall we give to the darkness of hell which is to last not for 
 			three days alone but for all eternity? </p>
-		<p>—The horror of this strait and dark prison is increased by 
+		<p><said who="Father Arnall">—The horror of this strait and dark prison is increased by 
 			its awful stench. All the filth of the world, all the offal and 
 			scum of the world, we are told, shall run there as to a vast 
 			reeking sewer when the terrible conflagration of the last day 
@@ -4348,7 +4348,7 @@
 			the reeking darkness,  a huge and rotting human fungus. Imagine 
 			all this and you will have some idea of the horror of the 
 			stench of hell. </p>
-		<p>—But this stench is not, horrible though it is, the greatest 
+		<p><said who="Father Arnall">—But this stench is not, horrible though it is, the greatest 
 			physical torment to which the damned are subjected. The 
 			torment of fire is the greatest torment to which the tyrant has 
 			ever subjected his fellowcreatures. Place your finger for a 
@@ -4368,7 +4368,7 @@
 			the shorter is its duration: but the fire of hell has this property 
 			that it preserves that which it burns and though it rages with 
 			incredible intensity it rages for ever. </p>
-		<p>—Our earthly fire again, no matter how fierce or widespread 
+		<p><said who="Father Arnall">—Our earthly fire again, no matter how fierce or widespread 
 			it may be, is always of a limited extent: but the lake of 
 			fire in hell is boundless, shoreless and bottomless. It is on 
 			record that the devil himself, when asked the question by a 
@@ -4382,7 +4382,7 @@
 			brains are boiling in the skull, the heart in the breast glowing 
 			and bursting, the bowels a redhot mass of burning pulp, the 
 			tender eyes flaming like molten balls. </p>
-		<p>—And yet what I have said as to the strength and quality 
+		<p><said who="Father Arnall">—And yet what I have said as to the strength and quality 
 			and boundlessness of this fire is as nothing when compared to 
 			its intensity, an intensity which it has as being the instrument 
 			chosen by divine design for the punishment of soul and body 
@@ -4401,7 +4401,7 @@
 			fires kindled in the abyss by the offended majesty of the Omnipotent 
 			God and fanned into everlasting and ever increasing 
 			fury by the breath of the anger of the Godhead. </p>
-		<p>—Consider finally that the torment of this infernal prison is 
+		<p><said who="Father Arnall">—Consider finally that the torment of this infernal prison is 
 			increased by the company of the damned themselves. Evil 
 			company on earth is so noxious that even the plants, as if by 
 			instinct, withdraw from the company of whatsoever is deadly 
@@ -4431,7 +4431,7 @@
 			turn upon those accomplices and upbraid them and curse 
 			them. But they are helpless and hopeless: it is too late now for 
 			repentance. </p>
-		<p>—Last of all consider the frightful torment to those damned 
+		<p><said who="Father Arnall">—Last of all consider the frightful torment to those damned 
 			souls, tempters and tempted alike,  of the company of the 
 			devils. These devils will afflict the damned in two ways, by 
 			their presence and by their reproaches. We can have no idea 
@@ -4474,7 +4474,7 @@
 			the contemplation of those unspeakable sins by which degraded 
 			man outrages and defiles the temple of the Holy Ghost, 
 			defiles and pollutes himself. </p>
-		<p>—O, my dear little brothers in Christ, may it never be our 
+		<p><said who="Father Arnall">—O, my dear little brothers in Christ, may it never be our 
 			lot to hear that language! May it never be our lot, I say! In the 
 			last day of terrible reckoning I pray fervently to God that not 
 			a single soul of those who are in this chapel today may be 
@@ -4516,10 +4516,10 @@
 			school. Mr Tate and Vincent Heron stood at the window, 
 			talking, jesting, gazing out at the bleak rain, moving their 
 			heads. </p>
-		<p>—I wish it would clear up. I had arranged to go for a spin 
+		<p><said who="Mr Tate">—I wish it would clear up. I had arranged to go for a spin 
 			on the bike with some fellows out by Malahide. But the roads 
 			must be kneedeep. </p>
-		<p>—It might clear up, sir. </p>
+		<p><said who="Vincent Heron">—It might clear up, sir. </p>
 		<p>The voices that he knew so well, the common words, the 
 			quiet of the classroom when the voices paused and the silence 
 			was filled by the sound of softly browsing cattle as the other 
@@ -4553,7 +4553,7 @@
 			listening to the flutter of its ventricles. </p>
 		<p>No escape. He had to confess, to speak out in words what 
 			he had done and thought, sin after sin. How? How? </p>
-		<p>—Father, I ... </p>
+		<p><said who="Stephen Dedalus">—Father, I ... </p>
 		<p>The thought slid like a cold shining rapier into his tender 
 			flesh: confession. But not there in the chapel of the college. 
 			He would confess all, every sin of deed and thought, sincerely: 
@@ -4568,14 +4568,14 @@
 			without was already failing and, as it fell slowly through the 
 			dull red blinds, it seemed that the sun of the last day was going 
 			down and that all souls were being gathered for the judgment. </p>
-		<p>—<emph>I am cast away from the sight of Thine eyes:</emph> words 
+		<p><said who="Father Arnall">—<emph>I am cast away from the sight of Thine eyes:</emph> words 
 			taken, my dear little brothers in Christ, from the Book of 
 			Psalms, thirtieth chapter, twentythird verse. In the name of 
 			the Father and of the Son and of the Holy Ghost. Amen. </p>
 		<p>The preacher began to speak in a quiet friendly tone. His 
 			face was kind and he joined gently the fingers of each hand, 
 			forming a frail cage by the union of their tips. </p>
-		<p>—This morning we endeavoured, in our reflection upon 
+		<p><said who="Father Arnall">—This morning we endeavoured, in our reflection upon 
 			hell, to make what our holy founder calls in his book of spiritual 
 			exercises, the composition of place. We endeavoured, that 
 			is, to imagine with the senses of the mind, in our imagination, 
@@ -4583,14 +4583,14 @@
 			torments which all who are in hell endure. This evening we 
 			shall consider for a few moments the nature of the spiritual 
 			torments of hell. </p>
-		<p>—Sin, remember, is a twofold enormity. It is a base consent 
+		<p><said who="Father Arnall">—Sin, remember, is a twofold enormity. It is a base consent 
 			to the promptings of our corrupt nature to the lower instincts, 
 			to that which is gross and beastlike; and it is also a turning 
 			away from the counsel of our higher nature, from all that is 
 			pure and holy, from the Holy God Himself. For this reason 
 			mortal sin is punished in hell by two different forms of punishment, 
 			physical and spiritual. </p>
-		<p>—Now  of all these spiritual pains by far the greatest is the 
+		<p><said who="Father Arnall">—Now  of all these spiritual pains by far the greatest is the 
 			pain of loss, so great, in fact, that in itself it is a torment 
 			greater than all the others. Saint Thomas, the greatest doctor 
 			of the church, the angelic doctor, as he is called, says that the 
@@ -4623,7 +4623,7 @@
 			feel the anguish of that separation, knowing full well that it is 
 			unchangeable, this is the greatest torment which the created 
 			soul is capable of bearing, <seg xml:lang="la">poena damni</seg>, the pain of loss. </p>
-		<p>—The second pain which will afflict the souls of the damned 
+		<p><said who="Father Arnall">—The second pain which will afflict the souls of the damned 
 			in hell is the pain of conscience. Just as in dead bodies worms 
 			are engendered by putrefaction so in the souls of the lost there 
 			arises a perpetual remorse from the putrefaction of sin, the 
@@ -4677,7 +4677,7 @@
 			shed during your mortal life would have gained for you. 
 			You implore now a moment of earthly life wherein to repent: 
 			in vain. That time is gone: gone for ever. </p>
-		<p>—Such is the threefold sting of conscience, the viper which 
+		<p><said who="Father Arnall">—Such is the threefold sting of conscience, the viper which 
 			gnaws the very heart's core of the wretches in hell so that filled 
 			with hellish fury they curse themselves for their folly and curse 
 			the evil companions who have brought them to such ruin and 
@@ -4685,7 +4685,7 @@
 			and torture them in eternity and even revile and curse the 
 			Supreme Being Whose goodness and patience they scorned 
 			and slighted but Whose justice and power they cannot evade. </p>
-		<p>—The next spiritual pain to which the damned are subjected 
+		<p><said who="Father Arnall">—The next spiritual pain to which the damned are subjected 
 			is the pain of extension. Man, in this earthly life, though 
 			he be capable of many evils, is not capable of them all at once 
 			inasmuch as one evil corrects and counteracts  another just as 
@@ -4703,7 +4703,7 @@
 			duration, a frightful state of wickedness which we can 
 			scarcely realise unless we bear in mind the enormity of sin and 
 			the hatred God bears to it. </p>
-		<p>—Opposed to this pain of extension and yet coexistent with 
+		<p><said who="Father Arnall">—Opposed to this pain of extension and yet coexistent with 
 			it we have the pain of intensity. Hell is the centre of evils and, 
 			as you know, things are more intense at their centres than at 
 			their remotest points. There are no contraries or admixtures of 
@@ -4731,7 +4731,7 @@
 			and low pleasures of the corrupt flesh, requires, this is what the 
 			blood of the innocent Lamb of God, shed for the redemption 
 			of sinners, trampled upon by the vilest of the vile, insists upon. </p>
-		<p>—Last and crowning torture of all the tortures of that awful 
+		<p><said who="Father Arnall">—Last and crowning torture of all the tortures of that awful 
 			place is the eternity of hell. Eternity! O, dread and dire word. 
 			Eternity! What mind of man can understand it? And, remember, 
 			it is an eternity of pain. Even though the pains of hell 
@@ -4773,7 +4773,7 @@
 			of such a period, after that eon of time the mere thought of 
 			which makes our very brain reel dizzily, eternity would have 
 			scarcely begun. </p>
-		<p>—A holy saint (one of our own fathers I believe it was) 
+		<p><said who="Father Arnall">—A holy saint (one of our own fathers I believe it was) 
 			was once vouchsafed a vision of hell. It seemed to him that he 
 			stood in the midst of a great hall, dark and silent save for the 
 			ticking of a great clock. The ticking went on unceasingly; and 
@@ -4802,7 +4802,7 @@
 			eternity an eternity of woe. Such is the terrible punishment 
 			decreed for those who die in mortal sin by an almighty and 
 			a just God. </p>
-		<p>—Yes, a just God! Men, reasoning always as men, are 
+		<p><said who="Father Arnall">—Yes, a just God! Men, reasoning always as men, are 
 			astonished that God should mete out an everlasting and 
 			infinite punishment in the fires of hell for a single grievous sin. 
 			They reason thus because, blinded by the gross illusion of the 
@@ -4818,7 +4818,7 @@
 			God, could not do so because sin, be it in thought or deed, 
 			is a transgression of His law and God would not be God if He 
 			did not punish the transgressor. </p>
-		<p>—A sin, an instant of rebellious pride of the intellect, made 
+		<p><said who="Father Arnall">—A sin, an instant of rebellious pride of the intellect, made 
 			Lucifer and a third part of the cohorts of angels fall from their 
 			glory. A sin, an instant of folly and weakness, drove Adam 
 			and Eve out of Eden and brought death and suffering into the 
@@ -4826,7 +4826,7 @@
 			Begotten Son of God came down to earth, lived and suffered 
 			and died a most painful death, hanging for three hours on the 
 			cross. </p>
-		<p>—O, my dear little brethren in Christ Jesus, will we then 
+		<p><said who="Father Arnall">—O, my dear little brethren in Christ Jesus, will we then 
 			offend that good Redeemer and provoke His anger? Will we 
 			trample again upon that torn and mangled corpse? Will we 
 			spit upon that face so full of sorrow and love? Will we too, 
@@ -4840,7 +4840,7 @@
 			the divine majesty, that which is punished by an eternity of 
 			agony, that which crucifies again the Son of God and makes 
 			a mockery of Him. </p>
-		<p>—I pray to God that my poor words may have availed 
+		<p><said who="Father Arnall">—I pray to God that my poor words may have availed 
 			today to confirm in holiness those who are in a state of grace, 
 			to strengthen the wavering, to lead back to the state of grace 
 			the poor soul that has strayed if any such be among you. I 
@@ -4854,7 +4854,7 @@
 			shame hold you back. God is still the merciful Lord Who 
 			wishes not the eternal death of the sinner but rather that he be 
 			converted and live. </p>
-		<p>—He calls you to Him. You are His. He made you out of 
+		<p><said who="Father Arnall">—He calls you to Him. You are His. He made you out of 
 			nothing. He loved you as only a God can love. His arms are 
 			open to receive you even though you have sinned against Him. 
 			Come to Him, poor sinner, poor vain and erring sinner. Now 
@@ -5002,7 +5002,7 @@
 			peace and shimmering lights and quiet fragrance he made a 
 			covenant with his heart. </p>
 		<p>He prayed: </p>
-		<p>—<emph>He once had meant to come on earth in heavenly glory 
+		<p><said who="Stephen Dedalus">—<emph>He once had meant to come on earth in heavenly glory 
 			but we sinned: and then He could not safely visit us but with a 
 			shrouded majesty and a bedimmed radiance for He was God. 
 			So He came Himself in weakness not in power and He sent 
@@ -5089,12 +5089,12 @@
 			to cross the street, an oilcan in her hand. He bent down and 
 			asked her was there a chapel near. </p>
 		<p>—A chapel, sir? Yes, sir. Church Street chapel. </p>
-		<p>—Church? </p>
+		<p><said who="Stephen Dedalus">—Church? </p>
 		<p>She  shifted the can to her other hand and directed him: 
 			and, as she held out her reeking withered right hand under its 
 			fringe of shawl, he bent lower towards her, saddened and 
 			soothed by her voice. </p>
-		<p>—Thank you. </p>
+		<p><said who="Stephen Dedalus">—Thank you. </p>
 		<p>—You are quite  welcome, sir. </p>
 		<p>The candles on the high altar had been extinguished but the 
 			fragrance of incense still floated down the dim nave. Bearded 
@@ -5174,51 +5174,51 @@
 			towards the white form, praying with his darkened eyes, 
 			praying with all his trembling body, swaying his head to and 
 			fro like a lost creature, praying with whimpering lips. </p>
-		<p>—Sorry! Sorry! O sorry! </p>
+		<p><said who="Stephen Dedalus">—Sorry! Sorry! O sorry! </p>
 		<p>The slide clicked back and his heart bounded in his breast. 
 			The face of an old priest was at the grating, averted from him, 
 			leaning upon a hand. He made the sign of the cross and 
 			prayed of the priest to bless him for he had sinned. Then, 
 			bowing his head, he repeated the <seg xml:lang="la">></seg> in fright. At the 
 			words <emph>my most grievous fault</emph> he ceased, breathless. </p>
-		<p>—How long is it since your last confession, my child? </p>
-		<p>—A long time, father. </p>
-		<p>—A month, my child? </p>
-		<p>—Longer, father. </p>
-		<p>—Three months, my child? </p>
-		<p>—Longer, father. </p>
-		<p>—Six months? </p>
-		<p>—Eight months, father. </p>
+		<p><said who="Priest">—How long is it since your last confession, my child? </p>
+		<p><said who="Stephen Dedalus">—A long time, father. </p>
+		<p><said who="Priest">—A month, my child? </p>
+		<p><said who="Stephen Dedalus">—Longer, father. </p>
+		<p><said who="Priest">—Three months, my child? </p>
+		<p><said who="Stephen Dedalus">—Longer, father. </p>
+		<p><said who="Priest">—Six months? </p>
+		<p><said who="Stephen Dedalus">—Eight months, father. </p>
 		<p>He had begun. The priest asked: </p>
-		<p>—And what do you remember since that time? </p>
+		<p><said who="Priest">—And what do you remember since that time? </p>
 		<p>He began to confess his sins: masses missed,  prayers not 
 			said, lies. </p>
-		<p>—Anything else, my child? </p>
+		<p><said who="Priest">—Anything else, my child? </p>
 		<p>Sins of anger, envy of  others, gluttony, vanity, disobedience. </p>
-		<p>—Anything else, my child? </p>
-		<p>—Sloth. </p>
-		<p>—Anything else, my child? </p>
+		<p><said who="Priest">—Anything else, my child? </p>
+		<p><said who="Stephen Dedalus">—Sloth. </p>
+		<p><said who="Priest">—Anything else, my child? </p>
 		<p>There was no help. He murmured: </p>
-		<p>—I ... committed sins of impurity, father. </p>
+		<p><said who="Stephen Dedalus">—I ... committed sins of impurity, father. </p>
 		<p>The priest did not turn his head. </p>
-		<p>—With yourself, my child? </p>
-		<p>—And ... with others. </p>
-		<p>—With women, my child? </p>
-		<p>—Yes, father. </p>
-		<p>—Were  they married women, my child? </p>
+		<p><said who="Priest">—With yourself, my child? </p>
+		<p><said who"Stephen Dedalus">—And ... with others. </p>
+		<p><said who"Priest">—With women, my child? </p>
+		<p><said who"Stephen Dedalus">—Yes, father. </p>
+		<p><said who="Priest">—Were  they married women, my child? </p>
 		<p>He did not know. His sins trickled from his lips, one by one, 
 			trickled in shameful drops from his soul festering and oozing 
 			like a sore, a squalid stream of vice. The last sins oozed 
 			forth, sluggish, filthy. There was no more to tell. He bowed his 
 			head, overcome. </p>
 		<p>The priest was silent. Then he asked: </p>
-		<p>—How old are you, my child? </p>
-		<p>—Sixteen, father. </p>
+		<p><said who="Priest">—How old are you, my child? </p>
+		<p><said who="Stephen Dedalus">—Sixteen, father. </p>
 		<p>The priest passed his hand several times over his face. 
 			Then, resting his forehead against his hand, he leaned towards 
 			the grating and, with eyes still averted, spoke slowly. His voice 
 			was weary and old. </p>
-		<p>—You are very young, my child, he said, and let me implore 
+		<p><said who="Priest">—You are very young, my child, he said, and let me implore 
 			of you to give up that sin. It is a terrible sin. It kills the 
 			body and it kills the soul. It is the cause of many crimes and 
 			misfortunes. Give it up, my child, for God's sake. It is 
@@ -5232,10 +5232,10 @@
 			you will promise God now that by His holy grace you will 
 			never offend Him any more by that wicked sin. You will make 
 			that solemn promise to God, will you not? </p>
-		<p>—Yes, father. </p>
+		<p><said who="Stephen Dedalus">—Yes, father. </p>
 		<p>The old and weary voice fell like sweet rain upon his quaking 
 			parching heart. How sweet and sad! </p>
-		<p>—Do so, my poor child. The devil has  led you astray. Drive 
+		<p><said who="Priest">—Do so, my poor child. The devil has  led you astray. Drive 
 			him back to hell when he tempts you to dishonour your body 
 			in that way - the foul spirit who hates Our Lord. Promise God 
 			now that you will give up that sin, that wretched wretched sin. </p>
@@ -5243,7 +5243,7 @@
 			he bent his head and heard the grave words of absolution 
 			spoken and saw the priest's hand raised above him in token 
 			of forgiveness. </p>
-		<p>—God bless you, my child. Pray for me. </p>
+		<p><said who="Priest">—God bless you, my child. Pray for me. </p>
 		<p>He knelt to say his penance, praying in a corner of the dark 
 			nave: and his prayers ascended to heaven from his purified 
 			heart like perfume streaming upwards from a heart of white 


### PR DESCRIPTION
I had a few questions/judgment decisions: 
I wondered how to attribute dialog to unnamed characters (EX: the woman who gives Stephen directions to church near the end of the chapter). For some of them, I gave an attribution (EX: for the confession at the end of the chapter, I labeled the priest Stephen is confessing to, "Priest"). 

Also, in the first dialog of the chapter I found it hard to identify who exactly is speaking (so I did not attribute these lines).

I also assumed that the rector is still "Father Conmee" (even though this full name is not referenced at all in Chapter 3). 

Before the sermons, there was a prayer said. It is not explicitly stated that the pastor ("Father Arnall") gives this opening prayer, but there is no indication of anyone else.

Some of the imaginary dialog in Stephen's head I was not sure how to attribute, but for some I did attribute (EX: I labeled "Virgin Mary" as speaking in the imaginary scene with Stephen and Emma)

Finally, I gather that the latin words spoken at end of chapter of the communion are spoken by the priest. First issue: which priest? (Or what name? Retreat is over; is it still Arnall?) Then, after "Amen" there is one more line of dialogue repeating "Corpus Domini nostri", was not sure who to attribute this to either; so I did not attribute these final three lines of dialog.
