### PR TITLE
Remove chapter prefixes from line numbers

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
     <div id="textBody">
       
         
-          <span class="lang"><span class="tag lang"> 
+          <span class="lang"><span class="tag lang">
 				Latin
 			</span>
             
@@ -132,13 +132,13 @@
            moocow coming down along the road and this moocow that <br>
            was coming down along the road met a nicens little boy named <br>
            baby tuckoo.....<br> </p>
-          <p class="textParagraph"> His father told him that story: his father looked at him <span class="tag lineNumber">10005</span><br>
+          <p class="textParagraph"> His father told him that story: his father looked at him <br>
            through a glass: he had a hairy face.<br> </p>
           <p class="textParagraph"> He was baby tuckoo. The moocow came down the road <br>
            where  Betty Byrne lived: she sold lemon platt.<br> </p>
           <p class="lg"><span class="tag type">song</span>
               <span class="emph"> O, the wild rose blossoms </span>  <br>
-              <span class="emph"> On the little green place. </span>  <span class="tag lineNumber">10010</span><br>
+              <span class="emph"> On the little green place. </span>  <span class="tag lineNumber">10</span><br>
           </p>
           <p class="textParagraph"> He sang that song. That was his song.<br> </p>
           <p class="lg"><span class="tag type">song</span>
@@ -146,35 +146,35 @@
           </p>
           <p class="textParagraph"> When you wet the bed first it is warm then it gets cold. His <br>
            mother put on the oilsheet. That had the queer smell.<br> </p>
-          <p class="textParagraph"> His mother had a nicer smell than his father. She played on <span class="tag lineNumber">10015</span><br>
+          <p class="textParagraph"> His mother had a nicer smell than his father. She played on <br>
            the piano the sailor's hornpipe for him to dance. He danced:<br> </p>
           <p class="lg"><span class="tag type">song</span>
               <span class="emph"> Tralala lala </span>  <br>
               <span class="emph"> Tralala tralaladdy </span>  <br>
               <span class="emph"> Tralala lala </span>  <br>
-              <span class="emph"> Tralala lala. </span>  <span class="tag lineNumber">10020</span><br>
+              <span class="emph"> Tralala lala. </span>  <span class="tag lineNumber">20</span><br>
           </p>
           <p class="textParagraph">  Uncle Charles and  Dante clapped. They were older than his <br>
            father and mother but  uncle Charles was older than  Dante.<br> </p>
           <p class="textParagraph"> Dante had two brushes in her press. The brush with the <br>
            maroon velvet back was for  Michael Davitt and the brush with <br>
-           the green velvet back was for  Parnell.  Dante gave him a cachou <span class="tag lineNumber">10025</span><br>
+           the green velvet back was for  Parnell.  Dante gave him a cachou <br>
            every time he brought her a piece of tissue paper.<br> </p>
           <p class="textParagraph"> The  Vances lived in number seven. They had a different <br>
            father and mother. They were Eileen's father and mother. <br>
            When they were grown up he was going to marry  Eileen.<br> </p>
-          <p class="textParagraph"> He hid under the table. His mother said:<span class="tag lineNumber">10030</span><br> </p>
+          <p class="textParagraph"> He hid under the table. His mother said:<span class="tag lineNumber">30</span><br> </p>
           <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Mary Dedalus</span>―O,  Stephen will apologise. <br></p> </p>
           <p class="textParagraph"> Dante said:<br> </p>
           <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Dante</span>―O, if not, the eagles will come and pull out his eyes. <br></p> </p>
           <p class="lg">
               <span class="emph"> Pull out his eyes, </span>  <br>
-              <span class="emph"> Apologise, </span>  <span class="tag lineNumber">10035</span><br>
+              <span class="emph"> Apologise, </span>  <br>
               <span class="emph"> Apologise, </span>  <br>
               <span class="emph"> Pull out his eyes. </span>  <br>
               <span class="emph"> Apologise, </span>  <br>
               <span class="emph"> Pull out his eyes, </span>  <br>
-              <span class="emph"> Pull out his eyes, </span>  <span class="tag lineNumber">10040</span><br>
+              <span class="emph"> Pull out his eyes, </span>  <span class="tag lineNumber">40</span><br>
               <span class="emph"> Apologise. </span>  <br>
             </p> <div class="divider">* * *</div>
          
@@ -182,567 +182,567 @@
             <p class="textParagraph"> The wide playgrounds were swarming with boys. All were <br>
              shouting and the prefects urged them on with strong cries. The <br>
              evening air was pale and chilly and after every charge and thud <br>
-             of the footballers the greasy leather orb flew like a heavy bird <span class="tag lineNumber">10045</span><br>
+             of the footballers the greasy leather orb flew like a heavy bird <br>
              through the grey light. He kept on the fringe of his line, out of <br>
              sight of his prefect, out of the reach of the rude feet, feigning to <br>
              run now and then. He felt his body small and weak amid the <br>
              throng of players and his eyes were weak and watery.  Rody <br>
-             Kickham was not like that: he would be captain of the third <span class="tag lineNumber">10050</span><br>
+             Kickham was not like that: he would be captain of the third <span class="tag lineNumber">50</span><br>
              line all the fellows said.<br> </p>
             <p class="textParagraph">  Rody Kickham was a decent fellow but  Nasty Roche was a <br>
              stink.  Rody Kickham had greaves in his number and a hamper <br>
              in the refectory.  Nasty Roche had big hands. He called the <br>
-             Friday pudding dog-in-the-blanket. And one day he had asked:<span class="tag lineNumber">10055</span><br> </p>
+             Friday pudding dog-in-the-blanket. And one day he had asked:<br> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Nasty Roche</span>―What is your name? <br></p> </p>
             <p class="textParagraph"> Stephen had answered:<br> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Stephen</span>―  Stephen Dedalus. <br></p> </p>
             <p class="textParagraph"> Then  Nasty Roche had said:<br> </p>
-            <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Nasty Roche</span>―What kind of a name is that? <span class="tag lineNumber">10060</span><br></p> </p>
+            <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Nasty Roche</span>―What kind of a name is that? <span class="tag lineNumber">60</span><br></p> </p>
             <p class="textParagraph"> And when  Stephen had not been able to answer  Nasty <br>
              Roche had asked:<br> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Nasty Roche</span>―What is your father? <br></p> </p>
             <p class="textParagraph">  Stephen had answered:<br> </p>
-            <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Stephen</span>―A gentleman. <span class="tag lineNumber">10065</span><br></p> </p>
+            <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Stephen</span>―A gentleman. <br></p> </p>
             <p class="textParagraph"> Then  Nasty Roche had asked:<br> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Nasty Roche</span>―Is he a magistrate? <br></p> </p>
             <p class="textParagraph"> He crept about from point to point on the fringe of his line, <br>
              making little runs now and then. But his hands were bluish <br>
-             with cold. He kept his hands in the sidepockets of his belted <span class="tag lineNumber">10070</span><br>
+             with cold. He kept his hands in the sidepockets of his belted <span class="tag lineNumber">70</span><br>
              grey suit. That was a belt round his jacket. And belt was also to <br>
              give a fellow a belt. One day a fellow had said to  Cantwell:<br> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">a fellow</span>―I'd give you such a belt in a second. <br></p> </p>
             <p class="textParagraph">  Cantwell had answered:<br> </p>
-            <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Cantwell</span>―Go and fight your match. Give  Cecil Thunder a belt. I'd like <span class="tag lineNumber">10075</span><br>
+            <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Cantwell</span>―Go and fight your match. Give  Cecil Thunder a belt. I'd like <br>
              to see you. He'd give you a toe in the rump for yourself. <br></p> </p>
             <p class="textParagraph"> That was not a nice expression. His mother had told him <br>
              not to speak with the rough boys in the college. Nice mother! <br>
              The first day in the hall of the castle when she had said good- <br>
-             bye she had put up her veil double to her nose to kiss him: and <span class="tag lineNumber">10080</span><br>
+             bye she had put up her veil double to her nose to kiss him: and <span class="tag lineNumber">80</span><br>
              her nose and eyes were red. But he had pretended not to see <br>
              that she was going to cry. She was a nice mother but she was <br>
              not so nice when she cried. And his father had given him two <br>
               fiveshilling  pieces for pocket money. And his father had told <br>
-             him if he wanted anything to write home to him and, whatever <span class="tag lineNumber">10085</span><br>
+             him if he wanted anything to write home to him and, whatever <br>
              he did, never to peach on a fellow. Then at the door of the <br>
              castle the rector had shaken hands with his father and mother, <br>
              his soutane fluttering in the breeze, and the car had driven off <br>
              with his father and mother on it. They had cried to him from <br>
-             the car, waving their hands:<span class="tag lineNumber">10090</span><br> </p>
+             the car, waving their hands:<span class="tag lineNumber">90</span><br> </p>
             <p class="dialog"><span class="tag dialog">Mary Dedalus, Simon Dedalus</span>
               <p class="textParagraph">―Goodbye,  Stephen, goodbye!<br> </p>
               <p class="textParagraph">―Goodbye,  Stephen, goodbye!<br> </p>
             </p>
             <p class="textParagraph"> He was caught in the whirl of a scrimmage and, fearful of <br>
              the flashing eyes and muddy boots, bent down to look through <br>
-             the legs. The fellows were struggling and groaning and their <span class="tag lineNumber">10095</span><br>
+             the legs. The fellows were struggling and groaning and their <br>
              legs were rubbing and kicking and stamping. Then  Jack <br>
              Lawton's yellow boots dodged out the ball and all the other <br>
              boots and legs ran after. He ran after them a little way and then <br>
              stopped. It was useless to run on. Soon they would be going <br>
-             home for the holidays. After supper in the  studyhall  he would <span class="tag lineNumber">10100</span><br>
+             home for the holidays. After supper in the  studyhall  he would <span class="tag lineNumber">100</span><br>
              change the number pasted up inside his desk from  seventyseven  <br>
              to  seventysix .<br> </p>
             <p class="textParagraph"> It would be better to be in the  studyhall  than out there in the <br>
              cold. The sky was pale and cold but there were lights in the <br>
-             castle. He wondered from which window  Hamilton Rowan <span class="tag lineNumber">10105</span><br>
+             castle. He wondered from which window  Hamilton Rowan <br>
              had thrown his hat on the haha and had there been flowerbeds <br>
              at that time under the windows. One day when he had been <br>
              called to the castle the butler had shown him the marks of the <br>
              soldiers' slugs in the wood of the door and had given him a <br>
-             piece of shortbread that the community ate. It was nice and <span class="tag lineNumber">10110</span><br>
+             piece of shortbread that the community ate. It was nice and <span class="tag lineNumber">110</span><br>
              warm to see the lights in the castle. It was like something in a <br>
              book. Perhaps   <span class="hide"> 52.640379 -1.132563 </span>   Leicester Abbey   was like that. And there were <br>
              nice sentences in  Doctor Cornwell's Spelling Book. They were <br>
              like poetry but they were only sentences to learn the spelling <br>
-             from.<span class="tag lineNumber">10115</span><br> </p>
+             from.<br> </p>
             <p class="lg">
                 <span class="emph">  Wolsey died in   <span class="hide"> 52.640379 -1.132563 </span>   Leicester Abbey   </span>  <br>
                 <span class="emph"> Where the abbots buried him. </span>  <br>
                 <span class="emph"> Canker is a disease of plants, </span>  <br>
                 <span class="emph"> Cancer one of animals. </span>  <br>
             </p>
-            <p class="textParagraph"> It would be nice to lie on the hearthrug before the fire, <span class="tag lineNumber">10120</span><br>
+            <p class="textParagraph"> It would be nice to lie on the hearthrug before the fire, <span class="tag lineNumber">120</span><br>
              leaning his head upon his hands, and think on those sentences. <br>
              He shivered as if he had cold slimy water next his skin. That <br>
              was mean of  Wells to shoulder him into the square ditch be- <br>
              cause he would not swop his little  snuffbox  for  Wells 's sea- <br>
-             soned hacking chestnut, the conqueror of forty. How cold and <span class="tag lineNumber">10125</span><br>
+             soned hacking chestnut, the conqueror of forty. How cold and <br>
              slimy the water had been! A fellow had once seen a big rat <br>
              jump plop into the scum. He shivered and longed to cry. It <br>
              would be so nice to be at home. Mother was sitting at the fire <br>
              with  Dante  waiting for  Brigid  to bring in the tea. She had her <br>
-             feet on the fender and her jewelly slippers were so hot and they <span class="tag lineNumber">10130</span><br>
+             feet on the fender and her jewelly slippers were so hot and they <span class="tag lineNumber">130</span><br>
              had such a lovely warm smell!  Dante  knew a lot of things. She <br>
              had taught him where the   <span class="hide"> -18.615949 41.280858 </span>   Mozambique Channel   was and what <br>
              was   <span class="hide"> 38.627003 -90.199404 </span>   the longest river in America   and what was the name of the <br>
              highest mountain in the moon.  Father Arnall  knew more than <br>
-              Dante  because he was a priest but both his father and  uncle <span class="tag lineNumber">10135</span><br>
+              Dante  because he was a priest but both his father and  uncle <br>
              Charles  said that  Dante  was a clever woman and a  wellread  <br>
              woman. And when  Dante  made that noise after dinner and <br>
              then put up her hand to her mouth: that was heartburn.<br> </p>
             <p class="textParagraph"> A voice cried far out on the playground:<br> </p>
-            <p class="textParagraph"> <p class="dialog"><span class="tag dialog">a voice</span>―All in! <span class="tag lineNumber">10140</span><br></p> </p>
+            <p class="textParagraph"> <p class="dialog"><span class="tag dialog">a voice</span>―All in! <span class="tag lineNumber">140</span><br></p> </p>
             <p class="textParagraph"> Then other voices cried from the lower and third lines:<br> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">other voices from the lower and third lines</span>―All in! All in! <br> </p> </p>
             <p class="textParagraph"> The players closed around, flushed and muddy, and he went <br>
              among them, glad to go in.  Rody Kickham  held the ball by its <br>
-             greasy lace. A fellow asked him to give it one last: but he <span class="tag lineNumber">10145</span><br>
+             greasy lace. A fellow asked him to give it one last: but he <br>
              walked on without even answering the fellow.  Simon Moonan  <br>
              told him not to because the prefect was looking. The fellow <br>
              turned to  Simon Moonan  and said:<br> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">a fellow</span>―We all know why you speak. You are  McGlade 's suck. <br></p> </p>
-            <p class="textParagraph"> Suck was a queer word. The fellow called  Simon Moonan  <span class="tag lineNumber">10150</span><br>
+            <p class="textParagraph"> Suck was a queer word. The fellow called  Simon Moonan  <span class="tag lineNumber">150</span><br>
              that name because  Simon Moonan  used to tie the prefect's false <br>
              sleeves behind his back and the prefect used to let on to be <br>
              angry. But the sound was ugly. Once he had washed his hands <br>
              in the lavatory of the   <span class="hide"> 53.342872 -6.260651 </span>   Wicklow Hotel   and his father pulled the <br>
-             stopper up by the chain after and the dirty water went down <span class="tag lineNumber">10155</span><br>
+             stopper up by the chain after and the dirty water went down <br>
              through the hole in the basin. And when it had all gone down <br>
              slowly the hole in the basin had made a sound like that: suck. <br>
              Only louder.<br> </p>
             <p class="textParagraph"> To remember that and the white look of the lavatory made <br>
-             him feel cold and then hot. There were two cocks that you <span class="tag lineNumber">10160</span><br>
+             him feel cold and then hot. There were two cocks that you <span class="tag lineNumber">160</span><br>
              turned and water came out: cold and hot. He felt cold and then <br>
              a little hot: and he could see the names printed on the cocks. <br>
              That was a very queer thing.<br> </p>
             <p class="textParagraph"> And the air in the corridor chilled him too. It was queer and <br>
-             wettish. But soon the gas would be lit and in burning it made a <span class="tag lineNumber">10165</span><br>
+             wettish. But soon the gas would be lit and in burning it made a <br>
              light noise like a little song. Always the same: and when the <br>
              fellows stopped talking in the playroom you could hear it.<br> </p>
             <p class="textParagraph"> It was the hour for sums.  Father Arnall  wrote a hard sum on <br>
              the board and then said:<br> </p>
-            <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Father Arnall</span>―Now then, who will win? Go ahead, York! Go ahead, Lan- <span class="tag lineNumber">10170</span><br>
+            <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Father Arnall</span>―Now then, who will win? Go ahead, York! Go ahead, Lan- <span class="tag lineNumber">170</span><br>
              caster! <br></p> </p>
             <p class="textParagraph">  Stephen  tried his best but the sum was too hard and he felt <br>
              confused. The little silk badge with the white rose on it that <br>
              was pinned on the breast of his jacket began to flutter. He was <br>
-             no good at sums but he tried his best so that York might not <span class="tag lineNumber">10175</span><br>
+             no good at sums but he tried his best so that York might not <br>
              lose.  Father Arnall 's face looked very black but he was not in a <br>
              wax: he was laughing. Then  Jack Lawton  cracked his fingers <br>
              and  Father Arnall  looked at his copybook and said:<br> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Father Arnall</span>―Right. Bravo Lancaster! The red rose wins. Come on now, <br>
-             York! Forge ahead! <span class="tag lineNumber">10180</span><br></p> </p>
+             York! Forge ahead! <span class="tag lineNumber">180</span><br></p> </p>
             <p class="textParagraph">  Jack Lawton  looked over from his side. The little silk badge <br>
              with the red rose on it looked very rich because he had a blue <br>
              sailor top on.  Stephen  felt his own face red too, thinking of all <br>
              the bets about who would get first place in elements,  Jack <br>
-             Lawton  or he. Some weeks  Jack Lawton  got the card for first <span class="tag lineNumber">10185</span><br>
+             Lawton  or he. Some weeks  Jack Lawton  got the card for first <br>
              and some weeks he got the card for first. His white silk badge <br>
              fluttered and fluttered as he worked at the next sum and heard <br>
               Father Arnall 's voice. Then all his eagerness passed away and <br>
              he felt his face quite cool. He thought his face must be white <br>
-             because it felt so cool. He could not get out the answer for the <span class="tag lineNumber">10190</span><br>
+             because it felt so cool. He could not get out the answer for the <span class="tag lineNumber">190</span><br>
              sum but it did not matter. White roses and red roses: those <br>
              were beautiful colours to think of. And the cards for first place <br>
              and second place and third place were beautiful colours too: <br>
              pink and cream and lavender. Lavender and cream and pink <br>
-             roses were beautiful to think of. Perhaps a wild rose might be <span class="tag lineNumber">10195</span><br>
+             roses were beautiful to think of. Perhaps a wild rose might be <br>
              like those colours: and he remembered the song about the wild <br>
              rose blossoms on the little green place. But you could not have <br>
              a green rose. But perhaps somewhere in the world you could.<br> </p>
             <p class="textParagraph"> The bell rang and then the classes began to file out of the <br>
-             rooms and along the corridors towards the refectory. He sat <span class="tag lineNumber">10200</span><br>
+             rooms and along the corridors towards the refectory. He sat <span class="tag lineNumber">200</span><br>
              looking at the two prints of butter on his plate but could not <br>
              eat the damp bread. The tablecloth was damp and limp. But he <br>
              drank off the hot weak tea which the clumsy scullion, girt with <br>
              a white apron, poured into his cup. He wondered whether the <br>
-             scullion's apron was damp too or whether all white things were <span class="tag lineNumber">10205</span><br>
+             scullion's apron was damp too or whether all white things were <br>
              cold and damp.  Nasty Roche  and  Saurin  drank cocoa that their <br>
              people sent them in tins. They said they could not drink the tea; <br>
              that it was hogwash. Their fathers were magistrates, the fel- <br>
              lows said.<br> </p>
-            <p class="textParagraph"> All the boys seemed to him very strange. They had all fa- <span class="tag lineNumber">10210</span><br>
+            <p class="textParagraph"> All the boys seemed to him very strange. They had all fa- <span class="tag lineNumber">210</span><br>
              thers and mothers and different clothes and voices. He longed <br>
              to be at home and lay his head on his mother's lap. But he <br>
              could not: and so he longed for the play and study and prayers <br>
              to be over and to be in bed.<br> </p>
-            <p class="textParagraph"> He drank another cup of hot tea and  Fleming  said:<span class="tag lineNumber">10215</span><br> </p>
+            <p class="textParagraph"> He drank another cup of hot tea and  Fleming  said:<br> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Fleming</span>―What's up? Have you a pain or what's up with you? <br></p> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Stephen</span>―I don't know,  Stephen  said. <br></p> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Fleming</span>―Sick in your breadbasket,  Fleming  said, because your face <br>
              looks white. It will go away. <br></p> </p>
-            <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Stephen</span>―O yes,  Stephen  said. <span class="tag lineNumber">10220</span><br></p> </p>
+            <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Stephen</span>―O yes,  Stephen  said. <span class="tag lineNumber">220</span><br></p> </p>
             <p class="textParagraph"> But he was not sick there. He thought that he was sick in his <br>
              heart if you could be sick in that place.  Fleming  was very <br>
              decent to ask him. He wanted to cry. He leaned his elbows on <br>
              the table and shut and opened the flaps of his ears. Then he <br>
-             heard the noise of the refectory every time he opened the flaps <span class="tag lineNumber">10225</span><br>
+             heard the noise of the refectory every time he opened the flaps <br>
              of his ears. It made a roar like a train at night. And when he <br>
              closed the flaps the roar was shut off like a train going into a <br>
              tunnel. That night at   <span class="hide"> 53.277911 -6.105844 </span>   Dalkey   the train had roared like that and <br>
              then, when it went into the tunnel, the roar stopped. He closed <br>
-             his eyes and the train went on, roaring and then stopping; <span class="tag lineNumber">10230</span><br>
+             his eyes and the train went on, roaring and then stopping; <span class="tag lineNumber">230</span><br>
              roaring again, stopping. It was nice to hear it roar and stop and <br>
              then roar out of the tunnel again and then stop.<br> </p>
             <p class="textParagraph"> Then the higher line fellows began to come down along the <br>
              matting in the middle of the refectory,  Paddy Rath  and  Jimmy <br>
-             Magee  and the Spaniard who was allowed to smoke cigars and <span class="tag lineNumber">10235</span><br>
+             Magee  and the Spaniard who was allowed to smoke cigars and <br>
              the little Portuguese who wore the woolly cap. And then the <br>
              lower line tables and the tables of the third line. And every <br>
              single fellow had a different way of walking.<br> </p>
             <p class="textParagraph"> He sat in a corner of the playroom pretending to watch a <br>
-             game of dominos and once or twice he was able to hear for an <span class="tag lineNumber">10240</span><br>
+             game of dominos and once or twice he was able to hear for an <span class="tag lineNumber">240</span><br>
              instant the little song of the gas. The prefect was at the door <br>
              with some boys and  Simon Moonan  was knotting his false <br>
              sleeves. He was telling them something about   <span class="hide"> 52.888640 -8.428450 </span>   Tullabeg  .<br> </p>
             <p class="textParagraph"> Then he went away from the door and  Wells  came over to <br>
-              Stephen  and said:<span class="tag lineNumber">10245</span><br> </p>
+              Stephen  and said:<br> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Wells</span>―Tell us,  Dedalus , do you kiss your mother every night before <br>
              you go to bed? <br></p> </p>
             <p class="textParagraph">  Stephen  answered:<br> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Stephen</span>―I do. <br></p> </p>
-            <p class="textParagraph">  Wells  turned to the other fellows and said:<span class="tag lineNumber">10250</span><br> </p>
+            <p class="textParagraph">  Wells  turned to the other fellows and said:<span class="tag lineNumber">250</span><br> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Wells</span>―O, I say, here's a fellow says he kisses his mother every night <br>
              before he goes to bed. <br></p> </p>
             <p class="textParagraph"> The other fellows stopped their game and turned round, <br>
              laughing.  Stephen  blushed under their eyes and said:<br> </p>
-            <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Stephen</span>―I do not. <span class="tag lineNumber">10255</span><br></p> </p>
+            <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Stephen</span>―I do not. <br></p> </p>
             <p class="textParagraph">  Wells  said:<br> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Wells</span>―O, I say, here's a fellow says he doesn't kiss his mother <br>
              before he goes to bed. <br></p> </p>
             <p class="textParagraph"> They all laughed again.  Stephen  tried to laugh with them. <br>
-             He felt his whole body hot and confused in a moment. What <span class="tag lineNumber">10260</span><br>
+             He felt his whole body hot and confused in a moment. What <span class="tag lineNumber">260</span><br>
              was the right answer to the question? He had given two and <br>
              still  Wells  laughed. But  Wells  must know the right answer for <br>
              he was in third of grammar. He tried to think of  Wells 's mother <br>
              but he did not dare to raise his eyes to  Wells 's face. He did not <br>
-             like  Wells 's face. It was  Wells  who had shouldered him into the <span class="tag lineNumber">10265</span><br>
+             like  Wells 's face. It was  Wells  who had shouldered him into the <br>
              square ditch the day before because he would not swop his <br>
              little  snuffbox  for  Wells 's seasoned hacking chestnut, the con- <br>
              queror of forty. It was a mean thing to do; all the fellows said it <br>
              was. And how cold and slimy the water had been! And a fellow <br>
-             had once seen a big rat jump plop into the scum.<span class="tag lineNumber">10270</span><br> </p>
+             had once seen a big rat jump plop into the scum.<span class="tag lineNumber">270</span><br> </p>
             <p class="textParagraph"> The cold slime of the ditch covered his whole body; and, <br>
              when the bell rang for study and the lines filed out of the <br>
              playrooms, he felt the cold air of the corridor and staircase <br>
              inside his clothes. He still tried to think what was the right <br>
-             answer. Was it right to kiss his mother or wrong to kiss his <span class="tag lineNumber">10275</span><br>
+             answer. Was it right to kiss his mother or wrong to kiss his <br>
              mother? What did that mean, to kiss? You put your face up like <br>
              that to say goodnight and then his mother put her face down. <br>
              That was to kiss. His mother put her lips on his cheek; her lips <br>
              were soft and they wetted his cheek; and they made a tiny little <br>
-             noise: kiss. Why did people do that with their two faces?<span class="tag lineNumber">10280</span><br> </p>
+             noise: kiss. Why did people do that with their two faces?<span class="tag lineNumber">280</span><br> </p>
             <p class="textParagraph"> Sitting in the  studyhall  he opened the lid of his desk and <br>
              changed the number pasted up inside from  seventyseven  to <br>
               seventysix . But the Christmas vacation was very far away: but <br>
              one time it would come because the earth moved round always.<br> </p>
-            <p class="textParagraph"> There was a picture of the earth on the first page of his <span class="tag lineNumber">10285</span><br>
+            <p class="textParagraph"> There was a picture of the earth on the first page of his <br>
              geography: a big ball in the middle of clouds.  Fleming  had a <br>
              box of crayons and one night during free study he had coloured <br>
              the earth green and the clouds maroon. That was like the two <br>
              brushes in  Dante 's press, the brush with the green velvet back <br>
-             for  Parnell  and the brush with the maroon velvet back for <span class="tag lineNumber">10290</span><br>
+             for  Parnell  and the brush with the maroon velvet back for <span class="tag lineNumber">290</span><br>
               Michael Davitt . But he had not told  Fleming  to colour them <br>
              those colours.  Fleming  had done it himself.<br> </p>
             <p class="textParagraph"> He opened the geography to study the lesson; but he could <br>
              not learn the names of places in  America . Still they were all <br>
-             different places that had those different names. They were all in <span class="tag lineNumber">10295</span><br>
+             different places that had those different names. They were all in <br>
              different countries and the countries were in continents and the <br>
              continents were in the world and the world was in the universe.<br> </p>
             <p class="textParagraph"> He turned to the flyleaf of the geography and read what he <br>
              had written there: himself, his name and where he was.<br> </p>
             <p class="lg">
-                <span class="emph">  Stephen Dedalus  </span>  <span class="tag lineNumber">10300</span><br>
+                <span class="emph">  Stephen Dedalus  </span>  <span class="tag lineNumber">300</span><br>
                 <span class="emph"> Class of Elements </span>  <br>
                 <span class="emph">   <span class="hide"> 53.310769 -6.684716 </span>   Clongowes Wood College   </span>  <br>
                 <span class="emph">   <span class="hide"> 53.251067 -6.665231 </span>   Sallins   </span>  <br>
                 <span class="emph">  County Kildare  </span>  <br>
-                <span class="emph">  Ireland  </span>  <span class="tag lineNumber">10305</span><br>
+                <span class="emph">  Ireland  </span>  <br>
                 <span class="emph">  Europe  </span>  <br>
                 <span class="emph">  The World  </span>  <br>
                 <span class="emph">  The Universe  </span>  <br>
             </p>
             <p class="textParagraph"> That was in his writing: and  Fleming  one night for a cod had <br>
-             written on the opposite page:<span class="tag lineNumber">10310</span><br> </p>
+             written on the opposite page:<span class="tag lineNumber">310</span><br> </p>
             <p class="lg">
                 <span class="emph">  Stephen Dedalus  is my name, </span>  <br>
                 <span class="emph">  Ireland  is my nation. </span>  <br>
                 <span class="emph">   <span class="hide"> 53.310769 -6.684716 </span>   Clongowes   is my  dwellingplace  </span>  <br>
                 <span class="emph"> And heaven my expectation. </span>  <br>
             </p>
-            <p class="textParagraph"> He read the verses backwards but then they were not poetry. <span class="tag lineNumber">10315</span><br>
+            <p class="textParagraph"> He read the verses backwards but then they were not poetry. <br>
              Then he read the flyleaf from the bottom to the top till he came <br>
              to his own name. That was he: and he read down the page <br>
              again. What was after  the universe ? Nothing. But was there <br>
              anything round  the universe  to show where it stopped before <br>
-             the nothing place began? It could not be a wall but there could <span class="tag lineNumber">10320</span><br>
+             the nothing place began? It could not be a wall but there could <span class="tag lineNumber">320</span><br>
              be a thin thin line there all round everything. It was very big to <br>
              think about everything and everywhere. Only  God  could do <br>
              that. He tried to think what a big thought that must be but he <br>
              could think only of  God .  God  was  God 's name just as his name <br>
-             was  Stephen .  <span class="emph"> Dieu </span>  was the French for  God  and that was  God 's <span class="tag lineNumber">10325</span><br>
+             was  Stephen .  <span class="emph"> Dieu </span>  was the French for  God  and that was  God 's <br>
              name too; and when anyone prayed to  God  and said  <span class="emph"> Dieu </span>  then <br>
               God  knew at once that it was a French person that was pray- <br>
               ing. But though there were different names for  God  in all the <br>
              different languages in the world and  God  understood what all <br>
-             the people who prayed said in their different languages still <span class="tag lineNumber">10330</span><br>
+             the people who prayed said in their different languages still <span class="tag lineNumber">330</span><br>
               God  remained always the same  God  and  God 's real name was <br>
               God .<br> </p>
             <p class="textParagraph"> It made him very tired to think that way. It made him feel <br>
              his head very big. He turned over the flyleaf and looked wearily <br>
-             at the green round earth in the middle of the maroon clouds. <span class="tag lineNumber">10335</span><br>
+             at the green round earth in the middle of the maroon clouds. <br>
              He wondered which was right, to be for the green or for the <br>
              maroon, because  Dante  had ripped the green velvet back off <br>
              the brush that was for  Parnell  one day with her scissors and <br>
              had told him that  Parnell  was a bad man. He wondered if they <br>
-             were arguing at home about that. That was called politics. <span class="tag lineNumber">10340</span><br>
+             were arguing at home about that. That was called politics. <span class="tag lineNumber">340</span><br>
              There were two sides in it:  Dante  was on one side and his <br>
              father and  Mr Casey  were on the other side but his mother and <br>
               uncle Charles  were on no side. Every day there was something <br>
              in the paper about it.<br> </p>
-            <p class="textParagraph"> It pained him that he did not know well what politics meant <span class="tag lineNumber">10345</span><br>
+            <p class="textParagraph"> It pained him that he did not know well what politics meant <br>
              and that he did not know where the universe ended. He felt <br>
              small and weak. When would he be like the fellows in poetry <br>
              and rhetoric? They had big voices and big boots and they <br>
              studied trigonometry. That was very far away. First came the <br>
-             vacation and then the next term and then vacation again and <span class="tag lineNumber">10350</span><br>
+             vacation and then the next term and then vacation again and <span class="tag lineNumber">350</span><br>
              then again another term and then again the vacation. It was <br>
              like a train going in and out of tunnels and that was like the <br>
              noise of the boys eating in the refectory when you opened and <br>
              closed the flaps of the ears. Term, vacation; tunnel, out; noise, <br>
-             stop. How far away it was! It was better to go to bed to sleep. <span class="tag lineNumber">10355</span><br>
+             stop. How far away it was! It was better to go to bed to sleep. <br>
              Only prayers in the chapel and then bed. He shivered and <br>
              yawned. It would be lovely in bed after the sheets got a bit hot. <br>
              First they were so cold to get into. He shivered to think how <br>
              cold they were first. But then they got hot and then he could <br>
-             sleep. It was lovely to be tired. He yawned again. Night prayers <span class="tag lineNumber">10360</span><br>
+             sleep. It was lovely to be tired. He yawned again. Night prayers <span class="tag lineNumber">360</span><br>
              and then bed: he shivered and wanted to yawn. It would be <br>
              lovely in a few minutes. He felt a warm glow creeping up from <br>
              the cold shivering sheets, warmer and warmer till he felt warm <br>
              all over, ever so warm; ever so warm and yet he shivered a little <br>
-             and still wanted to yawn.<span class="tag lineNumber">10365</span><br> </p>
+             and still wanted to yawn.<br> </p>
             <p class="textParagraph"> The bell rang for night prayers and he filed out of the  study- <br>
              hall  after the others and down the staircase and along the <br>
              corridors to the chapel. The corridors were darkly lit and the <br>
              chapel was darkly lit. Soon all would be dark and sleeping. <br>
-             There was cold night air in the chapel and the marbles were the <span class="tag lineNumber">10370</span><br>
+             There was cold night air in the chapel and the marbles were the <span class="tag lineNumber">370</span><br>
              colour the sea was at night. The sea was cold day and night: <br>
              but it was colder at night. It was cold and dark under the <br>
              seawall beside his father's house. But the kettle would be on the <br>
              hob to make punch.<br> </p>
-            <p class="textParagraph"> The prefect of the chapel prayed above his head and his <span class="tag lineNumber">10375</span><br>
+            <p class="textParagraph"> The prefect of the chapel prayed above his head and his <br>
              memory knew the responses:<br> </p>
             <p class="lg"><span class="tag type">prayer</span>
                 <span class="emph"> O Lord, open our lips </span>  <br>
                 <span class="emph"> And our mouth shall announce Thy praise. </span>  <br>
                 <span class="emph"> Incline unto our aid, O God! </span>  <br>
-                <span class="emph"> O Lord, make haste to help us! </span>  <span class="tag lineNumber">10380</span><br>
+                <span class="emph"> O Lord, make haste to help us! </span>  <span class="tag lineNumber">380</span><br>
             </p>
             <p class="textParagraph"> There was a cold night smell in the chapel. But it was a holy <br>
              smell. It was not like the smell of the old peasants who knelt at <br>
              the back of the chapel at Sunday mass. That was a smell of air <br>
              and rain and turf and corduroy. But they were very holy peas- <br>
-             ants. They breathed behind him on his neck and sighed as they <span class="tag lineNumber">10385</span><br>
+             ants. They breathed behind him on his neck and sighed as they <br>
              prayed. They lived in   <span class="hide"> 53.293785 -6.687040 </span>   Clane , , a fellow said: there were little <br>
              cottages there and he had seen a woman standing at the  half- <br>
              door  of a cottage with a child in her arms, as the cars had come <br>
              past from   <span class="hide"> 53.251067 -6.665231 </span>   Sallins  . It would be lovely to sleep for one night in <br>
-             that cottage before the fire of smoking turf, in the dark lit by <span class="tag lineNumber">10390</span><br>
+             that cottage before the fire of smoking turf, in the dark lit by <span class="tag lineNumber">390</span><br>
              the fire, in the warm dark, breathing the smell of the peasants, <br>
              air and rain and turf and corduroy. But, O, the road there <br>
              between the trees was dark! You would be lost in the dark. It <br>
              made him afraid to think of how it was.<br> </p>
-            <p class="textParagraph"> He heard the voice of the prefect of the chapel saying the last <span class="tag lineNumber">10395</span><br>
+            <p class="textParagraph"> He heard the voice of the prefect of the chapel saying the last <br>
              prayer. He prayed it too against the dark outside under the <br>
              trees.<br> </p>
             <p class="textParagraph">  Visit, we beseech Thee, O Lord, this habitation and <br>
              drive away from it all the snares of the enemy. May <br>
-             Thy holy angels dwell herein to preserve us in peace <span class="tag lineNumber">10400</span><br>
+             Thy holy angels dwell herein to preserve us in peace <span class="tag lineNumber">400</span><br>
              and may Thy blessing be always upon us through <br>
              Christ, Our Lord. Amen. <br> </p>
             <p class="textParagraph"> His fingers trembled as he undressed himself in the dormi- <br>
              tory. He told his fingers to hurry up. He had to undress and <br>
-             then kneel and say his own prayers and be in bed before the gas <span class="tag lineNumber">10405</span><br>
+             then kneel and say his own prayers and be in bed before the gas <br>
              was lowered so that he might not go to hell when he died. He <br>
              rolled his stockings off and put on his nightshirt quickly and <br>
              knelt trembling at his bedside and repeated his prayers quickly <br>
              quickly fearing that the gas would go down. He felt his shoul- <br>
-            ders shaking as he murmured:<span class="tag lineNumber">10410</span><br> </p>
+            ders shaking as he murmured:<span class="tag lineNumber">410</span><br> </p>
             <p class="lg"><span class="tag type">prayer</span>
                 God bless my father and my mother and spare them to <br>
                me!  <br>
                 God bless my little brothers and sisters and spare them <br>
                to me!  <br>
-                God bless  Dante  and  uncle Charles  and spare them to <span class="tag lineNumber">10415</span><br>
+                God bless  Dante  and  uncle Charles  and spare them to <br>
                me!  <br>
             </p>
             <p class="textParagraph"> He blessed himself and climbed quickly into bed and, tuck- <br>
              ing the end of the nightshirt under his feet, curled himself to <br>
              gether under the cold white sheets, shaking and trembling. But <br>
-             he would not go to hell when he died; and the shaking would <span class="tag lineNumber">10420</span><br>
+             he would not go to hell when he died; and the shaking would <span class="tag lineNumber">420</span><br>
              stop. A voice bade the boys in the dormitory goodnight. He <br>
              peered out for an instant over the coverlet and saw the yellow <br>
              curtains round and before his bed that shut him off on all sides. <br>
              The light was lowered quietly.<br> </p>
-            <p class="textParagraph"> The prefect's shoes went away. Where? Down the staircase <span class="tag lineNumber">10425</span><br>
+            <p class="textParagraph"> The prefect's shoes went away. Where? Down the staircase <br>
              and along the corridors or to his room at the end? He saw the <br>
              dark. Was it true about the black dog that walked there at night <br>
              with eyes as big as  carriagelamps ? They said it was the ghost of <br>
              a murderer. A long shiver of fear flowed over his body. He saw <br>
-             the dark entrance hall of the castle. Old servants in old dress <span class="tag lineNumber">10430</span><br>
+             the dark entrance hall of the castle. Old servants in old dress <span class="tag lineNumber">430</span><br>
              were in the  ironingroom  above the staircase. It was long ago. <br>
              The old servants were quiet. There was a fire there but the hall <br>
              was still dark. A figure came up the staircase from the hall. He <br>
              wore the white cloak of a marshal; his face was pale and <br>
-             strange; he held his hand pressed to his side. He looked out of <span class="tag lineNumber">10435</span><br>
+             strange; he held his hand pressed to his side. He looked out of <br>
              strange eyes at the old servants. They looked at him and saw <br>
              their master's face and cloak and knew that he had received his <br>
               deathwound . But only the dark was where they looked: only <br>
              dark silent air. Their master had received his  deathwound  on <br>
-             the battlefield of   <span class="hide"> 50.075538 14.437800 </span>   Prague   far away over the sea. He was standing <span class="tag lineNumber">10440</span><br>
+             the battlefield of   <span class="hide"> 50.075538 14.437800 </span>   Prague   far away over the sea. He was standing <span class="tag lineNumber">440</span><br>
              on the field; his hand was pressed to his side; his face was pale <br>
              and strange and he wore the white cloak of a marshal.<br> </p>
             <p class="textParagraph"> O how cold and strange it was to think of that! All the dark <br>
              was cold and strange. There were pale strange faces there, great <br>
-             eyes like  carriagelamps . They were the ghosts of murderers, the <span class="tag lineNumber">10445</span><br>
+             eyes like  carriagelamps . They were the ghosts of murderers, the <br>
              figures of marshals who had received their  deathwound  on <br>
              battlefields far away over the sea. What did they wish to say <br>
              that their faces were so strange?<br> </p>
             <p class="textParagraph">  Visit, we beseech Thee, O Lord, this habitation and drive <br>
-             away from it all.... <span class="tag lineNumber">10450</span><br> </p>
+             away from it all.... <span class="tag lineNumber">450</span><br> </p>
             <p class="textParagraph"> Going home for the holidays! That would be lovely: the <br>
              fellows had told him. Getting up on the cars in the early wintry <br>
              morning outside the door of the castle. The cars were rolling <br>
              on the gravel. Cheers for the rector!<br> </p>
-            <p class="textParagraph"> Hurray! Hurray! Hurray!<span class="tag lineNumber">10455</span><br> </p>
+            <p class="textParagraph"> Hurray! Hurray! Hurray!<br> </p>
             <p class="textParagraph"> The cars drove past the chapel and all caps were raised. <br>
              They drove merrily along the country roads. The drivers <br>
              pointed with their whips to   <span class="hide"> 53.262617 -6.666295 </span>   Bodenstown  . The fellows cheered. <br>
              They passed the farmhouse of the Jolly Farmer. Cheer after <br>
             The fellows cheered. They passed the farmhouse of the Jolly Farmer. Cheer after
-             cheer after cheer. Through   <span class="hide"> 53.293785 -6.687040 </span>   Clane   they drove, cheering and <span class="tag lineNumber">10460</span><br>
+             cheer after cheer. Through   <span class="hide"> 53.293785 -6.687040 </span>   Clane   they drove, cheering and <span class="tag lineNumber">460</span><br>
              cheered. The peasant women stood at the  halfdoors , the men <br>
              stood here and there. The lovely smell there was in the wintry <br>
              air: the smell of Clane: rain and wintry air and turf smoul- <br>
              dering and corduroy.<br> </p>
-            <p class="textParagraph"> The train was full of fellows: a long long chocolate train <span class="tag lineNumber">10465</span><br>
+            <p class="textParagraph"> The train was full of fellows: a long long chocolate train <br>
              with cream facings. The guards went to and fro opening, <br>
              closing, locking, unlocking the doors. They were men in dark <br>
              blue and silver; they had silvery whistles and their keys made a <br>
              quick music: click, click: click, click.<br> </p>
-            <p class="textParagraph"> And the train raced on over the flat lands and past the   <span class="hide"> 53.230556 -6.866389 </span>   Hill <span class="tag lineNumber">10470</span><br>
+            <p class="textParagraph"> And the train raced on over the flat lands and past the   <span class="hide"> 53.230556 -6.866389 </span>   Hill <span class="tag lineNumber">470</span><br>
              of Allen  . The  telegraphpoles  were passing, passing. The train <br>
              went on and on. It knew. There were coloured lanterns in the <br>
              hall of his father's house and ropes of green branches. There <br>
              were holly and ivy round the  pierglass  and holly and ivy, green <br>
-             and red, twined round the chandeliers. There were red holly <span class="tag lineNumber">10475</span><br>
+             and red, twined round the chandeliers. There were red holly <br>
              and green ivy round the old portraits on the walls. Holly and <br>
              ivy for him and for Christmas.<br> </p>
             <p class="textParagraph"> Lovely......<br> </p>
             <p class="textParagraph"> All the people. Welcome home,  Stephen ! Noises of welcome. <br>
-             His mother kissed him. Was that right? His father was a mar- <span class="tag lineNumber">10480</span><br>
+             His mother kissed him. Was that right? His father was a mar- <span class="tag lineNumber">480</span><br>
              shal now: higher than a magistrate. Welcome home,  Stephen !<br> </p>
             <p class="textParagraph"> Noises...<br> </p>
             <p class="textParagraph"> There was a noise of  curtainrings  running back along the <br>
              rods, of water being splashed in the basins. There was a noise <br>
-             of rising and dressing and washing in the dormitory: a noise of <span class="tag lineNumber">10485</span><br>
+             of rising and dressing and washing in the dormitory: a noise of <br>
              clapping of hands as the prefect went up and down telling the <br>
              fellows to look sharp. A pale sunlight showed the yellow cur- <br>
              tains drawn back, the tossed beds. His bed was very hot and his <br>
              face and body were very hot.<br> </p>
-            <p class="textParagraph"> He got up and sat on the side of his bed. He was weak. He <span class="tag lineNumber">10490</span><br>
+            <p class="textParagraph"> He got up and sat on the side of his bed. He was weak. He <span class="tag lineNumber">490</span><br>
              tried to pull on his stocking. It had a horrid rough feel. The <br>
              sunlight was queer and cold.<br> </p>
             <p class="textParagraph">  Fleming  said:<br> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Fleming</span>―Are you not well? <br></p> </p>
-            <p class="textParagraph"> He did not know; and  Fleming  said:<span class="tag lineNumber">10495</span><br> </p>
+            <p class="textParagraph"> He did not know; and  Fleming  said:<br> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Fleming</span>―Get back into bed. I'll tell  McGlade  you're not well. <br></p> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Fleming</span>―He's sick. <br></p> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog"></span>―Who is? <br></p> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Fleming</span>―Tell  McGlade . <br></p> </p>
-            <p class="textParagraph"> <p class="dialog"><span class="tag dialog"></span>―Get back into bed. <span class="tag lineNumber">10500</span><br></p> </p>
+            <p class="textParagraph"> <p class="dialog"><span class="tag dialog"></span>―Get back into bed. <span class="tag lineNumber">500</span><br></p> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog"></span>―Is he sick? <br></p> </p>
             <p class="textParagraph"> A fellow held his arms while he loosened the stocking cling- <br>
              ing to his foot and climbed back into the hot bed.<br> </p>
             <p class="textParagraph"> He crouched down between the sheets, glad of their tepid <br>
-             glow. He heard the fellows talk among themselves about him <span class="tag lineNumber">10505</span><br>
+             glow. He heard the fellows talk among themselves about him <br>
              as they dressed for mass. It was a mean thing to do, to shoulder <br>
              him into the square ditch, they were saying.<br> </p>
             <p class="textParagraph"> Then their voices ceased; they had gone. A voice at his bed <br>
              said:<br> </p>
-            <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Wells</span>―  Dedalus , don't spy on us, sure you won't? <span class="tag lineNumber">10510</span><br></p> </p>
+            <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Wells</span>―  Dedalus , don't spy on us, sure you won't? <span class="tag lineNumber">510</span><br></p> </p>
             <p class="textParagraph">  Wells 's face was there. He looked at it and saw that  Wells  <br>
              was afraid.<br> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Wells</span>―I didn't mean to. Sure you won't? <br></p> </p>
             <p class="textParagraph"> His father had told him, whatever he did, never to peach on <br>
-             a fellow. He shook his head and answered no and felt glad. <span class="tag lineNumber">10515</span><br>
+             a fellow. He shook his head and answered no and felt glad. <br>
               Wells  said:<br> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Wells</span>―I didn't mean to, honour bright. It was only for cod. I'm <br>
              sorry. <br></p> </p>
             <p class="textParagraph"> The face and the voice went away. Sorry because he was <br>
-             afraid. Afraid that it was some disease. Canker was a disease of <span class="tag lineNumber">10520</span><br>
+             afraid. Afraid that it was some disease. Canker was a disease of <span class="tag lineNumber">520</span><br>
              plants and cancer one of animals: or another different. That <br>
              was a long time ago then out on the playgrounds in the evening <br>
              light, creeping from point to point on the fringe of his line, a <br>
              heavy bird flying low through the grey light.  Leicester Abbey  lit <br>
-             up.  Wolsey  died there. The abbots buried him themselves.<span class="tag lineNumber">10525</span><br> </p>
+             up.  Wolsey  died there. The abbots buried him themselves.<br> </p>
             <p class="textParagraph"> It was not  Wells 's face, it was the prefect's. He was not <br>
              foxing. No, no: he was sick really. He was not foxing. And he <br>
              felt the prefect's hand on his forehead; and he felt his forehead <br>
              warm and damp against the prefect's cold damp hand. That <br>
-             was the way a rat felt, slimy and damp and cold. Every rat had <span class="tag lineNumber">10530</span><br>
+             was the way a rat felt, slimy and damp and cold. Every rat had <span class="tag lineNumber">530</span><br>
              two eyes to look out of. Sleek slimy coats, little little feet <br>
              tucked up to jump, black shiny eyes to look out of. They could <br>
              understand how to jump. But the minds of rats could not <br>
              understand trigonometry. When they were dead they lay on <br>
-             their sides. Their coats dried then. They were only dead things.<span class="tag lineNumber">10535</span><br> </p>
+             their sides. Their coats dried then. They were only dead things.<br> </p>
             <p class="textParagraph"> The prefect was there again and it was his voice that was <br>
              saying that he was to get up, that  Father Minister  had said he <br>
              was to get up and dress and go to the infirmary. And while he <br>
              was dressing himself as quickly as he could the prefect said:<br> </p>
-            <p class="textParagraph"> <p class="dialog"><span class="tag dialog">the prefect</span>―We must pack off to  Brother Michael  because we have the <span class="tag lineNumber">10540</span><br>
+            <p class="textParagraph"> <p class="dialog"><span class="tag dialog">the prefect</span>―We must pack off to  Brother Michael  because we have the <span class="tag lineNumber">540</span><br>
              collywobbles. Terrible thing to have the collywobbles! How we <br>
              wobble when we have the collywobbles! <br></p> </p>
             <p class="textParagraph"> He was very decent to say that. That was all to make him <br>
              laugh. But he could not laugh because his cheeks and lips were <br>
-             all shivery: and then the prefect had to laugh by himself.<span class="tag lineNumber">10545</span><br> </p>
+             all shivery: and then the prefect had to laugh by himself.<br> </p>
             <p class="textParagraph"> The prefect cried:<br> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">the prefect</span>―Quick march! Hayfoot! Strawfoot! <br></p> </p>
             <p class="textParagraph"> They went together down the staircase and along the corri- <br>
              dor and past the bath. As he passed the door he remembered <br>
-             with a vague fear the warm  turfcoloured  bogwater, the warm <span class="tag lineNumber">10550</span><br>
+             with a vague fear the warm  turfcoloured  bogwater, the warm <span class="tag lineNumber">550</span><br>
              moist air, the noise of plunges, the smell of the towels, like <br>
              medicine.<br> </p>
             <p class="textParagraph">  Brother Michael  was standing at the door of the infirmary <br>
              and from the door of the dark cabinet on his right came a smell <br>
-             like medicine. That came from the bottles on the shelves. The <span class="tag lineNumber">10555</span><br>
+             like medicine. That came from the bottles on the shelves. The <br>
              prefect spoke to  Brother Michael  and  Brother Michael  <br>
              answered and called the prefect sir. He had reddish hair mixed <br>
              with grey and a queer look. It was queer that he would always <br>
              be a brother. It was queer too that you could not call him sir <br>
-             because he was a brother and had a different kind of look. Was <span class="tag lineNumber">10560</span><br>
+             because he was a brother and had a different kind of look. Was <span class="tag lineNumber">560</span><br>
              he not holy enough or why could he not catch up on the others?<br> </p>
             <p class="textParagraph"> There were two beds in the room and in one bed there was a <br>
              fellow: and when they went in he called out:<br> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Athy</span>―Hello! It's young  Dedalus ! What's up? <br></p> </p>
-            <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Brother Michael</span>―The sky is up,  Brother Michael  said. <span class="tag lineNumber">10565</span><br></p> </p>
+            <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Brother Michael</span>―The sky is up,  Brother Michael  said. <br></p> </p>
             <p class="textParagraph"> He was a fellow out of the third of grammar and, while  Stephen  <br>
              was undressing, he asked  Brother Michael  to bring him a round <br>
              of buttered toast.<br> </p>
          <p class="textParagraph"><p class="dialog"><span class="tag dialog">Athy</span>―Ah, do!</p> he said. <br></p>
-            <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Brother Michael</span>―Butter you up! said  Brother Michael . You'll get your walking <span class="tag lineNumber">10570</span><br>
+            <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Brother Michael</span>―Butter you up! said  Brother Michael . You'll get your walking <span class="tag lineNumber">570</span><br>
              papers in the morning when the doctor comes. <br></p> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Athy</span>―Will I?</p> the fellow said. <p class="dialog"><span class="tag dialog">Athy</span>I'm not well yet. <br></p> </p>
             <p class="textParagraph">  Brother Michael  repeated:<br> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Athy</span>―You'll get your walking papers, I tell you. <br></p> </p>
-            <p class="textParagraph"> He bent down to rake the fire. He had a long back like the <span class="tag lineNumber">10575</span><br>
+            <p class="textParagraph"> He bent down to rake the fire. He had a long back like the <br>
              long back of a  tramhorse . He shook the poker gravely and <br>
              nodded his head at the fellow out of third of grammar.<br> </p>
             <p class="textParagraph"> Then  Brother Michael  went away and after a while the fel- <br>
              low out of third of grammar turned in towards the wall and fell <br>
-             asleep.<span class="tag lineNumber">10580</span><br> </p>
+             asleep.<span class="tag lineNumber">580</span><br> </p>
             <p class="textParagraph"> That was the infirmary. He was sick then. Had they written <br>
              home to tell his mother and father? But it would be quicker for <br>
              one of the priests to go himself to tell them. Or he would write <br>
              a letter for the priest to bring.<br> </p>
             <p class="lg"><span class="tag type">letter</span>
-                <span class="emph"> Dear Mother </span>  <span class="tag lineNumber">10585</span><br>
+                <span class="emph"> Dear Mother </span>  <br>
                 <span class="emph"> I am sick. I want to go home. Please come and take <br>
                me home. I am in the infirmary. </span>  <br>
                 <span class="emph"> Your fond son, </span>  <br>
                 <span class="emph">  Stephen  </span>  <br>
             </p>
-            <p class="textParagraph"> How far away they were! There was cold sunlight outside <span class="tag lineNumber">10590</span><br>
+            <p class="textParagraph"> How far away they were! There was cold sunlight outside <span class="tag lineNumber">590</span><br>
              the window. He wondered if he would die. You could die just <br>
              the same on a sunny day. He might die before his mother came. <br>
              Then he would have a dead mass in the chapel like the way the <br>
@@ -751,124 +751,124 @@
              rector would be there in a cope of black and gold and there <br>
              would be tall yellow candles on the altar and round the cata- <br>
              falque. And they would carry the coffin out of the chapel <br>
-             slowly and he would be buried in the little graveyard of the <span class="tag lineNumber">10600</span><br>
+             slowly and he would be buried in the little graveyard of the <span class="tag lineNumber">600</span><br>
              community off the main avenue of limes. And  Wells  would be <br>
              sorry then for what he had done. And the bell would toll <br>
              slowly.<br> </p>
             <p class="textParagraph"> He could hear the tolling. He said over to himself the song <br>
-             that  Brigid  had taught him.<span class="tag lineNumber">10605</span><br> </p>
+             that  Brigid  had taught him.<br> </p>
             <p class="lg"><span class="tag type">song</span>
                 <span class="emph"> Dingdong! The castle bell! </span>  <br>
                 <span class="emph"> Farewell, my mother! </span>  <br>
                 <span class="emph"> Bury me in the old churchyard </span>  <br>
                 <span class="emph"> Beside my eldest brother. </span>  <br>
-                <span class="emph"> My coffin shall be black, </span>  <span class="tag lineNumber">10610</span><br>
+                <span class="emph"> My coffin shall be black, </span>  <span class="tag lineNumber">610</span><br>
                 <span class="emph"> Six angels at my back, </span>  <br>
                 <span class="emph"> Two to sing and two to pray </span>  <br>
                 <span class="emph"> And two to carry my soul away. </span>  <br>
             </p>
             <p class="textParagraph"> How beautiful and sad that was! How beautiful the words <br>
-             were where they said <span class="emph"> Bury me in the old churchyard </span>! A tremor <span class="tag lineNumber">10615</span><br>
+             were where they said <span class="emph"> Bury me in the old churchyard </span>! A tremor <br>
              passed over his body. How sad and how beautiful! He wanted <br>
              to cry quietly but not for himself: for the words, so beautiful <br>
              and sad, like music. The bell! The bell! Farewell! O farewell!<br> </p>
             <p class="textParagraph"> The cold sunlight was weaker and  Brother Michael  was <br>
-             standing at his bedside with a bowl of  beeftea . He was glad for <span class="tag lineNumber">10620</span><br>
+             standing at his bedside with a bowl of  beeftea . He was glad for <span class="tag lineNumber">620</span><br>
              his mouth was hot and dry. He could hear them playing on the <br>
              playgrounds. It was after lunchtime. And the day was going on <br>
              in the college just as if he were there.<br> </p>
             <p class="textParagraph"> Then  Brother Michael  was going away and the fellow out of <br>
-             third of grammar told him to be sure and come back and tell <span class="tag lineNumber">10625</span><br>
+             third of grammar told him to be sure and come back and tell <br>
              him all the news in the paper. He told  Stephen  that his name <br>
              was  Athy  and that his father kept a lot of racehorses that were <br>
              spiffing jumpers and that his father would give a good tip to <br>
               Brother Mi- <br>
-             chael  any time he wanted it because  Brother Michael  was very decent and always told him the news out of the <span class="tag lineNumber">10630</span><br>
+             chael  any time he wanted it because  Brother Michael  was very decent and always told him the news out of the <span class="tag lineNumber">630</span><br>
              paper they got every day up in the castle. There was every kind <br>
              of news in the paper: accidents, shipwrecks, sports and politics.<br> </p>
             <p class="textParagraph"><p class="dialog"><span class="tag dialog">Athy</span>―Now it is all about politics in the paper,</p> he said. <p class="dialog"><span class="tag dialog">Athy</span>Do your <br>
              people talk about that too? <br></p> </p>
-            <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Stephen</span>―Yes,  Stephen  said. <span class="tag lineNumber">10635</span><br></p> </p>
+            <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Stephen</span>―Yes,  Stephen  said. <br></p> </p>
             <p class="textParagraph"><p class="dialog"><span class="tag dialog">Athy</span>―Mine too,</p> he said. <br></p>
             <p class="textParagraph"> Then he thought for a moment and said:<br> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Athy</span>―You have a queer name,  Dedalus , and I have a queer name <br>
              too,   <span class="hide"> 52.991834 -6.985728 </span>    Athy   . My name is the name of a town. Your name is like <br>
-             Latin. <span class="tag lineNumber">10640</span><br></p> </p>
+             Latin. <span class="tag lineNumber">640</span><br></p> </p>
             <p class="textParagraph"> Then he asked:<br> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Athy</span>―Are you good at riddles? <br></p> </p>
             <p class="textParagraph">  Stephen  answered:<br> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Stephen</span>―Not very good. <br></p> </p>
-            <p class="textParagraph"> Then he said:<span class="tag lineNumber">10645</span><br> </p>
+            <p class="textParagraph"> Then he said:<br> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Athy</span>―Can you answer me this one? Why is the county  Kildare  like <br>
              the leg of a fellow's breeches? <br></p> </p>
             <p class="textParagraph">  Stephen  thought what could be the answer and then said:<br> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Stephen</span>―I give it up. <br></p> </p>
-            <p class="textParagraph"><p class="dialog"><span class="tag dialog">Athy</span>―Because there is a thigh in it,</p> he said. <p class="dialog"><span class="tag dialog">Athy</span>Do you see the joke? <span class="tag lineNumber">10650</span><br>
+            <p class="textParagraph"><p class="dialog"><span class="tag dialog">Athy</span>―Because there is a thigh in it,</p> he said. <p class="dialog"><span class="tag dialog">Athy</span>Do you see the joke? <span class="tag lineNumber">650</span><br>
               Athy   is the town in the county  Kildare  and a thigh is the other <br>
             thigh. <br></p></p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Stephen</span>―O, I see,  Stephen  said. <br></p> </p>
             <p class="textParagraph"><p class="dialog"><span class="tag dialog">Athy</span>―That's an old riddle,</p> he said. <br></p>
-            <p class="textParagraph"> After a moment he said:<span class="tag lineNumber">10655</span><br> </p>
+            <p class="textParagraph"> After a moment he said:<br> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Athy</span>―I say! <br></p> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Stephen</span>―What? asked  Stephen . <br></p> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Athy</span>―You know, he said, you can ask that riddle another way? <br></p> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Stephen</span>―Can you? said  Stephen . <br></p> </p>
-            <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Athy</span>―The same riddle, he said. Do you know the other way to ask <span class="tag lineNumber">10660</span><br>
+            <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Athy</span>―The same riddle, he said. Do you know the other way to ask <span class="tag lineNumber">660</span><br>
              it?<br></p> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Stephen</span>―No, said  Stephen . <br></p> </p>
             <p class="textParagraph"><p class="dialog"><span class="tag dialog">Athy</span>―Can you not think of the other way?</p> he said. <br></p>
             <p class="textParagraph"> He looked at  Stephen  over the bedclothes as he spoke. Then <br>
-             he lay back on the pillow and said:<span class="tag lineNumber">10665</span><br> </p>
+             he lay back on the pillow and said:<br> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Athy</span>―There is another way but I won't tell you what it is. <br></p> </p>
             <p class="textParagraph"> Why did he not tell it? His father, who kept the racehorses, <br>
              must be a magistrate too like  Saurin 's father and  Nasty Roche 's <br>
              father. He thought of his own father, of how he sang songs <br>
-             while his mother played and of how he always gave him a <span class="tag lineNumber">10670</span><br>
+             while his mother played and of how he always gave him a <span class="tag lineNumber">670</span><br>
              shilling when he asked for sixpence and he felt sorry for him <br>
              that he was not a magistrate like the other boys' fathers. Then <br>
              why was he sent to that place with them? But his father had <br>
              told him that he would be no stranger there because his grand- <br>
-             uncle had presented an address to the liberator there fifty years <span class="tag lineNumber">10675</span><br>
+             uncle had presented an address to the liberator there fifty years <br>
              before. You could know the people of that time by their old <br>
              dress. It seemed to him a solemn time: and he wondered if that <br>
              was the time when the fellows in  Clongowes  wore blue coats <br>
              with brass buttons and yellow waistcoats and caps of  rabbit- <br>
-            skin  and drank beer like grownup people and kept greyhounds <span class="tag lineNumber">10680</span><br>
+            skin  and drank beer like grownup people and kept greyhounds <span class="tag lineNumber">680</span><br>
              of their own to course the hares with.<br> </p>
             <p class="textParagraph"> He looked at the window and saw that the daylight had <br>
              grown weaker. There would be cloudy grey light over the play- <br>
              grounds. There was no noise on the playgrounds. The class <br>
-             must be doing the themes or perhaps  Father Arnall  was reading <span class="tag lineNumber">10685</span><br>
+             must be doing the themes or perhaps  Father Arnall  was reading <br>
              a legend out of the book.<br> </p>
             <p class="textParagraph"> It was queer that they had not given him any medicine. <br>
              Perhaps  Brother Michael  would bring it back when he came. <br>
              They said you got stinking stuff to drink when you were in the <br>
-             infirmary. But he felt better now than before. It would be nice <span class="tag lineNumber">10690</span><br>
+             infirmary. But he felt better now than before. It would be nice <span class="tag lineNumber">690</span><br>
              getting better slowly. You could get a book then. There was a <br>
              book in the library about  Holland . There were lovely foreign <br>
              names in it and pictures of  strangelooking  cities and ships. It <br>
              made you feel so happy.<br> </p>
-            <p class="textParagraph"> How pale the light was at the window! But that was nice. <span class="tag lineNumber">10695</span><br>
+            <p class="textParagraph"> How pale the light was at the window! But that was nice. <br>
              The fire rose and fell on the wall. It was like waves. Someone <br>
              had put coal on and he heard voices. They were talking. It was <br>
              the noise of the waves. Or the waves were talking among them- <br>
             selves as they rose and fell.<br> </p>
-            <p class="textParagraph"> He saw the sea of waves, long dark waves rising and falling, <span class="tag lineNumber">10700</span><br>
+            <p class="textParagraph"> He saw the sea of waves, long dark waves rising and falling, <span class="tag lineNumber">700</span><br>
              dark under the moonless night. A tiny light twinkled at the <br>
              pierhead where the ship was entering: and he saw a multitude <br>
              of people gathered by the waters' edge to see the ship that was <br>
              entering their harbour. A tall man stood on the deck, looking <br>
-             out towards the flat dark land: and by the light at the pierhead <span class="tag lineNumber">10705</span><br>
+             out towards the flat dark land: and by the light at the pierhead <br>
              he saw his face, the sorrowful face of  Brother Michael .<br> </p>
             <p class="textParagraph"> He saw him lift his hand towards the people and heard him <br>
              say in a loud voice of sorrow over the waters:<br> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Brother Michael</span>―He is dead. We saw him lying upon the catafalque. <br></p> </p>
-            <p class="textParagraph"> A wail of sorrow went up from the people.<span class="tag lineNumber">10710</span><br> </p>
+            <p class="textParagraph"> A wail of sorrow went up from the people.<span class="tag lineNumber">710</span><br> </p>
             <p class="textParagraph"> <p class="dialog"><span class="tag dialog">the people</span>―Parnell!  Parnell ! He is dead! <br></p> </p>
             <p class="textParagraph"> They fell upon their knees, moaning in sorrow.<br> </p>
             <p class="textParagraph"> And he saw  Dante  in a maroon velvet dress and with a green <br>
              velvet mantle hanging from her shoulders walking proudly and <br>
-             silently past the people who knelt by the waters' edge.<span class="tag lineNumber">10715</span><br> </p>
+             silently past the people who knelt by the waters' edge.<br> </p>
 
             <div class="divider">* * *</div>
           
@@ -877,441 +877,441 @@
              under the ivytwined branches of the chandelier the Christmas <br>
              table was spread. They had come home a little late and still <br>
              dinner was not ready: but it would be ready in a jiffy, his <br>
-             mother had said. They were waiting for the door to open and <span class="tag lineNumber">10720</span><br>
+             mother had said. They were waiting for the door to open and <span class="tag lineNumber">720</span><br>
              for the servants to come in, holding the big dishes covered with <br>
              their heavy metal covers.<br> </p>
             <p class="textParagraph">  All were waiting: uncle Charles, who sat far away in the <br>
              shadow of the window, Dante and Mr Casey, who sat in the <br>
-             easychairs at either side of the hearth, Stephen, seated on a <span class="tag lineNumber">10725</span><br>
+             easychairs at either side of the hearth, Stephen, seated on a <br>
              chair between them, his feet resting on the toasted boss. Mr <br>
              Dedalus looked at himself in the pierglass above the mantel- <br>
              piece, waxed out his moustache ends and then, parting his <br>
              coattails, stood with his back to the glowing fire: and still, from <br>
-             time to time, he withdrew a hand from his coattail to wax out <span class="tag lineNumber">10730</span><br>
+             time to time, he withdrew a hand from his coattail to wax out <span class="tag lineNumber">730</span><br>
              one of his moustache ends. Mr Casey leaned his head to one <br>
              side and, smiling, tapped the gland of his neck with his fingers. <br>
              And Stephen smiled too for he knew now that it was not true <br>
              that Mr Casey had a purse of silver in his throat. He smiled to <br>
-             think how the silvery noise which Mr Casey used to make had <span class="tag lineNumber">10735</span><br>
+             think how the silvery noise which Mr Casey used to make had <br>
              deceived him. And when he had tried to open Mr Casey's hand <br>
              to see if the purse of silver was hidden there he had seen that <br>
              the fingers could not be straightened out: and Mr Casey had <br>
              told him that he had got those three cramped fingers making a <br>
-             birthday present for Queen Victoria.<span class="tag lineNumber">10740</span><br> </p>
+             birthday present for Queen Victoria.<span class="tag lineNumber">740</span><br> </p>
             <p class="textParagraph">  Mr Casey tapped the gland of his neck and smiled at StephenSte- <br>
              phen with sleepy eyes: and Mr Dedalus said to him: <br>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Yes. Well now, that's all right. O, we had a good walk, <br>
              hadn't we, John? Yes ...... I wonder if there's any likelihood of <br>
-             dinner this evening. Yes ..... O, well now, we got a good breath <span class="tag lineNumber">10745</span><br>
+             dinner this evening. Yes ..... O, well now, we got a good breath <br>
              of ozone round <span class="hide">53.190760 -6.089490</span>the Head today. Ay, bedad. <br></p> </p>
             <p class="textParagraph">  He turned to Dante and said: <br>
              <p class="dialog"><span class="tag dialog">John Casey</span>―You didn't stir out at all, Mrs Riordan? <br></p> </p>
             <p class="textParagraph">  Dante frowned and said shortly: <br>
-             <p class="dialog"><span class="tag dialog">Dante</span>―No. <span class="tag lineNumber">10750</span><br></p> </p>
+             <p class="dialog"><span class="tag dialog">Dante</span>―No. <span class="tag lineNumber">750</span><br></p> </p>
             <p class="textParagraph">  Mr Dedalus dropped his coattails and went over to the side- <br>
              sideboard. He brought forth a great stone jar of whisky from the <br>
              locker and filled the decanter slowly, bending now and then to <br>
              see how much he had poured in. Then replacing the jar in the <br>
-             locker he poured out a little of the whisky into two glasses, <span class="tag lineNumber">10755</span><br>
+             locker he poured out a little of the whisky into two glasses, <br>
              added a little water and came with them back to the fireplace. <br>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―A thimbleful, John,</p> he said. <p class="dialog"><span class="tag dialog">Simon Dedalus</span>Just to whet your appetite. <br></p></p>
             <p class="textParagraph">  Mr Casey took the glass, drank, and placed it near him on <br>
              the mantelpiece. Then he said: <br>
-             <p class="dialog"><span class="tag dialog">John Casey</span>―Well, I can't help thinking of our friend Christopher manu- <span class="tag lineNumber">10760</span><br>
+             <p class="dialog"><span class="tag dialog">John Casey</span>―Well, I can't help thinking of our friend Christopher manu- <span class="tag lineNumber">760</span><br>
              facturing .... <br></p> </p>
             <p class="textParagraph">  He broke into a fit of laughter and coughing and added: <br>
              <p class="dialog"><span class="tag dialog">John Casey</span>―... manufacturing that champagne for those fellows. <br></p> </p>
             <p class="textParagraph">Mr Dedalus laughed loudly. <br>
-              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Is it Christy?</p> he said. <p class="dialog"><span class="tag dialog">Simon Dedalus</span>There's more cunning in one of those <span class="tag lineNumber">10765</span><br>
+              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Is it Christy?</p> he said. <p class="dialog"><span class="tag dialog">Simon Dedalus</span>There's more cunning in one of those <br>
             warts on his bald head than in a pack of jack foxes. <br></p></p>
             <p class="textParagraph">  He inclined his head, closed his eyes, and, licking his lips <br>
              profusely, began to speak with the voice of the hotel keeper. <br>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―And he has such a soft mouth when he's speaking to you, <br>
-             don't you know. He's very moist and watery about the dew- <span class="tag lineNumber">10770</span><br>
+             don't you know. He's very moist and watery about the dew- <span class="tag lineNumber">770</span><br>
              dewlaps, God bless him. <br></p> </p>
             <p class="textParagraph">  Mr Casey was still struggling through his fit of coughing and <br>
              laughter. Stephen, seeing and hearing the hotel keeper through <br>
              his father's face and voice, laughed.<br> </p>
-            <p class="textParagraph">  Mr Dedalus put up his eyeglass and, staring down at him, <span class="tag lineNumber">10775</span><br>
+            <p class="textParagraph">  Mr Dedalus put up his eyeglass and, staring down at him, <br>
              said quietly and kindly: <br>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―What are you laughing at, you little puppy, you? <br></p> </p>
             <p class="textParagraph">  The servants entered and placed the dishes on the table. Mrs <br>
             Dedalus followed and the places were arranged. <br></p>
-              <p class="dialog"><span class="tag dialog">Mary Dedalus</span>―Sit over,</p> she said. <span class="tag lineNumber">10780</span><br>
+              <p class="dialog"><span class="tag dialog">Mary Dedalus</span>―Sit over,</p> she said. <span class="tag lineNumber">780</span><br>
             <p class="textParagraph">  Mr Dedalus went to the end of the table and said: <br>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Now, Mrs Riordan, sit over. John, sit you down, my hearty. <br></p> </p>
             <p class="textParagraph">  He looked round to where uncle Charles sat and said: <br>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Now then, sir, there's a bird here waiting for you. <br></p> </p>
-            <p class="textParagraph">  When all had taken their seats he laid his hand on the cover <span class="tag lineNumber">10785</span><br>
+            <p class="textParagraph">  When all had taken their seats he laid his hand on the cover <br>
              and then said quickly, withdrawing it: <br>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Now, Stephen. <br></p> </p>
             <p class="textParagraph">  Stephen stood up in his place to say the grace before meals:<br> </p>
             <p class="textParagraph">   <p class="dialog"><span class="tag dialog">Stephen</span> <p class="lg"> Bless us, O Lord, and these Thy gifts which through <br>
-             Thy bounty we are about to receive through Christ <span class="tag lineNumber">10790</span><br>
+             Thy bounty we are about to receive through Christ <span class="tag lineNumber">790</span><br>
              Our Lord. Amen.  </p> <br> </p>  </p>
             <p class="textParagraph">  All blessed themselves and Mr Dedalus with a sigh of pleas- <br>
              ure lifted from the dish the heavy cover pearled around the <br>
              edge with glistening drops.<br> </p>
-            <p class="textParagraph">  Stephen looked at the plump turkey which had lain, trussed <span class="tag lineNumber">10795</span><br>
+            <p class="textParagraph">  Stephen looked at the plump turkey which had lain, trussed <br>
              and skewered, on the kitchen table. He knew that his father <br>
              had paid a guinea for it in <span class="hide">53.346308 -6.257925</span>Dunn's of D'Olier Street and that the <br>
              man had prodded it often at the breastbone to show how good <br>
              it was: and he remembered the man's voice when he had said: <br>
-             <p class="dialog"><span class="tag dialog">the butcher</span>―Take that one, sir. That's the real Ally Daly. <span class="tag lineNumber">10800</span><br></p> </p>
+             <p class="dialog"><span class="tag dialog">the butcher</span>―Take that one, sir. That's the real Ally Daly. <span class="tag lineNumber">800</span><br></p> </p>
             <p class="textParagraph">  Why did Mr Barrett in Clongowes call his pandybat a tur- <br>
              key? It was not like a turkey. But Clongowes was far away: and <br>
              the warm heavy smell of turkey and ham and celery rose from <br>
              the plates and dishes and the great fire was banked high and <br>
-             red in the grate and the green ivy and red holly made you feel <span class="tag lineNumber">10805</span><br>
+             red in the grate and the green ivy and red holly made you feel <br>
              so happy and when dinner was ended the big plumpudding <br>
              would be carried in, studded with peeled almonds and sprigs of <br>
              holly, with bluish fire running around it and a little green flag <br>
              flying from the top.<br> </p>
-            <p class="textParagraph">  It was his first Christmas dinner and he thought of his little <span class="tag lineNumber">10810</span><br>
+            <p class="textParagraph">  It was his first Christmas dinner and he thought of his little <span class="tag lineNumber">810</span><br>
              brothers and sisters who were waiting in the nursery, as he had <br>
              often waited, till the pudding came. The deep low collar and <br>
              the <span class="hide">51.487402 -0.607942</span>Eton jacket made him feel queer and oldish: and that morn- <br>
              ing when his mother had brought him down to the parlour, <br>
-             dressed for mass, his father had cried. That was because he was <span class="tag lineNumber">10815</span><br>
+             dressed for mass, his father had cried. That was because he was <br>
              thinking of his own father. And uncle Charles had said so too.<br> </p>
             <p class="textParagraph">  Mr Dedalus covered the dish and began to eat hungrily. <br>
              Then he said: <br>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Poor old Christy, he's nearly lopsided now with roguery. <br> </p>
-             <p class="dialog"><span class="tag dialog">Mary Dedalus</span>―Simon, said Mrs Dedalus, you haven't given Mrs Riordan <span class="tag lineNumber">10820</span><br>
+             <p class="dialog"><span class="tag dialog">Mary Dedalus</span>―Simon, said Mrs Dedalus, you haven't given Mrs Riordan <span class="tag lineNumber">820</span><br>
              any sauce. <br></p> </p>
             <p class="textParagraph">  Mr Dedalus seized the sauceboat. <br>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Haven't I?  he cried. Mrs Riordan, pity the poor blind. <br></p> </p>
             <p class="textParagraph">  Dante covered her plate with her hands and said: <br>
-             <p class="dialog"><span class="tag dialog">Dante</span>―No, thanks. <span class="tag lineNumber">10825</span><br></p> </p>
+             <p class="dialog"><span class="tag dialog">Dante</span>―No, thanks. <br></p> </p>
             <p class="textParagraph">  Mr Dedalus turned to uncle Charles. <br>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―How are you off, sir? <br> </p>
              <p class="dialog"><span class="tag dialog">Uncle Charles</span>―Right as the mail, Simon. <br> </p>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―You, John? <br> </p>
-             <p class="dialog"><span class="tag dialog">John Casey</span>―I'm all right. Go on yourself. <span class="tag lineNumber">10830</span><br> </p>
+             <p class="dialog"><span class="tag dialog">John Casey</span>―I'm all right. Go on yourself. <span class="tag lineNumber">830</span><br> </p>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Mary? Here, Stephen, here's something to make your hair <br>
              curl. <br></p> </p>
             <p class="textParagraph">  He poured sauce freely over Stephen's plate and set the boat <br>
              again on the table. Then he asked uncle Charles was it tender. <br>
-             Uncle Charles could not speak because his mouth was full but <span class="tag lineNumber">10835</span><br>
+             Uncle Charles could not speak because his mouth was full but <br>
              he nodded that it was. <br>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―That was a good answer our friend made to the canon. <br>
              What? said Mr Dedalus. <br> </p>
              <p class="dialog"><span class="tag dialog">John Casey</span>―I didn't think he had that much in him, said Mr Casey. <br> </p>
-             <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―I'll pay you your dues, father, when you cease turning the <span class="tag lineNumber">10840</span><br>
+             <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―I'll pay you your dues, father, when you cease turning the <span class="tag lineNumber">840</span><br>
              house of God into a pollingbooth.<br> </p>
              <p class="dialog"><span class="tag dialog">Dante</span>―A nice answer, said Dante, for any man calling himself a <br>
              catholic to give to his priest. <br> </p>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―They have only themselves to blame, said Mr Dedalus <br>
-             suavely. If they took a fool's advice they would confine their <span class="tag lineNumber">10845</span><br>
+             suavely. If they took a fool's advice they would confine their <br>
              attention to religion. <br> </p>
              <p class="dialog"><span class="tag dialog">Dante</span>―It is religion,</p> Dante said. <p class="dialog"><span class="tag dialog">Dante</span>They are doing their duty in warn- <br>
              ing the people. <br> </p>
              <p class="dialog"><span class="tag dialog">John Casey</span>―We go to the house of God, Mr Casey said, in all humility to <br>
-             pray to our Maker and not to hear election addresses. <span class="tag lineNumber">10850</span><br> </p>
+             pray to our Maker and not to hear election addresses. <span class="tag lineNumber">850</span><br> </p>
              <p class="dialog"><span class="tag dialog">Dante</span>―It is religion, Dante said again. They are right. They must <br>
              direct their flocks. <br> </p>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―And preach politics from the altar, is it? asked Mr Dedalus. <br> </p>
              <p class="dialog"><span class="tag dialog">Dante</span>―Certainly, said Dante. It is a question of public morality. A <br>
-             priest would not be a priest if he did not tell his flock what is <span class="tag lineNumber">10855</span><br>
+             priest would not be a priest if he did not tell his flock what is <br>
              right and what is wrong. <br></p> </p>
             <p class="textParagraph">  Mrs Dedalus laid down her knife and fork, saying: <br>
              <p class="dialog"><span class="tag dialog">Mary Dedalus</span>―For pity's sake and for pity' sake let us have no political <br>
              discussion on this day of all days in the year. <br> </p>
-             <p class="dialog"><span class="tag dialog">Uncle Charles</span>―Quite right, ma'am, said uncle Charles. Now, Simon, that's <span class="tag lineNumber">10860</span><br>
+             <p class="dialog"><span class="tag dialog">Uncle Charles</span>―Quite right, ma'am, said uncle Charles. Now, Simon, that's <span class="tag lineNumber">860</span><br>
              quite enough now. Not another word now. <br> </p>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Yes, yes, said Mr Dedalus quickly. <br></p> </p>
             <p class="textParagraph">  He uncovered the dish boldly and said: <br>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Now then, who's for more turkey? <br></p> </p>
-            <p class="textParagraph">  Nobody answered. Dante said: <span class="tag lineNumber">10865</span><br>
+            <p class="textParagraph">  Nobody answered. Dante said: <br>
              <p class="dialog"><span class="tag dialog">Dante</span>―Nice language for any catholic to use! <br> </p>
              <p class="dialog"><span class="tag dialog">Mary Dedalus</span>―Mrs Riordan, I appeal to you, said Mrs Dedalus, to let the <br>
              matter drop now. <br></p> </p>
             <p class="textParagraph">  Dante turned on her and said: <br>
-             <p class="dialog"><span class="tag dialog">Dante</span>―And am I to sit here and listen to the pastors of my church <span class="tag lineNumber">10870</span><br>
+             <p class="dialog"><span class="tag dialog">Dante</span>―And am I to sit here and listen to the pastors of my church <span class="tag lineNumber">870</span><br>
              being flouted? <br> </p>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Nobody is saying a word against them, said Mr Dedalus, so <br>
              long as they don't meddle in politics. <br> </p>
              <p class="dialog"><span class="tag dialog">Dante</span>―The bishops and priests of Ireland have spoken, said Dante, <br>
-             and they must be obeyed. <span class="tag lineNumber">10875</span><br> </p>
+             and they must be obeyed. <br> </p>
              <p class="dialog"><span class="tag dialog">John Casey</span>―Let them leave politics alone, said Mr Casey, or the people <br>
              may leave their church alone. <br> </p>
              <p class="dialog"><span class="tag dialog">Dante</span>―You hear? said Dante turning to Mrs Dedalus. <br> </p>
              <p class="dialog"><span class="tag dialog">Mary Dedalus</span>―Mr Casey! Simon! said Mrs Dedalus. Let it end now. <br> </p>
-             <p class="dialog"><span class="tag dialog">Uncle Charles</span>―Too bad! Too bad! said uncle Charles. <span class="tag lineNumber">10880</span><br> </p>
+             <p class="dialog"><span class="tag dialog">Uncle Charles</span>―Too bad! Too bad! said uncle Charles. <span class="tag lineNumber">880</span><br> </p>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―What? cried Mr Dedalus. Were we to desert him at the bid- <br>
              ding of the English people? <br> </p>
              <p class="dialog"><span class="tag dialog">Dante</span>―He was no longer worthy to lead, said Dante. He was a <br>
              public sinner. <br> </p>
-             <p class="dialog"><span class="tag dialog">John Casey</span>―We are all sinners and black sinners, said Mr Casey coldly. <span class="tag lineNumber">10885</span><br> </p>
+             <p class="dialog"><span class="tag dialog">John Casey</span>―We are all sinners and black sinners, said Mr Casey coldly. <br> </p>
              <p class="dialog"><span class="tag dialog">Dante</span>―<span class="hide">Matthew 18.7</span>Woe be to the man by whom the scandal cometh! said Mrs <br>
              Riordan. <span class="hide">Luke 17.1-2</span>It would be better for him that a millstone were tied <br>
              about his neck and that he were cast into the depths of the sea <br>
              rather than that he should scandalise one of these, my least <br>
-             little ones. That is the language of the Holy Ghost.<span class="tag lineNumber">10890</span><br> </p>
+             little ones. That is the language of the Holy Ghost.<span class="tag lineNumber">890</span><br> </p>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―And very bad language, if you ask me, said Mr Dedalus <br>
              coolly. <br> </p>
              <p class="dialog"><span class="tag dialog">Uncle Charles</span>―Simon! Simon! said uncle Charles. The boy. <br> </p>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Yes, yes, said Mr Dedalus. I meant about the ... I was think- <br>
-             ing about the bad language of that railway porter. Well now, <span class="tag lineNumber">10895</span><br>
+             ing about the bad language of that railway porter. Well now, <br>
              that's all right. Here, Stephen, show me your plate, old chap. <br>
              Eat away now. Here. <br></p> </p>
             <p class="textParagraph">  He heaped up the food on Stephen's plate and served uncle <br>
              Charles and Mr Casey to large pieces of turkey and splashes of <br>
-             sauce. Mrs Dedalus was eating little and Dante sat with her <span class="tag lineNumber">10900</span><br>
+             sauce. Mrs Dedalus was eating little and Dante sat with her <span class="tag lineNumber">900</span><br>
              hands in her lap. She was red in the face. Mr Dedalus rooted <br>
              with the carvers at the end of the dish and said: <br>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―There's a tasty bit here we call the pope's nose. If any lady <br>
              or gentleman .....<br></p> </p>
-            <p class="textParagraph">  He held a piece of fowl up on the prong of the carvingfork. <span class="tag lineNumber">10905</span><br>
+            <p class="textParagraph">  He held a piece of fowl up on the prong of the carvingfork. <br>
              Nobody spoke. He put it on his own plate, saying: <br>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Well, you can't say but you were asked. I think I had better <br>
              eat it myself because I'm not well in my health lately. <br></p> </p>
             <p class="textParagraph">  He winked at Stephen and, replacing the dishcover, began to <br>
-             eat again.<span class="tag lineNumber">10910</span><br> </p>
+             eat again.<span class="tag lineNumber">910</span><br> </p>
             <p class="textParagraph">  There was a silence while he ate. Then he said: <br>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Well now, the day kept up fine after all. There were plenty <br>
              of strangers down too. <br></p> </p>
             <p class="textParagraph">  Nobody spoke. He said again: <br>
-             <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―I think there were more strangers down than last Christmas. <span class="tag lineNumber">10915</span><br></p> </p>
+             <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―I think there were more strangers down than last Christmas. <br></p> </p>
             <p class="textParagraph">  He looked round at the others whose faces were bent to- <br>
              towards their plates and, receiving no reply, waited for a moment <br>
              and said bitterly: <br>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Well, my Christmas dinner has been spoiled anyhow. <br> </p>
-             <p class="dialog"><span class="tag dialog">Dante</span>―There could be neither luck nor grace,</p> Dante said, <p class="dialog"><span class="tag dialog">Dante</span>in a house <span class="tag lineNumber">10920</span><br>
+             <p class="dialog"><span class="tag dialog">Dante</span>―There could be neither luck nor grace,</p> Dante said, <p class="dialog"><span class="tag dialog">Dante</span>in a house <span class="tag lineNumber">920</span><br>
              where there is no respect for the pastors of the church. <br></p> </p>
             <p class="textParagraph">  Mr Dedalus threw his knife and fork noisily on his plate. <br>
               <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Respect!</p> he said. <p class="dialog"><span class="tag dialog">Simon Dedalus</span>Is it for Billy with the lip or for the tub of <br>
              guts up in <span class="hide">54.350280 -6.652792</span>Armagh? Respect! <br> </p>
-             <p class="dialog"><span class="tag dialog">John Casey</span>―Princes of the church, said Mr Casey with slow scorn. <span class="tag lineNumber">10925</span><br> </p>
+             <p class="dialog"><span class="tag dialog">John Casey</span>―Princes of the church, said Mr Casey with slow scorn. <br> </p>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Lord Leitrim's coachman, yes, said Mr Dedalus. <br> </p>
              <p class="dialog"><span class="tag dialog">Dante</span>―They are the Lord's anointed,</p> Dante said. <p class="dialog"><span class="tag dialog">Dante</span>They are an hon- <br>
              our to their country. <br> </p>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Tub of guts, said Mr Dedalus coarsely. He has a handsome <br>
-             face, mind you, in repose. You should see that fellow lapping <span class="tag lineNumber">10930</span><br>
+             face, mind you, in repose. You should see that fellow lapping <span class="tag lineNumber">930</span><br>
              up his bacon and cabbage of a cold winter's day. O Johnny! <br></p> </p>
             <p class="textParagraph">  He twisted his features into a grimace of heavy bestiality and <br>
              made a lapping noise with his lips. <br>
              <p class="dialog"><span class="tag dialog">Mary Dedalus</span>―Really, Simon, said Mrs Dedalus, you should not speak that <br>
-             way before Stephen. It's not right. <span class="tag lineNumber">10935</span><br> </p>
+             way before Stephen. It's not right. <br> </p>
              <p class="dialog"><span class="tag dialog">Dante</span>―O, he'll remember all this when he grows up, said Dante <br>
              hotly, - the language he heard against God and religion and <br>
              priests in his own home. <br> </p>
              <p class="dialog"><span class="tag dialog">John Casey</span>―Let him remember too, cried Mr Casey to her from across <br>
-             the table, the language with which the priests and the priests' <span class="tag lineNumber">10940</span><br>
+             the table, the language with which the priests and the priests' <span class="tag lineNumber">940</span><br>
              pawns broke Parnell's heart and hounded him into his grave. <br>
              Let him remember that too when he grows up. <br> </p>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Sons of bitches! cried Mr Dedalus. When he was down they <br>
              turned on him to betray him and rend him like rats in a sewer. <br>
-             Lowlived dogs! And they look it! By Christ, they look it! <span class="tag lineNumber">10945</span><br> </p>
+             Lowlived dogs! And they look it! By Christ, they look it! <br> </p>
              <p class="dialog"><span class="tag dialog">Dante</span>―They behaved rightly, cried Dante. They obeyed their <br>
              bishops and their priests. Honour to them! <br> </p>
              <p class="dialog"><span class="tag dialog">Mary Dedalus</span>―Well, it is perfectly dreadful to say that not even for one day <br>
              of the year, said Mrs Dedalus, can we be free from these dread- <br>
-             ful disputes! <span class="tag lineNumber">10950</span><br></p> </p>
+             ful disputes! <span class="tag lineNumber">950</span><br></p> </p>
             <p class="textParagraph">  Uncle Charles raised his hands mildly and said: <br>
              <p class="dialog"><span class="tag dialog">Uncle Charles</span>―Come now, come now, come now! Can we not have our <br>
              opinions whatever they are without this bad temper and this <br>
              bad language? It is too bad surely. <br></p> </p>
-            <p class="textParagraph">  Mrs Dedalus spoke to Dante in a low voice but Dante said <span class="tag lineNumber">10955</span><br>
+            <p class="textParagraph">  Mrs Dedalus spoke to Dante in a low voice but Dante said <br>
              loudly: <br>
              <p class="dialog"><span class="tag dialog">Dante</span>―I will not say nothing. I will defend my church and my <br>
              religion when it is insulted and spit on by renegade catholics. <br></p> </p>
             <p class="textParagraph">  Mr Casey pushed his plate rudely into the middle of the <br>
-             table and, resting his elbows before him, said in a harsh voice <span class="tag lineNumber">10960</span><br>
+             table and, resting his elbows before him, said in a harsh voice <span class="tag lineNumber">960</span><br>
              to his host: <br>
              <p class="dialog"><span class="tag dialog">John Casey</span>―Tell me, did I tell you that story about a very famous spit? <br> </p>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―You did not, John, said Mr Dedalus. <br> </p>
              <p class="dialog"><span class="tag dialog">John Casey</span>―Why then, said Mr Casey, it is a most instructive story. It <br>
-             happened not long ago in the <span class="hide"> 52.986231 -6.367254</span>county Wicklow where we are <span class="tag lineNumber">10965</span><br>
+             happened not long ago in the <span class="hide"> 52.986231 -6.367254</span>county Wicklow where we are <br>
              now. <br></p> </p>
             <p class="textParagraph">  He broke off and, turning towards Dante, said with quiet <br>
              indignation: <br>
              <p class="dialog"><span class="tag dialog">John Casey</span>―And I may tell you, ma'am, that I, if you mean me, am no <br>
-             renegade catholic. I am a catholic as my father was and his <span class="tag lineNumber">10970</span><br>
+             renegade catholic. I am a catholic as my father was and his <span class="tag lineNumber">970</span><br>
              father before him and his father before him again when we <br>
              gave up our lives rather than sell our faith. <br> </p>
             <p class="dialog"><span class="tag dialog">Dante</span>―The more shame to you now,</p> Dante said, <p class="dialog"><span class="tag dialog">Dante</span>to speak as you <br>
              do. <br> </p>
-             <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―The story, John, said Mr Dedalus smiling. Let us have the <span class="tag lineNumber">10975</span><br>
+             <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―The story, John, said Mr Dedalus smiling. Let us have the <br>
              story anyhow. <br> </p>
              <p class="dialog"><span class="tag dialog">Dante</span>―Catholic indeed! repeated Dante ironically. The blackest <br>
              protestant in the land would not speak the language I have <br>
              heard this evening. <br></p> </p>
-            <p class="textParagraph">  Mr Dedalus began to sway his head to and fro, crooning like <span class="tag lineNumber">10980</span><br>
+            <p class="textParagraph">  Mr Dedalus began to sway his head to and fro, crooning like <span class="tag lineNumber">980</span><br>
              a country singer. <br>
              <p class="dialog"><span class="tag dialog">John Casey</span>―I am no protestant, I tell you again, said Mr Casey flushing. <br></p> </p>
             <p class="textParagraph">  Mr Dedalus, still crooning and swaying his head, began to <br>
              sing in a grunting nasal tone: <br>
             <p class="dialog"><span class="tag dialog">Simon Dedalus</span> 
               <p class="lg">
-                 O, come all you Roman catholics <span class="tag lineNumber">10985</span><br>
+                 O, come all you Roman catholics <br>
                  That never went to mass. <br>
               </p>
              </p></p>
             <p class="textParagraph">  He took up his knife and fork again in good humour and set <br>
              to eating, saying to Mr Casey: <br>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Let us have the story, John. It will help us to digest. <br></p> </p>
-            <p class="textParagraph">  Stephen looked with affection at Mr Casey's face which <span class="tag lineNumber">10990</span><br>
+            <p class="textParagraph">  Stephen looked with affection at Mr Casey's face which <span class="tag lineNumber">990</span><br>
              stared across the table over his joined hands. He liked to sit <br>
              near him at the fire, looking up at his dark fierce face. But his <br>
              dark eyes were never fierce and his slow voice was good to <br>
              listen to. But why was he then against the priests? Because <br>
-             Dante must be right then. But he had heard his father say that <span class="tag lineNumber">10995</span><br>
+             Dante must be right then. But he had heard his father say that <br>
              she was a spoiled nun and that she had come out of the convent <br>
              in the Alleghanies when her brothers had got the money from <br>
              the savages for the trinkets and  chainies. Perhaps that made her <br>
              severe against Parnell. And she did not like him to play with <br>
-             Eileen because Eileen was a protestant and when she was <span class="tag lineNumber">11000</span><br>
+             Eileen because Eileen was a protestant and when she was <span class="tag lineNumber">1000</span><br>
              young she knew children that used to play with protestants and <br>
              the protestants used to make fun of the litany of the Blessed <br>
              Virgin. <span class="emph">Tower of Ivory</span>, they used to say, <span class="emph">House of Gold!</span> How <br>
              could a woman be a tower of ivory or a house of gold? Who <br>
-             was right then? And he remembered the evening in the infirm- <span class="tag lineNumber">11005</span><br>
+             was right then? And he remembered the evening in the infirm- <br>
              ary in Clongowes, the dark waters, the light at the pierhead <br>
              and the moan of sorrow from the people when they had heard.<br> </p>
             <p class="textParagraph">  Eileen had long white hands. One evening when playing tig <br>
              she had put her hands over his eyes: long and white and thin <br>
-             and cold and soft. That was ivory: a cold white thing. That <span class="tag lineNumber">11010</span><br>
+             and cold and soft. That was ivory: a cold white thing. That <span class="tag lineNumber">1010</span><br>
              was the meaning of <span class="emph">Tower of Ivory</span>. <br>
              <p class="dialog"><span class="tag dialog">John Casey</span>―The story is very short and sweet,</p> Mr Casey said. <p class="dialog"><span class="tag dialog">John Casey</span>It was one <br>
              day down in <span class="hide">52.797693 -6.159929</span>Arklow, a cold bitter day, not long before the <br>
              chief died. May God have mercy on him! <br></p> </p>
-            <p class="textParagraph">  He closed his eyes wearily and paused. Mr Dedalus took a <span class="tag lineNumber">11015</span><br>
+            <p class="textParagraph">  He closed his eyes wearily and paused. Mr Dedalus took a <br>
              bone from his plate and tore some meat from it with his teeth, <br>
              saying: <br>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Before he was killed, you mean. <br></p> </p>
             <p class="textParagraph">  Mr Casey opened his eyes, sighed and went on: <br>
-             <p class="dialog"><span class="tag dialog">John Casey</span>―It was down in Arklow one day. We were down there at a <span class="tag lineNumber">11020</span><br>
+             <p class="dialog"><span class="tag dialog">John Casey</span>―It was down in Arklow one day. We were down there at a <span class="tag lineNumber">1020</span><br>
              meeting and after the meeting was over we had to make our <br>
              way to the railway station through the crowd. Such booing and <br>
              baaing, man, you never heard. They called us all the names in <br>
              the world. Well there was one old lady, and a drunken old <br>
-             harridan she was surely, that paid all her attention to me. She <span class="tag lineNumber">11025</span><br>
+             harridan she was surely, that paid all her attention to me. She <br>
              kept dancing along beside me in the mud bawling and scream- <br>
              ing into my face: <span class="emph">Priesthunter! The <span class="hide">48.856614 2.352222</span>Paris Funds! Mr Fox! Kitty <br>
              O'Shea!</span> <br> </p>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―And what did you do, John? asked Mr Dedalus. <br> </p>
-             <p class="dialog"><span class="tag dialog">John Casey</span>―I let her bawl away, said Mr Casey. It was a cold day and to <span class="tag lineNumber">11030</span><br>
+             <p class="dialog"><span class="tag dialog">John Casey</span>―I let her bawl away, said Mr Casey. It was a cold day and to <span class="tag lineNumber">1030</span><br>
              keep up my heart I had (saving your presence, ma'am) a quid of <br>
              <span class="hide">53.275526 -7.493385</span>Tullamore in my mouth and sure I couldn't say a word in any <br>
              case because my mouth was full of tobacco juice. <br> </p>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Well, John? <br> </p>
-             <p class="dialog"><span class="tag dialog">John Casey</span>―Well. I let her bawl away to her heart's content <span class="emph">Kitty O'Shea</span> <span class="tag lineNumber">11035</span><br>
+             <p class="dialog"><span class="tag dialog">John Casey</span>―Well. I let her bawl away to her heart's content <span class="emph">Kitty O'Shea</span> <br>
              and the rest of it till at last she called that lady a name that I <br>
              won't sully this Christmas board nor your ears, ma'am, nor my <br>
              own lips by repeating. <br></p> </p>
             <p class="textParagraph">  He paused. Mr Dedalus, lifting his head from the bone, <br>
-             asked: <span class="tag lineNumber">11040</span><br>
+             asked: <span class="tag lineNumber">1040</span><br>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―And what did you do, John? <br> </p>
              <p class="dialog"><span class="tag dialog">John Casey</span>―Do! said Mr Casey. She stuck her ugly old face up at me <br>
              when she said it and I had my mouth full of tobacco juice. I <br>
              bent down to her and <span class="emph">Phth!</span> says I to her like that. <br></p> </p>
-            <p class="textParagraph">  He turned aside and made the act of spitting. <span class="tag lineNumber">11045</span><br>
+            <p class="textParagraph">  He turned aside and made the act of spitting. <br>
              <p class="dialog"><span class="tag dialog">John Casey</span>―<span class="emph">Phth!</span> says I to her like that, right into her eye. <br></p> </p>
             <p class="textParagraph">  He clapped a hand to his eye and gave a hoarse scream of <br>
              pain. <br>
              <p class="dialog"><span class="tag dialog">John Casey</span>―<span class="emph">O Jesus, Mary and Joseph!</span> says she. <span class="emph">I'm blinded! I'm <br>
-             blinded and drownded!</span> <span class="tag lineNumber">11050</span><br></p> </p>
+             blinded and drownded!</span> <span class="tag lineNumber">1050</span><br></p> </p>
             <p class="textParagraph">  He stopped in a fit of coughing and laughter, repeating: <br>
              <p class="dialog"><span class="tag dialog">John Casey</span>―<span class="emph">I'm blinded entirely!</span><br></p> </p>
             <p class="textParagraph">  Mr Dedalus laughed loudly and lay back in his chair while <br>
              uncle Charles swayed his head to and fro.<br> </p>
-            <p class="textParagraph">  Dante looked terribly angry and repeated while they <span class="tag lineNumber">11055</span><br>
+            <p class="textParagraph">  Dante looked terribly angry and repeated while they <br>
              laughed: <br>
              <p class="dialog"><span class="tag dialog">Dante</span>―Very nice! Ha! Very nice! <br></p> </p>
             <p class="textParagraph">  It was not nice about the spit in the woman's eye. But what <br>
              was the name the woman had called Kitty O'Shea that Mr <br>
-             Casey would not repeat? He thought of Mr Casey walking <span class="tag lineNumber">11060</span><br>
+             Casey would not repeat? He thought of Mr Casey walking <span class="tag lineNumber">1060</span><br>
              through the crowds of people and making speeches from a <br>
              wagonette. That was what he had been in prison for and he <br>
              remembered that one night Sergeant O'Neill had come to the <br>
              house and had stood in the hall, talking in a low voice with his <br>
-             father and chewing nervously at the chinstrap of his cap. And <span class="tag lineNumber">11065</span><br>
+             father and chewing nervously at the chinstrap of his cap. And <br>
              that night Mr Casey had not gone to <span class="hide">53.349805 -6.260310 </span>Dublin by train but a car <br>
              had come to the door and he had heard his father say some- <br>
              something about <span class="hide">53.265647 -6.156109</span>the Cabinteely road.<br> </p>
             <p class="textParagraph">  He was for Ireland and Parnell and so was his father: and so <br>
-             was Dante too for one night at the band on the esplanade she <span class="tag lineNumber">11070</span><br>
+             was Dante too for one night at the band on the esplanade she <span class="tag lineNumber">1070</span><br>
              had hit a gentleman on the head with her umbrella because he <br>
              had taken off his hat when the band played <span class="emph">God save the <br>
              Queen</span> at the end.<br> </p>
             <p class="textParagraph">  Mr Dedalus gave a snort of contempt. <br>
-             <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Ah, John,</p> he said. <p class="dialog"><span class="tag dialog">Simon Dedalus</span>It is true for them. We are an unfortunate <span class="tag lineNumber">11075</span><br>
+             <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Ah, John,</p> he said. <p class="dialog"><span class="tag dialog">Simon Dedalus</span>It is true for them. We are an unfortunate <br>
              priestridden race and always were and always will be till the <br>
              end of the chapter. <br></p> </p>
             <p class="textParagraph">  Uncle Charles shook his head, saying: <br>
              <p class="dialog"><span class="tag dialog">Uncle Charles</span>―A bad business! A bad business! <br></p> </p>
-            <p class="textParagraph">  Mr Dedalus repeated: <span class="tag lineNumber">11080</span><br>
+            <p class="textParagraph">  Mr Dedalus repeated: <span class="tag lineNumber">1080</span><br>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―A priestridden Godforsaken race! <br></p> </p>
             <p class="textParagraph">  He pointed to the portrait of his grandfather on the wall to <br>
              his right. <br>
               <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Do you see that old chap up there, John?</p> he said. <p class="dialog"><span class="tag dialog">Simon Dedalus</span>He was a <br>
-             good Irishman when there was no money in the job. He was <span class="tag lineNumber">11085</span><br>
+             good Irishman when there was no money in the job. He was <br>
              condemned to death as a whiteboy. But he had a saying about <br>
              our clerical friends, that he would never let one of them put his <br>
              two feet under his mahogany. <br></p></p>
             <p class="textParagraph">  Dante broke in angrily: <br>
-             <p class="dialog"><span class="tag dialog">Dante</span>―If we are a priestridden race we ought to be proud of it! <span class="tag lineNumber">11090</span><br>
+             <p class="dialog"><span class="tag dialog">Dante</span>―If we are a priestridden race we ought to be proud of it! <span class="tag lineNumber">1090</span><br>
              They are the apple of God's eye. <span class="hide">Zacharia 2:8</span> <span class="emph">Touch them not, says Christ, <br>
              for they are the apple of My eye.</span><br> </p>
              <p class="dialog"><span class="tag dialog">John Casey</span>―And can we not love our country then? asked Mr Casey. Are <br>
              we not to follow the man that was born to lead us? <br> </p>
-             <p class="dialog"><span class="tag dialog">Dante</span>―A traitor to his country! replied Dante. A traitor, an adul- <span class="tag lineNumber">11095</span><br>
+             <p class="dialog"><span class="tag dialog">Dante</span>―A traitor to his country! replied Dante. A traitor, an adul- <br>
              adulterer! The priests were right to abandon him. The priests were <br>
              always the true friends of Ireland. <br> </p>
              <p class="dialog"><span class="tag dialog">John Casey</span>―Were they, faith? said Mr Casey. <br></p> </p>
             <p class="textParagraph">  He threw his fist on the table and, frowning angrily, pro- <br>
-             protruded one finger after another. <span class="tag lineNumber">11100</span><br>
+             protruded one finger after another. <span class="tag lineNumber">1100</span><br>
              <p class="dialog"><span class="tag dialog">John Casey</span>―Didn't the bishops of Ireland betray us in the time of the <br>
              union when bishop Lanigan presented an address of loyalty to <br>
              the marquess Cornwallis? Didn't the bishops and priests sell <br>
              the aspirations of this country in 1829 in return for catholic <br>
-             emancipation? Didn't they denounce the fenian movement <span class="tag lineNumber">11105</span><br>
+             emancipation? Didn't they denounce the fenian movement <br>
              from the pulpit and in the confession box? And didn't they <br>
              dishonour the ashes of Terence Bellew MacManus? <br></p> </p>
             <p class="textParagraph">  His face was glowing with anger and Stephen felt the glow <br>
              rise to his own cheek as the spoken words thrilled him. Mr <br>
-             Dedalus uttered a guffaw of coarse scorn. <span class="tag lineNumber">11110</span><br>
+             Dedalus uttered a guffaw of coarse scorn. <span class="tag lineNumber">1110</span><br>
              <p class="dialog"><span class="tag dialog">John Casey</span>―O, by God, he cried, I forgot little old Paul Cullen! Another <br>
              apple of God's eye! <br></p> </p>
             <p class="textParagraph">  Dante bent across the table and cried to Mr Casey: <br>
              <p class="dialog"><span class="tag dialog">Dante</span>―Right! Right! They were always right! God and morality and <br>
-             religion come first. <span class="tag lineNumber">11115</span><br></p> </p>
+             religion come first. <br></p> </p>
             <p class="textParagraph">  Mrs Dedalus, seeing her excitement, said to her: <br>
              <p class="dialog"><span class="tag dialog">Mary Dedalus</span>―Mrs Riordan, don't excite yourself answering them. <br> </p>
              <p class="dialog"><span class="tag dialog">Dante</span>―God and religion before everything! Dante cried. God and <br>
              religion before the world! <br></p> </p>
-            <p class="textParagraph">  Mr Casey raised his clenched fist and brought it down on <span class="tag lineNumber">11120</span><br>
+            <p class="textParagraph">  Mr Casey raised his clenched fist and brought it down on <span class="tag lineNumber">1120</span><br>
              the table with a crash. <br>
              <p class="dialog"><span class="tag dialog">John Casey</span>―Very well, then, he shouted hoarsely, if it comes to that, no <br>
              God for Ireland! <br> </p>
              <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―John! John! cried Mr Dedalus, seizing his guest by the coat <br>
-             coatsleeve. <span class="tag lineNumber">11125</span><br></p> </p>
+             coatsleeve. <br></p> </p>
             <p class="textParagraph">  Dante stared across the table, her cheeks shaking. Mr Casey <br>
              struggled up from his chair and bent across the table towards <br>
              her, scraping the air from before his eyes with one hand as <br>
              though he were tearing aside a cobweb. <br>
-             <p class="dialog"><span class="tag dialog">John Casey</span>―No God for Ireland! he cried. We have had too much God in <span class="tag lineNumber">11130</span><br>
+             <p class="dialog"><span class="tag dialog">John Casey</span>―No God for Ireland! he cried. We have had too much God in <span class="tag lineNumber">1130</span><br>
              Ireland. Away with God! <br> </p>
              <p class="dialog"><span class="tag dialog">Dante</span>―Blasphemer! Devil! screamed Dante, starting to her feet and <br>
              almost spitting in his face. <br></p> </p>
             <p class="textParagraph">  Uncle Charles and Mr Dedalus pulled Mr Casey back into <br>
-             his chair again, talking to him from both sides reasonably. He <span class="tag lineNumber">11135</span><br>
+             his chair again, talking to him from both sides reasonably. He <br>
              stared before him out of his dark flaming eyes, repeating: <br>
              <p class="dialog"><span class="tag dialog">John Casey</span>―Away with God, I say! <br></p> </p>
             <p class="textParagraph">  Dante shoved her chair violently aside and left the table, <br>
              upsetting her napkinring which rolled slowly along the carpet <br>
-             and came to rest against the foot of an easychair. Mrs Dedalus <span class="tag lineNumber">11140</span><br>
+             and came to rest against the foot of an easychair. Mrs Dedalus <span class="tag lineNumber">1140</span><br>
              rose quickly and followed her towards the door. At the door <br>
              Dante turned round violently and shouted down the room, her <br>
              cheeks flushed and quivering with rage: <br>
              <p class="dialog"><span class="tag dialog">Dante</span>―Devil out of hell! We won! We crushed him to death! Fiend! <br></p> </p>
-            <p class="textParagraph">  The door slammed behind her.<span class="tag lineNumber">11145</span><br> </p>
+            <p class="textParagraph">  The door slammed behind her.<br> </p>
             <p class="textParagraph">  Mr Casey, freeing his arms from his holders, suddenly <br>
              bowed his head on his hands with a sob of pain. <br>
              <p class="dialog"><span class="tag dialog">John Casey</span>―Poor Parnell! he cried loudly. My dead king! <br></p> </p>
             <p class="textParagraph">  He sobbed loudly and bitterly.<br> </p>
-            <p class="textParagraph">  Stephen, raising his terrorstricken face, saw that his father's <span class="tag lineNumber">11150</span><br>
+            <p class="textParagraph">  Stephen, raising his terrorstricken face, saw that his father's <span class="tag lineNumber">1150</span><br>
              eyes were full of tears.<br> </p>
         <div class="divider">* * *</div> 
           
@@ -1319,702 +1319,702 @@
             <p class="textParagraph">  The fellows talked together in little groups.<br> </p>
             <p class="textParagraph">  One fellow said: <br>
              <p class="dialog"><span class="tag dialog">a fellow</span>―They were caught near the <span class="hide">53.290670 -6.535060</span>Hill of Lyons. <br> </p>
-             <p class="dialog"><span class="tag dialog">a fellow</span>―Who caught them? <span class="tag lineNumber">11155</span><br> </p>
+             <p class="dialog"><span class="tag dialog">a fellow</span>―Who caught them? <br> </p>
              <p class="dialog"><span class="tag dialog">a fellow</span>―Mr Gleeson and the minister. They were on a car. <br></p> </p>
             <p class="textParagraph">  The same fellow added: <br>
              <p class="dialog"><span class="tag dialog">a fellow</span>―A fellow in the higher line told me. <br> </p>
              <p class="dialog"><span class="tag dialog">Fleming</span>Fleming asked: <br> </p>
-             <p class="dialog"><span class="tag dialog">a fellow</span>―But why did they run away, tell us? <span class="tag lineNumber">11160</span><br> </p>
+             <p class="dialog"><span class="tag dialog">a fellow</span>―But why did they run away, tell us? <span class="tag lineNumber">1160</span><br> </p>
              <p class="dialog"><span class="tag dialog">Cecil Thunder</span>―I know why,</p> Cecil Thunder said. <p class="dialog"><span class="tag dialog">Cecil Thunder</span>Because they had fecked <br>
              cash out of the rector's room. <br> </p>
              <p class="dialog"><span class="tag dialog">a fellow</span>―Who fecked it? <br> </p>
              <p class="dialog"><span class="tag dialog">John Casey</span>―Kickham's brother. And they all went shares in it. <br></p> </p>
-            <p class="textParagraph">  But that was stealing. How could they have done that? <span class="tag lineNumber">11165</span><br>
+            <p class="textParagraph">  But that was stealing. How could they have done that? <br>
             <p class="dialog"><span class="tag dialog">Wells</span>―A fat lot you know about it, Thunder!</p> Wells said. <p class="dialog"><span class="tag dialog">Wells</span>I know <br>
              why they scut. <br> </p>
              <p class="dialog"><span class="tag dialog">a fellow</span>―Tell us why. <br> </p>
              <p class="dialog"><span class="tag dialog">Wells</span>―I was told not to,</p> Wells said. <br>
-             <p class="dialog"><span class="tag dialog">all</span>―O, go on, Wells,</p> all said. <p class="dialog"><span class="tag dialog">all</span>You might tell us. We won't let it <span class="tag lineNumber">11170</span><br>
+             <p class="dialog"><span class="tag dialog">all</span>―O, go on, Wells,</p> all said. <p class="dialog"><span class="tag dialog">all</span>You might tell us. We won't let it <span class="tag lineNumber">1170</span><br>
              out. <br></p> </p>
             <p class="textParagraph">  Stephen bent forward his head to hear. Wells looked round <br>
              to see if anyone was coming. Then he said secretly: <br>
              <p class="dialog"><span class="tag dialog">Wells</span>―You know the altar wine they keep in the press in the sac- <br>
-             risty? <span class="tag lineNumber">11175</span><br> </p>
+             risty? <br> </p>
              <p class="dialog"><span class="tag dialog">all</span>―Yes. <br> </p>
              <p class="dialog"><span class="tag dialog">Wells</span>―Well, they drank that and it was found out who did it by the <br>
              smell. And that's why they ran away, if you want to know. <br></p> </p>
             <p class="textParagraph">  And the fellow who had spoken first said: <br>
-             <p class="dialog"><span class="tag dialog">a fellow</span>―Yes, that's what I heard too from the fellow in the higher <span class="tag lineNumber">11180</span><br>
+             <p class="dialog"><span class="tag dialog">a fellow</span>―Yes, that's what I heard too from the fellow in the higher <span class="tag lineNumber">1180</span><br>
              line. <br></p> </p>
             <p class="textParagraph">  The fellows were all silent. Stephen stood among them, <br>
              afraid to speak, listening. A faint sickness of awe made him feel <br>
              weak. How could they have done that? He thought of the dark <br>
-             silent sacristy. There were dark wooden presses there where the <span class="tag lineNumber">11185</span><br>
+             silent sacristy. There were dark wooden presses there where the <br>
              crimped surplices lay quietly folded. It was not the chapel but <br>
              still you had to speak under your breath. It was a holy place. <br>
              He remembered the summer evening he had been there to be <br>
              dressed as boatbearer, the evening of the procession to the little <br>
-             altar in the wood. A strange and holy place. The boy that held <span class="tag lineNumber">11190</span><br>
+             altar in the wood. A strange and holy place. The boy that held <span class="tag lineNumber">1190</span><br>
              the censer had swung it gently to and fro near the door with the <br>
              silvery cap lifted by the middle chain to keep the coals lighting. <br>
              That was called charcoal: and it had burned quietly as the <br>
              fellow had swung it gently and had given off a weak sour smell. <br>
-             And then when all were vested he had stood holding out the <span class="tag lineNumber">11195</span><br>
+             And then when all were vested he had stood holding out the <br>
              boat to the rector and the rector had put a spoonful of incense <br>
              in  and it had hissed on the red coals.<br> </p>
             <p class="textParagraph">  The fellows were talking together in little groups here and <br>
              there on the playground. The fellows seemed to him to have <br>
-             grown smaller: that was because a sprinter had knocked him <span class="tag lineNumber">11200</span><br>
+             grown smaller: that was because a sprinter had knocked him <span class="tag lineNumber">1200</span><br>
              down the day before, a fellow out of second of grammar. He <br>
              had been thrown by the fellow's machine lightly on the cinder- <br>
              path and his spectacles had been broken in three pieces and <br>
              some of the grit of the cinders had gone into his mouth.<br> </p>
-            <p class="textParagraph">  That was why the fellows seemed to him smaller and farther <span class="tag lineNumber">11205</span><br>
+            <p class="textParagraph">  That was why the fellows seemed to him smaller and farther <br>
              away and the goalposts so thin and far and the soft grey sky so <br>
              high up. But there was no play on the football grounds for <br>
              cricket was coming: and some said that Barnes would be the <br>
              prof and some said it would be Flowers. And all over the play- <br>
-             playgrounds they were playing rounders and bowling twisters and <span class="tag lineNumber">11210</span><br>
+             playgrounds they were playing rounders and bowling twisters and <span class="tag lineNumber">1210</span><br>
              lobs. And from here and from there came the sounds of the <br>
              cricket bats through the soft grey air. They said: pick, pack, <br>
              pock, puck: like drops of water in a fountain slowly falling in <br>
              the brimming bowl.<br> </p>
-            <p class="textParagraph">  Athy, who had been silent, said quietly: <span class="tag lineNumber">11215</span><br>
+            <p class="textParagraph">  Athy, who had been silent, said quietly: <br>
              <p class="dialog"><span class="tag dialog">Athy</span>―You are all wrong. <br></p> </p>
             <p class="textParagraph">  All turned towards him eagerly. <br>
              <p class="dialog"><span class="tag dialog">a fellow</span>―Why? <br> </p>
              <p class="dialog"><span class="tag dialog">a fellow</span>―Do you know? <br> </p>
-             <p class="dialog"><span class="tag dialog">a fellow</span>―Who told you? <span class="tag lineNumber">11220</span><br> </p>
+             <p class="dialog"><span class="tag dialog">a fellow</span>―Who told you? <span class="tag lineNumber">1220</span><br> </p>
              <p class="dialog"><span class="tag dialog">a fellow</span>―Tell us, Athy. <br></p> </p>
             <p class="textParagraph">  Athy pointed across the playground to where Simon <br>
              Moonan was walking by himself kicking a stone before him. <br></p>
             <p class="textParagraph"><p class="dialog"><span class="tag dialog">Athy</span>―Ask him,</p> he said. <br></p>
-            <p class="textParagraph">  The fellows looked there and then said: <span class="tag lineNumber">11225</span><br>
+            <p class="textParagraph">  The fellows looked there and then said: <br>
              <p class="dialog"><span class="tag dialog">a fellow</span>―Why him? <br> </p>
              <p class="dialog"><span class="tag dialog">a fellow</span>―Is he in it? <br> </p>
              <p class="dialog"><span class="tag dialog">a fellow</span>―Tell us, Athy. Go on. You might if you know. <br></p> </p>
             <p class="textParagraph">  Athy lowered his voice and said: <br>
-             <p class="dialog"><span class="tag dialog">Athy</span>―Do you know why those fellows scut? I will tell you but you <span class="tag lineNumber">11230</span><br>
+             <p class="dialog"><span class="tag dialog">Athy</span>―Do you know why those fellows scut? I will tell you but you <span class="tag lineNumber">1230</span><br>
              must not let on you know. <br></p> </p>
             <p class="textParagraph">  He paused for a moment and then said mysteriously: <br>
              <p class="dialog"><span class="tag dialog">Athy</span>―They were caught with Simon Moonan and Tusker Boyle in <br>
              the square one night. <br></p> </p>
-            <p class="textParagraph">  The fellows looked at him and asked: <span class="tag lineNumber">11235</span><br>
+            <p class="textParagraph">  The fellows looked at him and asked: <br>
              <p class="dialog"><span class="tag dialog">a fellow</span>―Caught? <br> </p>
              <p class="dialog"><span class="tag dialog">a fellow</span>―What doing? <br></p> </p>
             <p class="textParagraph">  Athy said: <br>
              <p class="dialog"><span class="tag dialog">Athy</span>―Smugging. <br></p> </p>
-            <p class="textParagraph">  All the fellows were silent: and Athy said: <span class="tag lineNumber">11240</span><br>
+            <p class="textParagraph">  All the fellows were silent: and Athy said: <span class="tag lineNumber">1240</span><br>
              <p class="dialog"><span class="tag dialog">Athy</span>―And that's why. <br></p> </p>
             <p class="textParagraph">  Stephen looked at the faces of the fellows but they were all <br>
              looking across the playground. He wanted to ask somebody <br>
              about it. What did that mean about the smugging in the <br>
-             square? Why did the five fellows out of the higher line run <span class="tag lineNumber">11245</span><br>
+             square? Why did the five fellows out of the higher line run <br>
              away for that? It was a joke, he thought. Simon Moonan had <br>
              nice clothes and one night he had shown him a ball of creamy <br>
              sweets that the fellows of the football fifteen had rolled down <br>
              to him along the carpet in the middle of the refectory when he <br>
-             was at the door. It was the night of the match against the <span class="tag lineNumber">11250</span><br>
+             was at the door. It was the night of the match against the <span class="tag lineNumber">1250</span><br>
              Bective Rangers and the ball was made just like a red and green <br>
              apple only it opened and it was full of the creamy sweets. And <br>
              one day Boyle had said that an elephant had two tuskers in- <br>
              instead of two tusks and that was why he was called Tusker <br>
-             Boyle but some fellows called him Lady Boyle because he was <span class="tag lineNumber">11255</span><br>
+             Boyle but some fellows called him Lady Boyle because he was <br>
              always at his nails, paring them.<br> </p>
             <p class="textParagraph">  Eileen had long thin cool white hands too because she was a <br>
              girl. They were like ivory; only soft. That was the meaning of <br>
              <span class="emph">Tower of Ivory</span> but protestants could not understand it and <br>
-             made fun of it. One day he had stood beside her looking into <span class="tag lineNumber">11260</span><br>
+             made fun of it. One day he had stood beside her looking into <span class="tag lineNumber">1260</span><br>
              the hotel grounds. A waiter was running up a trail of bunting <br>
              on the flagstaff and a fox terrier was scampering to and fro on <br>
              the sunny lawn. She had put her hand into his pocket where his <br>
              hand was and he had felt how cool and thin and soft her hand <br>
-             was. She had said that pockets were funny things to have: and <span class="tag lineNumber">11265</span><br>
+             was. She had said that pockets were funny things to have: and <br>
              then all of a sudden she had broken away and had run laughing <br>
              down the sloping curve of the path. Her fair hair had streamed <br>
              out behind her like gold in the sun. <span class="emph">Tower of Ivory. House of <br>
              Gold.</span> By thinking about things you could understand them.<br> </p>
-            <p class="textParagraph">  But why in the square? You went there when you wanted to <span class="tag lineNumber">11270</span><br>
+            <p class="textParagraph">  But why in the square? You went there when you wanted to <span class="tag lineNumber">1270</span><br>
              do something. It was all thick slabs of slate and water trickled <br>
              all day out of tiny pinholes and there was a queer smell of stale <br>
              water there. And behind the door of one of the  closets there <br>
              was a drawing in red pencil of a bearded man in a Roman dress <br>
-             with a brick in each hand and underneath was the name of the <span class="tag lineNumber">11275</span><br>
+             with a brick in each hand and underneath was the name of the <br>
              drawing:<br> </p>
             <p class="textParagraph">  <span class="emph">Balbus was building a wall.</span>  <br> </p>
             <p class="textParagraph">  Some fellow had drawn it there for a cod. It had a funny <br>
              face but it was very like a man with a beard. And on the wall of <br>
-             another closet there was written in backhand  in beautiful writ- <span class="tag lineNumber">11280</span><br>
+             another closet there was written in backhand  in beautiful writ- <span class="tag lineNumber">1280</span><br>
              ing:<br> </p>
             <p class="textParagraph">  Julius Caesar wrote The Calico Belly.  <br> </p>
             <p class="textParagraph">  Perhaps that was why they were there  because it was a place <br>
              where some fellows wrote things for cod. But all the same it <br>
-             was queer what Athy said and the way he said it. It was not a <span class="tag lineNumber">11285</span><br>
+             was queer what Athy said and the way he said it. It was not a <br>
              cod because they had run away. He looked with the others in <br>
              silence across the playground and began to feel afraid.<br> </p>
             <p class="textParagraph">  At last Fleming said: <br>
              <p class="dialog"><span class="tag dialog">Fleming</span>―And we are all to be punished for what other fellows did? <br> </p>
-             <p class="dialog"><span class="tag dialog">Cecil Thunder</span>―I won't come back, see if I do,</p> Cecil Thunder said. <p class="dialog"><span class="tag dialog">Cecil Thunder</span>Three <span class="tag lineNumber">11290</span><br>
+             <p class="dialog"><span class="tag dialog">Cecil Thunder</span>―I won't come back, see if I do,</p> Cecil Thunder said. <p class="dialog"><span class="tag dialog">Cecil Thunder</span>Three <span class="tag lineNumber">1290</span><br>
              days' silence in the refectory and sending us up for six and eight <br>
              every minute. <br> </p>
             <p class="dialog"><span class="tag dialog">Wells</span>―Yes,</p> said Wells. <p class="dialog"><span class="tag dialog">Wells</span>And old Barrett has a new way of twisting <br>
              the note so that you can't open it and fold it again to see how <br>
-             many ferulae you are to get. I won't come back too. <span class="tag lineNumber">11295</span><br> </p>
+             many ferulae you are to get. I won't come back too. <br> </p>
             <p class="dialog"><span class="tag dialog">Cecil Thunder</span>―Yes,</p> said Cecil Thunder, <p class="dialog"><span class="tag dialog">Cecil Thunder</span>and the prefect of studies was in <br>
              second of grammar this morning. <br> </p>
             <p class="dialog"><span class="tag dialog">Fleming</span>―Let us get up a rebellion,</p> Fleming said. <p class="dialog"><span class="tag dialog">Fleming</span>Will we? <br></p> </p>
             <p class="textParagraph">  All the fellows were silent. The air was very silent and you <br>
-             could hear the cricket bats but more slowly than before: pick, <span class="tag lineNumber">11300</span><br>
+             could hear the cricket bats but more slowly than before: pick, <span class="tag lineNumber">1300</span><br>
              pock.<br> </p>
             <p class="textParagraph">  Wells asked: <br>
              <p class="dialog"><span class="tag dialog">Wells</span>―What is going to be done to them? <br> </p>
              <p class="dialog"><span class="tag dialog">Athy</span>―Simon Moonan and Tusker are going to be flogged, Athy <br>
-             said, and the fellows in the higher line got their choice of <span class="tag lineNumber">11305</span><br>
+             said, and the fellows in the higher line got their choice of <br>
              flogging or being expelled. <br> </p>
              <p class="dialog"><span class="tag dialog">a fellow</span>―And which are they taking? asked the fellow who had <br>
              spoken first. <br> </p>
              <p class="dialog"><span class="tag dialog">Athy</span>―All are taking expulsion except Corrigan, Athy answered. <br>
-             He's going to be flogged by Mr Gleeson. <span class="tag lineNumber">11310</span><br> </p>
+             He's going to be flogged by Mr Gleeson. <span class="tag lineNumber">1310</span><br> </p>
              <p class="dialog"><span class="tag dialog">Fleming</span>―Is it Corrigan that big fellow? said Fleming. Why, he'd be <br>
              able for two of Gleeson! <br> </p>
             <p class="dialog"><span class="tag dialog">Cecil Thunder</span>―I know why,</p> Cecil Thunder said. <p class="dialog"><span class="tag dialog">Cecil Thunder</span>He is right and the other <br>
              fellows are wrong because a flogging wears off after a bit but a <br>
-             fellow that has been expelled from college is known all his life <span class="tag lineNumber">11315</span><br>
+             fellow that has been expelled from college is known all his life <br>
              on  account of it. Besides Gleeson won't flog him hard. <br> </p>
             <p class="dialog"><span class="tag dialog">Fleming</span>―It's best of his play not to,</p> Fleming said. <br> 
              <p class="dialog"><span class="tag dialog">Cecil Thunder</span>―I wouldn't like to be Simon Moonan and Tusker,</p> Cecil <br>
              Thunder said. <p class="dialog"><span class="tag dialog">Cecil Thunder</span>But I don't believe they will be flogged. Perhaps <br>
-             they will be sent up for twice nine. <span class="tag lineNumber">11320</span><br> </p>
+             they will be sent up for twice nine. <span class="tag lineNumber">1320</span><br> </p>
             <p class="dialog"><span class="tag dialog">Athy</span>―No, no,</p> said Athy. <p class="dialog"><span class="tag dialog">Athy</span>They'll both get it on the vital spot. <br></p> </p>
             <p class="textParagraph">  Wells rubbed himself and said in a crying voice: <br>
              <p class="dialog"><span class="tag dialog">Wells</span>―Please, sir, let me off! <br></p> </p>
             <p class="textParagraph">  Athy grinned and turned up the sleeves of his jacket, saying: <br>
             <p class="dialog"><span class="tag dialog">Athy</span> 
               <p class="lg">
-                 It can't be helped; <span class="tag lineNumber">11325</span><br>
+                 It can't be helped; <br>
                  It must be done. <br>
                  So down with your breeches <br>
                  And out with your bum. <br>
               </p>
              </p></p>
             <p class="textParagraph">  The fellows laughed; but he felt that they were a little afraid. <br>
-             In the silence of the soft grey air he heard the cricket bats from <span class="tag lineNumber">11330</span><br>
+             In the silence of the soft grey air he heard the cricket bats from <span class="tag lineNumber">1330</span><br>
              here and from there: pock. That was a sound to hear but if you <br>
              were hit then you would feel a pain. The pandybat made a <br>
              sound too but not like that. The fellows said it was made of <br>
              whalebone and leather with lead inside: and he wondered what <br>
-             was the pain like. There were different kinds of pains  for all the <span class="tag lineNumber">11335</span><br>
+             was the pain like. There were different kinds of pains  for all the <br>
              different kinds of sounds. A long thin cane would have a high <br>
              whistling sound and he wondered what was that pain like. It <br>
              made him shivery to think of it and cold: and what Athy said <br>
              too. But what was there to laugh at in it? It made him shivery: <br>
-             but that was because you always felt like a shiver when you let <span class="tag lineNumber">11340</span><br>
+             but that was because you always felt like a shiver when you let <span class="tag lineNumber">1340</span><br>
              down your trousers. It was the same in the bath when you <br>
              undressed yourself. He wondered who had to let them down, <br>
              the master or the boy himself. O how could they laugh about it <br>
              that way?<br> </p>
-            <p class="textParagraph">  He looked at Athy's rolledup sleeves and knuckly inky <span class="tag lineNumber">11345</span><br>
+            <p class="textParagraph">  He looked at Athy's rolledup sleeves and knuckly inky <br>
              hands. He had rolled up his sleeves to show how Mr Gleeson <br>
              would roll up his sleeves. But Mr Gleeson had round shiny <br>
              cuffs and clean white wrists and fattish white hands and the <br>
              nails of them were long and pointed. Perhaps he pared them <br>
-             too like Lady Boyle. But they were terribly long and pointed <span class="tag lineNumber">11350</span><br>
+             too like Lady Boyle. But they were terribly long and pointed <span class="tag lineNumber">1350</span><br>
              nails. So long and cruel they were though the white fattish <br>
              hands were not cruel but gentle. And though he trembled with <br>
              cold and fright to think of the cruel long nails and of the high <br>
              whistling sound of the cane and of the chill you felt at the end <br>
-             of your shirt when you undressed yourself yet he felt a feeling <span class="tag lineNumber">11355</span><br>
+             of your shirt when you undressed yourself yet he felt a feeling <br>
              of queer quiet pleasure inside him to think of the white fattish <br>
              hands, clean and strong  and gentle. And he thought of what <br>
              Cecil Thunder had said; that Mr Gleeson would not flog Cor- <br>
              Corrigan hard. And Fleming had said he would not because it was <br>
-             best of his play not to. But that was not why.<span class="tag lineNumber">11360</span><br> </p>
+             best of his play not to. But that was not why.<span class="tag lineNumber">1360</span><br> </p>
             <p class="textParagraph">  A voice from far out on the playgrounds cried: <br>
              <p class="dialog"><span class="tag dialog">a fellow</span>―All in! <br></p> </p>
             <p class="textParagraph">  And other voices cried: <br>
              <p class="dialog"><span class="tag dialog">other voices</span>―All in! All in! <br></p> </p>
-            <p class="textParagraph">  During the writing lesson he sat with his arms folded, listen- <span class="tag lineNumber">11365</span><br>
+            <p class="textParagraph">  During the writing lesson he sat with his arms folded, listen- <br>
              ing to the slow scraping of the pens. Mr Harford went to and <br>
              fro making little signs in red pencil and sometimes sitting <br>
              beside the boy to show him how to hold the pen. He had tried <br>
              to spell out the headline for himself though he knew already <br>
-             what it was for it was the last in the book. <span class="emph">Zeal without <span class="tag lineNumber">11370</span><br>
+             what it was for it was the last in the book. <span class="emph">Zeal without <span class="tag lineNumber">1370</span><br>
              prudence is like a ship adrift.</span> But the lines of the letters were <br>
              like fine invisible threads and it was only by closing his right <br>
              eye tight tight and staring out of the left eye that he could make <br>
              out the full curves of the capital.<br> </p>
-            <p class="textParagraph">  But Mr Harford was very decent and never got into a wax. <span class="tag lineNumber">11375</span><br>
+            <p class="textParagraph">  But Mr Harford was very decent and never got into a wax. <br>
              All the other masters got into dreadful waxes. But why were <br>
              they to suffer for what fellows in the higher line did? Wells had <br>
              said that they had drunk some of the altar wine out of the press <br>
              in the sacristy and that it had been found out who had done it <br>
-             by the smell. Perhaps they had stolen a monstrance to run away <span class="tag lineNumber">11380</span><br>
+             by the smell. Perhaps they had stolen a monstrance to run away <span class="tag lineNumber">1380</span><br>
              with it and sell it somewhere. That must have been a terrible <br>
              sin, to go in  quietly there at night, to open the dark press and <br>
              steal the flashing gold thing into which God was put on the <br>
              altar in the middle of flowers and candles at benediction while <br>
-             the incense went up in clouds at both sides as the fellow swung <span class="tag lineNumber">11385</span><br>
+             the incense went up in clouds at both sides as the fellow swung <br>
              the censer and Dominic Kelly sang the first part by himself in <br>
              the choir. But God was not in it of course when they stole it. <br>
              But still it was a strange and a great sin even to touch it. He <br>
              thought of it with deep awe; a terrible and strange sin: it <br>
-             thrilled him to think of it in the silence when the pens scraped <span class="tag lineNumber">11390</span><br>
+             thrilled him to think of it in the silence when the pens scraped <span class="tag lineNumber">1390</span><br>
              lightly. But to drink the altar wine out of the press and be <br>
              found out by the smell was a sin too: but it was not terrible <br>
              and strange. It only made you feel a little sickish on account <br>
              of the smell of the wine. Because on the day when he had <br>
-             made his first holy communion in  the chapel he had shut his <span class="tag lineNumber">11395</span><br>
+             made his first holy communion in  the chapel he had shut his <br>
              eyes and opened his mouth and put out his tongue a little: and <br>
              when the rector had stooped down to give him the holy com- <br>
              communion he had smelt a faint winy smell off the rector's breath <br>
              after the wine of the mass. The word was beautiful: wine. It <br>
-             made you think of dark purple because the grapes were dark <span class="tag lineNumber">11400</span><br>
+             made you think of dark purple because the grapes were dark <span class="tag lineNumber">1400</span><br>
              purple that grew in Greece outside houses like white temples. <br>
              But the faint smell off the rector's breath had made him feel <br>
              a sick feeling on the morning of his first communion. The day <br>
              of your first communion was the happiest day of your life. <br>
-             And once a lot of generals had asked Napoleon what was the <span class="tag lineNumber">11405</span><br>
+             And once a lot of generals had asked Napoleon what was the <br>
              happiest day of his life. They thought he would say the day <br>
              he won some great battle or the day he was made an emperor. <br>
              But he said: <br>
              <p class="dialog"><span class="tag dialog">Napoleon</span>―Gentlemen, the happiest day of my life was the day on which <br>
-             I made my first holy communion. <span class="tag lineNumber">11410</span><br></p> </p>
+             I made my first holy communion. <span class="tag lineNumber">1410</span><br></p> </p>
             <p class="textParagraph">  Father Arnall came in and the Latin lesson began and he <br>
              remained still, leaning on the desk with his arms folded. Father <br>
              Arnall gave out the themebooks and he said that they were <br>
              scandalous and that they were all to be written out again with <br>
-             the corrections at once. But the worst of all was Fleming's <span class="tag lineNumber">11415</span><br>
+             the corrections at once. But the worst of all was Fleming's <br>
              theme because the pages were stuck together by a blot: and <br>
              Father Arnall held it up by a corner and said it was an insult to <br>
              any master to send him up such a theme. Then he asked Jack <br>
              Lawton to decline the noun <span class="emph">mare</span> and Jack Lawton stopped at <br>
-             the ablative singular and could not go on with the plural. <span class="tag lineNumber">11420</span><br>
+             the ablative singular and could not go on with the plural. <span class="tag lineNumber">1420</span><br>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―You should be ashamed of yourself, said Father Arnall <br>
              sternly. You, the leader of the class! <br></p> </p>
             <p class="textParagraph">  Then he asked the next boy and the next and the next. <br>
              Nobody knew. Father Arnall became very quiet, more and <br>
-             more quiet as each boy tried to answer and could not. But his <span class="tag lineNumber">11425</span><br>
+             more quiet as each boy tried to answer and could not. But his <br>
              face was blacklooking and his eyes were staring though his <br>
              voice was so quiet. Then he asked Fleming and Fleming said <br>
              that that word had no plural. Father Arnall suddenly shut the <br>
              book and shouted at him: <br>
-             <p class="dialog"><span class="tag dialog">Father Arnall</span>―Kneel out there in the middle of the class. You are one of the <span class="tag lineNumber">11430</span><br>
+             <p class="dialog"><span class="tag dialog">Father Arnall</span>―Kneel out there in the middle of the class. You are one of the <span class="tag lineNumber">1430</span><br>
              idlest boys I ever met. Copy out your themes again the rest of <br>
              you. <br></p> </p>
             <p class="textParagraph">  Fleming moved heavily out of his place and knelt between <br>
              the two last benches. The other boys bent over their theme- <br>
-             books and began to write. A silence filled the classroom and <span class="tag lineNumber">11435</span><br>
+             books and began to write. A silence filled the classroom and <br>
              Stephen, glancing timidly at Father Arnall's dark face, saw that <br>
              it was a little red from the wax he was in.<br> </p>
             <p class="textParagraph">  Was that a sin for Father Arnall to be in a wax or was he <br>
              allowed to get into a wax when the boys were idle because that <br>
-             made them study better or was he only letting on to be in a <span class="tag lineNumber">11440</span><br>
+             made them study better or was he only letting on to be in a <span class="tag lineNumber">1440</span><br>
              wax? It was because he was allowed because a priest would <br>
              know what a sin was and would not do it. But if he did it one <br>
              time by mistake what would he do to go to confession? Perhaps <br>
              he would go to confession to the minister. And if the minister <br>
-             did it he would go to the rector: and the rector to the provin- <span class="tag lineNumber">11445</span><br>
+             did it he would go to the rector: and the rector to the provin- <br>
              cial: and the provincial to the general of the jesuits. That was <br>
              called the order: and he had heard his father say that they were <br>
              all clever men. They could all have become highup people in <br>
              the world if they had not become jesuits. And he wondered <br>
-             what Father Arnall and Paddy Barrett would have become and <span class="tag lineNumber">11450</span><br>
+             what Father Arnall and Paddy Barrett would have become and <span class="tag lineNumber">1450</span><br>
              what Mr McGlade and Mr Gleeson would have become if they <br>
              had not become jesuits. It was hard to think what because you <br>
              would have to think of them in a different way with different <br>
              coloured coats and trousers and with beards and moustaches <br>
-             and different kinds of hats.<span class="tag lineNumber">11455</span><br> </p>
+             and different kinds of hats.<br> </p>
             <p class="textParagraph">  The door opened quietly and closed. A quick whisper ran <br>
              through the class: the prefect of studies. There was an instant <br>
              of dead silence and then the loud crack of a pandybat on the <br>
              last desk. Stephen's heart leapt up in fear. <br>
-             <p class="dialog"><span class="tag dialog">Father Dolan</span>―Any boys want flogging here, Father Arnall? cried the pre- <span class="tag lineNumber">11460</span><br>
+             <p class="dialog"><span class="tag dialog">Father Dolan</span>―Any boys want flogging here, Father Arnall? cried the pre- <span class="tag lineNumber">1460</span><br>
              fect of studies. Any lazy idle loafers that want flogging in this <br>
              class? <br></p> </p>
             <p class="textParagraph">  He came to the middle of the class and saw Fleming on his <br>
              knees. <br>
-             <p class="dialog"><span class="tag dialog">Father Dolan</span>―Hoho! he cried. Who is this boy? Why is he on his knees? <span class="tag lineNumber">11465</span><br>
+             <p class="dialog"><span class="tag dialog">Father Dolan</span>―Hoho! he cried. Who is this boy? Why is he on his knees? <br>
              What is your name, boy? <br> </p>
              <p class="dialog"><span class="tag dialog">Fleming</span>―Fleming, sir. <br> </p>
              <p class="dialog"><span class="tag dialog">Father Dolan</span>―Hoho, Fleming! An idler of course. I can see it in your eye. <br>
              Why is he on his knees, Father Arnall? <br> </p>
-            <p class="dialog"><span class="tag dialog">Father Arnall</span>―He wrote a bad Latin theme,</p> Father Arnall said, <p class="dialog"><span class="tag dialog">Father Arnall</span>and he <span class="tag lineNumber">11470</span><br>
+            <p class="dialog"><span class="tag dialog">Father Arnall</span>―He wrote a bad Latin theme,</p> Father Arnall said, <p class="dialog"><span class="tag dialog">Father Arnall</span>and he <span class="tag lineNumber">1470</span><br>
              missed all the questions in grammar. <br> </p>
             <p class="dialog"><span class="tag dialog">Father Dolan</span>―Of course he did!</p> cried the prefect of studies. <p class="dialog"><span class="tag dialog">Father Arnall</span>Of course he <br>
              did! A born idler! I can see it in the corner of his eye. <br></p> </p>
             <p class="textParagraph">  He banged his pandybat down on the desk and cried: <br>
-             <p class="dialog"><span class="tag dialog">Father Dolan</span>―Up, Fleming! Up, my boy! <span class="tag lineNumber">11475</span><br></p> </p>
+             <p class="dialog"><span class="tag dialog">Father Dolan</span>―Up, Fleming! Up, my boy! <br></p> </p>
             <p class="textParagraph">  Fleming stood up slowly. <br>
                 <p class="dialog"><span class="tag dialog">Father Dolan</span>―Hold out!</p> cried the prefect of studies. <br> </p>
             <p class="textParagraph">  Fleming held out his hand. The pandybat came down on it <br>
              with a loud smacking sound: one, two, three, four, five, six. <br>
-             <p class="dialog"><span class="tag dialog">Father Dolan</span>―Other hand! <span class="tag lineNumber">11480</span><br></p> </p>
+             <p class="dialog"><span class="tag dialog">Father Dolan</span>―Other hand! <span class="tag lineNumber">1480</span><br></p> </p>
             <p class="textParagraph">  The pandybat came down again in six loud quick smacks. <br>
              <p class="dialog"><span class="tag dialog">Father Dolan</span>―Kneel down!</p> cried the prefect of studies. <br></p>
             <p class="textParagraph">  Fleming knelt down squeezing his hands under his armpits, <br>
              his face contorted with pain, but Stephen knew how hard his <br>
-             hands were because Fleming was always rubbing rosin into <span class="tag lineNumber">11485</span><br>
+             hands were because Fleming was always rubbing rosin into <br>
              them. But perhaps he was in great pain for the noise of the <br>
              pandies was terrible. Stephen's heart was beating and flutter- <br>
              ing. <br>
              <p class="dialog"><span class="tag dialog">Father Dolan</span>―At your work, all of you!</p> shouted the prefect of studies. <p class="dialog"><span class="tag dialog">Father Dolan</span>We <br>
-             want no lazy idle loafers here, lazy idle little schemers. At your <span class="tag lineNumber">11490</span><br>
+             want no lazy idle loafers here, lazy idle little schemers. At your <span class="tag lineNumber">1490</span><br>
              work, I tell you. Father Dolan will be in to see you every day. <br>
              Father Dolan will be in tomorrow. <br></p> </p>
             <p class="textParagraph">  He poked one of the boys in the side with the pandybat, <br>
              saying: <br>
-             <p class="dialog"><span class="tag dialog">Father Dolan</span>―You, boy! When will Father Dolan be in again? <span class="tag lineNumber">11495</span><br> </p>
+             <p class="dialog"><span class="tag dialog">Father Dolan</span>―You, boy! When will Father Dolan be in again? <br> </p>
              <p class="dialog"><span class="tag dialog">Tom Furlong</span>―Tomorrow, sir, said Tom Furlong's voice. <br> </p>
              <p class="dialog"><span class="tag dialog">Father Dolan</span>―Tomorrow and tomorrow and tomorrow,</p> said the prefect of <br>
              studies. <p class="dialog"><span class="tag dialog">Father Dolan</span>Make up your minds for that. Every day Father Dolan. <br>
              Write away. You, boy, who are you? <br></p> </p>
-            <p class="textParagraph">  Stephen's heart jumped suddenly. <span class="tag lineNumber">11500</span><br>
+            <p class="textParagraph">  Stephen's heart jumped suddenly. <span class="tag lineNumber">1500</span><br>
              <p class="dialog"><span class="tag dialog">Stephen</span>―Dedalus, sir. <br> </p>
              <p class="dialog"><span class="tag dialog">Father Dolan</span>―Why are you not writing like the others? <br> </p>
              <p class="dialog"><span class="tag dialog">Stephen</span>―I ..... my ... <br></p> </p>
             <p class="textParagraph">  He could not speak with fright. <br>
-             <p class="dialog"><span class="tag dialog">Father Dolan</span>―Why is he not writing, Father Arnall? <span class="tag lineNumber">11505</span><br> </p>
+             <p class="dialog"><span class="tag dialog">Father Dolan</span>―Why is he not writing, Father Arnall? <br> </p>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―He broke his glasses,</p> said Father Arnall, <p class="dialog"><span class="tag dialog">Father Arnall</span>and I exempted him <br>
              from work. <br> </p>
              <p class="dialog"><span class="tag dialog">Father Dolan</span>―Broke? What is this I hear? What is this your name is?</p> said <br>
              the prefect of studies. <br>
-             <p class="dialog"><span class="tag dialog">Stephen</span>―Dedalus, sir. <span class="tag lineNumber">11510</span><br> </p>
+             <p class="dialog"><span class="tag dialog">Stephen</span>―Dedalus, sir. <span class="tag lineNumber">1510</span><br> </p>
              <p class="dialog"><span class="tag dialog">Father Dolan</span>―Out here, Dedalus. Lazy little schemer. I see schemer in your <br>
              face. Where did you break your glasses? <br></p> </p>
             <p class="textParagraph">  Stephen stumbled into the middle of the class, blinded by <br>
              fear and haste. <br>
-             <p class="dialog"><span class="tag dialog">Father Dolan</span>―Where did you break your glasses?</p> repeated the prefect of <span class="tag lineNumber">11515</span><br>
+             <p class="dialog"><span class="tag dialog">Father Dolan</span>―Where did you break your glasses?</p> repeated the prefect of <br>
              studies. <br> 
              <p class="dialog"><span class="tag dialog">Stephen</span>―The cinderpath, sir. <br> </p>
              <p class="dialog"><span class="tag dialog">Father Dolan</span>―Hoho! The cinderpath!</p> cried the prefect of studies. <p class="dialog"><span class="tag dialog">Father Dolan</span>I know <br>
              that trick. <br></p> </p>
-            <p class="textParagraph">  Stephen lifted his eyes in wonder and saw for a moment <span class="tag lineNumber">11520</span><br>
+            <p class="textParagraph">  Stephen lifted his eyes in wonder and saw for a moment <span class="tag lineNumber">1520</span><br>
              Father Dolan's whitegrey not young face, his baldy whitegrey <br>
              head with fluff at the sides of it, the steel rims of his spectacles <br>
              and his nocoloured eyes looking through the glasses. Why did <br>
              he say that he knew that trick? <br>
-             <p class="dialog"><span class="tag dialog">Father Dolan</span>―Lazy idle little loafer!</p> cried the prefect of studies. <p class="dialog"><span class="tag dialog">Father Dolan</span>Broke my <span class="tag lineNumber">11525</span><br>
+             <p class="dialog"><span class="tag dialog">Father Dolan</span>―Lazy idle little loafer!</p> cried the prefect of studies. <p class="dialog"><span class="tag dialog">Father Dolan</span>Broke my <br>
              glasses! An old schoolboy trick! Out with your hand this mo- <br>
              moment! <br></p> </p>
             <p class="textParagraph">  Stephen closed his eyes and held out in the air his trembling <br>
              hand with the palm upwards. He felt the prefect of studies <br>
-             touch it for a moment at the fingers to straighten it and then <span class="tag lineNumber">11530</span><br>
+             touch it for a moment at the fingers to straighten it and then <span class="tag lineNumber">1530</span><br>
              the swish of the sleeve of the soutane as the pandybat was lifted <br>
              to strike. A hot burning stinging tingling blow like the loud <br>
              crack of a broken stick made his trembling hand crumple to- <br>
              together like a leaf in the fire: and at the sound and the pain <br>
-             scalding tears were driven into his eyes. His whole body was <span class="tag lineNumber">11535</span><br>
+             scalding tears were driven into his eyes. His whole body was <br>
              shaking with fright, his arm was shaking and his crumpled <br>
              burning livid hand shook like a loose leaf in the air. A cry <br>
              sprang to his lips, a prayer to be let off. But though the tears <br>
              scalded his eyes and his limbs quivered with pain and fright he <br>
-             held back the hot tears and the cry that scalded his throat. <span class="tag lineNumber">11540</span><br>
+             held back the hot tears and the cry that scalded his throat. <span class="tag lineNumber">1540</span><br>
              <p class="dialog"><span class="tag dialog">Father Dolan</span>―Other hand!</p> shouted the prefect of studies. <br> </p>
             <p class="textParagraph">  Stephen drew back his maimed and quivering right arm and <br>
              held out his left hand. The soutane sleeve swished again as the <br>
              pandybat was lifted and a loud crashing sound and a fierce <br>
-             maddening tingling burning pain made his hand shrink to- <span class="tag lineNumber">11545</span><br>
+             maddening tingling burning pain made his hand shrink to- <br>
              together with the palms and fingers in a livid quivering mass. The <br>
              scalding water burst forth from his eyes and, burning with <br>
              shame and agony and fear, he drew back his shaking arm in <br>
              terror and burst out into a whine of pain. His body shook with <br>
-             a palsy of fright and in shame and rage he felt the scalding cry <span class="tag lineNumber">11550</span><br>
+             a palsy of fright and in shame and rage he felt the scalding cry <span class="tag lineNumber">1550</span><br>
              come from his throat and the scalding tears falling out of his <br>
              eyes and down his flaming cheeks. <br>
              <p class="dialog"><span class="tag dialog">Father Dolan</span>―Kneel down! cried the prefect of studies. <br></p> </p>
             <p class="textParagraph">  Stephen knelt down quickly pressing his beaten hands to his <br>
-             sides. To think of them  beaten and swollen with pain all in a <span class="tag lineNumber">11555</span><br>
+             sides. To think of them  beaten and swollen with pain all in a <br>
              moment made him feel so sorry for them as if they were not his <br>
              own but someone else's that he felt so sorry for. And as he <br>
              knelt, calming the last sobs in his throat and feeling the burning <br>
              tingling pain pressed in to his sides, he thought of the hands <br>
-             which he had held out in the air with the palms up and of the <span class="tag lineNumber">11560</span><br>
+             which he had held out in the air with the palms up and of the <span class="tag lineNumber">1560</span><br>
              firm touch of the prefect of studies when he had steadied the <br>
              shaking fingers and of the beaten swollen reddened mass of <br>
              palm and fingers that shook helplessly  in the air. <br>
              <p class="dialog"><span class="tag dialog">Father Dolan</span>―Get at your work, all of you, cried the prefect of studies <br>
-             from the door. Father Dolan will be in every day to see if any <span class="tag lineNumber">11565</span><br>
+             from the door. Father Dolan will be in every day to see if any <br>
              boy, any lazy idle little loafer wants flogging. Every day. Every <br>
              day. <br></p> </p>
             <p class="textParagraph">  The door closed behind him.<br> </p>
             <p class="textParagraph">  The hushed class continued to copy out the themes. Father <br>
-             Arnall rose from his seat and went among them, helping the <span class="tag lineNumber">11570</span><br>
+             Arnall rose from his seat and went among them, helping the <span class="tag lineNumber">1570</span><br>
              boys with gentle words and telling them the mistakes they had <br>
              made. His voice was very gentle and soft. Then he returned to <br>
              his seat and said to Fleming and Stephen: <br>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―You may return to your places, you two. <br></p> </p>
-            <p class="textParagraph">  Fleming and Stephen rose and, walking to their seats, sat <span class="tag lineNumber">11575</span><br>
+            <p class="textParagraph">  Fleming and Stephen rose and, walking to their seats, sat <br>
              down. Stephen, scarlet with shame, opened a book quickly <br>
              with one weak hand and bent down upon it, his face close to <br>
              the page.<br> </p>
             <p class="textParagraph">  It was unfair and cruel: because the doctor had told him not <br>
-             to read without glasses and he had written home to his father <span class="tag lineNumber">11580</span><br>
+             to read without glasses and he had written home to his father <span class="tag lineNumber">1580</span><br>
              that morning to send him a new pair. And Father Arnall had <br>
              said that he need not study till the new glasses came. Then to <br>
              be called a schemer before the class and to be pandied when he <br>
              always got the card for first or second and was the leader of the <br>
-             Yorkists! How could the prefect of studies know that it was a <span class="tag lineNumber">11585</span><br>
+             Yorkists! How could the prefect of studies know that it was a <br>
              trick? He felt the touch of the prefect's fingers as they had <br>
              steadied his hand and at first he had thought that he was going <br>
              to shake hands with him because the fingers were soft and firm: <br>
              but then in an instant he had heard the swish of the soutane <br>
-             sleeve and the crash. It was cruel and unfair to make him kneel <span class="tag lineNumber">11590</span><br>
+             sleeve and the crash. It was cruel and unfair to make him kneel <span class="tag lineNumber">1590</span><br>
              in the middle of the class then: and Father Arnall had told them <br>
              both that they might return to their places without making any <br>
              difference between them. He listened to Father Arnall's low <br>
              and gentle voice as he corrected the themes. Perhaps he was <br>
-             sorry now and wanted to be decent. But it was unfair and cruel. <span class="tag lineNumber">11595</span><br>
+             sorry now and wanted to be decent. But it was unfair and cruel. <br>
              The prefect of studies was a priest but that was cruel and <br>
              unfair. And his whitegrey face and the nocoloured eyes behind <br>
              the steelrimmed spectacles were cruel looking because he had <br>
              steadied the hand first with his firm soft fingers and that was to <br>
-             hit it better and louder. <span class="tag lineNumber">11600</span><br>
+             hit it better and louder. <span class="tag lineNumber">1600</span><br>
              <p class="dialog"><span class="tag dialog">Fleming</span>―It's a stinking mean thing, that's what it is, said Fleming in <br>
              the corridor as the classes were passing out in file to the refec- <br>
              tory, to pandy a fellow for what is not his fault. <br> </p>
              <p class="dialog"><span class="tag dialog">Nasty Roche</span>―You really broke your glasses by accident, didn't you? Nasty <br>
-             Roche asked. <span class="tag lineNumber">11605</span><br></p> </p>
+             Roche asked. <br></p> </p>
             <p class="textParagraph">  Stephen felt his heart filled by Fleming's words and did not <br>
              answer. <br>
              <p class="dialog"><span class="tag dialog">Fleming</span>―Of course he did! said Fleming. I wouldn't stand it. I'd go up <br>
              and tell the rector on him. <br> </p>
-             <p class="dialog"><span class="tag dialog">Cecil Thunder</span>―Yes, said Cecil Thunder eagerly, and I saw him lift the <span class="tag lineNumber">11610</span><br>
+             <p class="dialog"><span class="tag dialog">Cecil Thunder</span>―Yes, said Cecil Thunder eagerly, and I saw him lift the <span class="tag lineNumber">1610</span><br>
              pandybat over his shoulder and he's not allowed to do that. <br> </p>
              <p class="dialog"><span class="tag dialog">Nasty Roche</span>―Did they hurt much? Nasty Roche asked. <br> </p>
              <p class="dialog"><span class="tag dialog">Stephen</span>―Very much,</p> Stephen said. <br>
              <p class="dialog"><span class="tag dialog">Fleming</span>―I wouldn't stand it,</p> Fleming repeated, <p class="dialog"><span class="tag dialog">Fleming</span>from Baldyhead or <br>
-             any other Baldyhead. It's a stinking mean low trick, that's what <span class="tag lineNumber">11615</span><br>
+             any other Baldyhead. It's a stinking mean low trick, that's what <br>
              it is. I'd go up straight up to the rector and tell him about it <br>
              after dinner. <br> </p>
              <p class="dialog"><span class="tag dialog">Cecil Thunder</span>―Yes, do. Yes, do,</p> said Cecil Thunder. <br>
              <p class="dialog"><span class="tag dialog">Nasty Roche</span>―Yes, do. Yes, go up and tell the rector on him, Dedalus,</p> said <br>
-             Nasty Roche, <p class="dialog"><span class="tag dialog">Nasty Roche</span>because he said that he'd come in tomorrow <span class="tag lineNumber">11620</span><br>
+             Nasty Roche, <p class="dialog"><span class="tag dialog">Nasty Roche</span>because he said that he'd come in tomorrow <span class="tag lineNumber">1620</span><br>
              again to pandy you. <br> </p>
              <p class="dialog"><span class="tag dialog">all</span>―Yes, yes. Tell the rector,</p> all said. <br> </p>
             <p class="textParagraph">  And there were some fellows out of second of grammar lis- <br>
              listening and one of them said: <br>
-             <p class="dialog"><span class="tag dialog">a fellow out of second of grammar</span>―The senate and the Roman people declared that Dedalus had <span class="tag lineNumber">11625</span><br>
+             <p class="dialog"><span class="tag dialog">a fellow out of second of grammar</span>―The senate and the Roman people declared that Dedalus had <br>
              been wrongly punished. <br></p> </p>
             <p class="textParagraph">  It was wrong; it was unfair and cruel: and, as he sat in the <br>
              refectory, he suffered time after time in memory the same hu- <br>
              humiliation until he began to wonder whether it might not really <br>
-             be that there was something in his face which made him look <span class="tag lineNumber">11630</span><br>
+             be that there was something in his face which made him look <span class="tag lineNumber">1630</span><br>
              like a schemer and he wished he had a little mirror to see. But <br>
              there could not be; and it was unjust and cruel and unfair.<br> </p>
             <p class="textParagraph">  He could not eat the blackish fish fritters they got on <br>
              Wednesdays in lent and one of his potatoes had the mark of the <br>
-             spade in it. Yes, he would do what the fellows had told him. He <span class="tag lineNumber">11635</span><br>
+             spade in it. Yes, he would do what the fellows had told him. He <br>
              would go up and tell the rector that he had been wrongly <br>
              punished. A thing like that had been done before by somebody <br>
              in history, by some great person whose head was in the books <br>
              of history. And the rector would declare that he had been <br>
-             wrongly punished because the senate and the Roman people <span class="tag lineNumber">11640</span><br>
+             wrongly punished because the senate and the Roman people <span class="tag lineNumber">1640</span><br>
              always declared that the man who did that had been wrongly <br>
              punished. Those were the great men whose names were in <br>
              Richmal Magnall's Questions. History was all about those men <br>
              and what they did and that was what Peter Parley's Tales about <br>
-             Greece and Rome were all about. Peter Parley himself was on <span class="tag lineNumber">11645</span><br>
+             Greece and Rome were all about. Peter Parley himself was on <br>
              the first page in a picture. There was a road over a heath with <br>
              grass at the side and little bushes: and Peter Parley had a broad <br>
              hat like a protestant minister and a big stick and he was walk- <br>
              ing fast along the road to <span class="hide">39.074208 21.824312</span>Greece and <br>
             <span class="hide">41.902783 12.496366</span>Rome.</p>
-            <p class="textParagraph">  It was easy what he had to do. All he had to do  was when <span class="tag lineNumber">11650</span><br>
+            <p class="textParagraph">  It was easy what he had to do. All he had to do  was when <span class="tag lineNumber">1650</span><br>
              the dinner was over and he came out in his turn to go on <br>
              walking but not out to the corridor but up the staircase on the <br>
              right that led to the castle. He had nothing to do but that: to <br>
              turn to the right and walk fast up the staircase and in half a <br>
-             minute he would be in the low dark narrow corridor that led <span class="tag lineNumber">11655</span><br>
+             minute he would be in the low dark narrow corridor that led <br>
              through the castle to the rector's room. And every fellow had <br>
              said that it was unfair, even the fellow out of second of gram- <br>
              mar who had said that about the senate and the Roman people.<br> </p>
             <p class="textParagraph">  What would happen? He heard the fellows of the higher line <br>
-             stand up at the top of the refectory and heard their steps as <span class="tag lineNumber">11660</span><br>
+             stand up at the top of the refectory and heard their steps as <span class="tag lineNumber">1660</span><br>
              they came down the matting: Paddy Rath and Jimmy Magee <br>
              and the Spaniard and the Portuguese and the fifth was big <br>
              Corrigan who was going to be flogged by Mr Gleeson. That <br>
              was why the prefect of studies had called him a schemer and <br>
-             pandied him for nothing: and, straining his weak eyes, tired <span class="tag lineNumber">11665</span><br>
+             pandied him for nothing: and, straining his weak eyes, tired <br>
              with the tears, he watched big Corrigan's broad shoulders and <br>
              big hanging black head passing in the file. But he had done <br>
              something and besides Mr Gleeson would not flog him hard: <br>
              and he remembered how big Corrigan looked in the bath. He <br>
-             had skin the same colour as the turfcoloured bogwater in the <span class="tag lineNumber">11670</span><br>
+             had skin the same colour as the turfcoloured bogwater in the <span class="tag lineNumber">1670</span><br>
              shallow end of the bath and when he walked along the side his <br>
              feet slapped loudly on the wet tiles and at every step his thighs <br>
              shook a little because he was fat.<br> </p>
             <p class="textParagraph">  The refectory was half empty and the fellows were still <br>
-             passing out in file. He could go up the staircase because there <span class="tag lineNumber">11675</span><br>
+             passing out in file. He could go up the staircase because there <br>
              was never a priest or a prefect outside the refectory door. But <br>
              he could not go. The rector would side with the prefect of <br>
              studies and think it was a schoolboy trick and then the prefect <br>
              of studies would come in every day the same only it would be <br>
-             worse because he would be dreadfully waxy at any fellow <span class="tag lineNumber">11680</span><br>
+             worse because he would be dreadfully waxy at any fellow <span class="tag lineNumber">1680</span><br>
              going up to the rector about him. The fellows had told him to <br>
              go but they would not go themselves. They had forgotten all <br>
              about it. No, it was best to forget all about it: and perhaps the <br>
              prefect of studies had only said he would come in. No, it was <br>
-             best to hide out of the way because when you were small and <span class="tag lineNumber">11685</span><br>
+             best to hide out of the way because when you were small and <br>
              young you could often escape that way.<br> </p>
             <p class="textParagraph">  The fellows at his table stood up. He stood up and passed <br>
              out among them in the file. He had to decide. He was coming <br>
              near the door. If he went on with the fellows he could never go <br>
-             up to the rector because he could not leave the playground for <span class="tag lineNumber">11690</span><br>
+             up to the rector because he could not leave the playground for <span class="tag lineNumber">1690</span><br>
              that. And if he went and was pandied all the same all the <br>
              fellows would make fun and talk about young Dedalus going <br>
              up to the rector to tell on the prefect of studies.<br> </p>
             <p class="textParagraph">  He was walking down along the matting and he saw the <br>
-             door before him. It was impossible: he could not. He thought <span class="tag lineNumber">11695</span><br>
+             door before him. It was impossible: he could not. He thought <br>
              of the baldy head of the prefect of studies with the cruel no- <br>
              nocoloured eyes looking at him and he heard the voice of the <br>
              prefect of studies asking him twice what his name was. Why <br>
              could he not remember the name when he was told the first <br>
-             time? Was he not listening the first time or was it to make fun <span class="tag lineNumber">11700</span><br>
+             time? Was he not listening the first time or was it to make fun <span class="tag lineNumber">1700</span><br>
              out of the name? The great men in the history had names like <br>
              that and nobody made fun of them. It was his own name that <br>
              he should have made fun of if he wanted to make fun. Dolan: it <br>
              was like the name of a woman that washed clothes.<br> </p>
-            <p class="textParagraph">  He had reached the door and, turning quickly  to the right, <span class="tag lineNumber">11705</span><br>
+            <p class="textParagraph">  He had reached the door and, turning quickly  to the right, <br>
              walked up the stairs: and, before he could make up his mind to <br>
              come back, he had entered the low dark narrow corridor that <br>
              led to the castle. And as he crossed the threshold of the door of <br>
              the corridor  he saw, without turning his head to look, that all <br>
-             the fellows were looking after him as they went filing by.<span class="tag lineNumber">11710</span><br> </p>
+             the fellows were looking after him as they went filing by.<span class="tag lineNumber">1710</span><br> </p>
             <p class="textParagraph">  He passed along the narrow dark corridor, passing little <br>
              doors that were the doors of the rooms of the community. He <br>
              peered in front of him and right and left through the gloom and <br>
              thought that those must be portraits. It was dark and silent and <br>
-             his eyes were weak and tired with tears so that he could not <span class="tag lineNumber">11715</span><br>
+             his eyes were weak and tired with tears so that he could not <br>
              see. But he thought they were the portraits of the saints and <br>
              great men of the order who were looking down on him silently <br>
              as he passed: saint Ignatius Loyola holding an open book and <br>
              pointing to the words Ad Majorem Dei Gloriam in it, saint <br>
-             Francis Xavier pointing to his chest, Lorenzo Ricci with his <span class="tag lineNumber">11720</span><br>
+             Francis Xavier pointing to his chest, Lorenzo Ricci with his <span class="tag lineNumber">1720</span><br>
              berretta on his head like one of the prefects of the lines, the <br>
              three patrons of holy youth, saint Stanislaus Kostka, saint <br>
              Aloysius Gonzaga and blessed John Berchmans, all with young <br>
              faces because they died when they were young, and Father <br>
-             Peter Kenny sitting in a chair wrapped in a big cloak.<span class="tag lineNumber">11725</span><br> </p>
+             Peter Kenny sitting in a chair wrapped in a big cloak.<br> </p>
             <p class="textParagraph">  He came out on the landing above the entrance hall and <br>
              looked about him. That was where Hamilton Rowan had <br>
              passed and the marks of the soldiers' slugs were there. And it <br>
              was there that the old servants had seen the ghost in the white <br>
-             cloak of a marshal.<span class="tag lineNumber">11730</span><br> </p>
+             cloak of a marshal.<span class="tag lineNumber">1730</span><br> </p>
             <p class="textParagraph">  An old servant was sweeping at the end of the landing. He <br>
              asked him where was the rector's room and the old servant <br>
              pointed to the door at the far end and looked after him as he <br>
              went on to it and knocked.<br> </p>
-            <p class="textParagraph">  There was no answer. He knocked again more loudly and <span class="tag lineNumber">11735</span><br>
+            <p class="textParagraph">  There was no answer. He knocked again more loudly and <br>
              his heart jumped when he heard a muffled voice say: <br>
              <p class="dialog"><span class="tag dialog">the rector</span>―Come in! <br></p> </p>
             <p class="textParagraph">  He turned the handle and opened the door and fumbled for <br>
              the handle of the green baize door inside. He found it and <br>
-             pushed it open and went in.<span class="tag lineNumber">11740</span><br> </p>
+             pushed it open and went in.<span class="tag lineNumber">1740</span><br> </p>
             <p class="textParagraph">  He saw the rector sitting at a desk writing. There was a skull <br>
              on the desk and a strange solemn smell in the room like the old <br>
              leather of chairs.<br> </p>
             <p class="textParagraph">  His heart was beating fast on account of the solemn place he <br>
-             was in and the silence of the room:  and he looked at the skull <span class="tag lineNumber">11745</span><br>
+             was in and the silence of the room:  and he looked at the skull <br>
              and at the rector's kindlooking face. <br>
              <p class="dialog"><span class="tag dialog">the rector</span>―Well, my little man, said the rector. What is it? <br></p> </p>
             <p class="textParagraph">  Stephen swallowed down the thing in his throat and said: <br>
              <p class="dialog"><span class="tag dialog">Stephen</span>―I broke my glasses, sir. <br></p> </p>
-            <p class="textParagraph">  The rector opened his mouth and said: <span class="tag lineNumber">11750</span><br>
+            <p class="textParagraph">  The rector opened his mouth and said: <span class="tag lineNumber">1750</span><br>
              <p class="dialog"><span class="tag dialog">the rector</span>―O! <br></p> </p>
             <p class="textParagraph">  Then he smiled and said: <br>
              <p class="dialog"><span class="tag dialog">the rector</span>―Well, if we broke our glasses we must write home for a new <br>
              pair. <br> </p>
-             <p class="dialog"><span class="tag dialog">Stephen</span>―I wrote home, sir,</p> said Stephen, <p class="dialog"><span class="tag dialog">Stephen</span>and Father Arnall said I am <span class="tag lineNumber">11755</span><br>
+             <p class="dialog"><span class="tag dialog">Stephen</span>―I wrote home, sir,</p> said Stephen, <p class="dialog"><span class="tag dialog">Stephen</span>and Father Arnall said I am <br>
              not to study till they come. <br> </p>
              <p class="dialog"><span class="tag dialog">the rector</span>―Quite right!</p> said the rector. <br> </p>
             <p class="textParagraph">  Stephen swallowed down the thing again  and tried to keep <br>
              his legs and his voice from shaking. <br>
-             <p class="dialog"><span class="tag dialog">Stephen</span>―But, sir .... <span class="tag lineNumber">11760</span><br> </p>
+             <p class="dialog"><span class="tag dialog">Stephen</span>―But, sir .... <span class="tag lineNumber">1760</span><br> </p>
              <p class="dialog"><span class="tag dialog">the rector</span>―Yes? <br> </p>
              <p class="dialog"><span class="tag dialog">Stephen</span>―Father Dolan came in today and pandied me because I was <br>
              not writing my theme. <br></p> </p>
             <p class="textParagraph">  The rector looked at him in silence and he could feel the <br>
-             blood rising to his face and the tears about to rise to his eyes.<span class="tag lineNumber">11765</span><br> </p>
+             blood rising to his face and the tears about to rise to his eyes.<br> </p>
             <p class="textParagraph">  The rector said: <br>
              <p class="dialog"><span class="tag dialog">the rector</span>―Your name is Dedalus, isn't it? <br> </p>
              <p class="dialog"><span class="tag dialog">Stephen</span>―Yes, sir. <br> </p>
              <p class="dialog"><span class="tag dialog">the rector</span>―And where did you break your glasses? <br> </p>
-             <p class="dialog"><span class="tag dialog">Stephen</span>―On the cinderpath, sir. A fellow was coming out of the <span class="tag lineNumber">11770</span><br>
+             <p class="dialog"><span class="tag dialog">Stephen</span>―On the cinderpath, sir. A fellow was coming out of the <span class="tag lineNumber">1770</span><br>
              bicycle house and I fell and they got broken. I don't know the <br>
              fellow's name. <br></p> </p>
             <p class="textParagraph">  The rector looked at him again in silence. Then he smiled <br>
              and said: <br>
-             <p class="dialog"><span class="tag dialog">the rector</span>―O, well, it was a mistake. I am sure Father Dolan did not <span class="tag lineNumber">11775</span><br>
+             <p class="dialog"><span class="tag dialog">the rector</span>―O, well, it was a mistake. I am sure Father Dolan did not <br>
              know. <br> </p>
              <p class="dialog"><span class="tag dialog">Stephen</span>―But I told him I broke them, sir, and he pandied me. <br> </p>
              <p class="dialog"><span class="tag dialog">the rector</span>―Did you tell him that you had written home for a new pair? <br>
              the rector asked. <br> </p>
-             <p class="dialog"><span class="tag dialog">Stephen</span>―No, sir. <span class="tag lineNumber">11780</span><br> </p>
+             <p class="dialog"><span class="tag dialog">Stephen</span>―No, sir. <span class="tag lineNumber">1780</span><br> </p>
              <p class="dialog"><span class="tag dialog">the rector</span>―O well then,</p> said the rector, <p class="dialog"><span class="tag dialog">the rector</span>Father Dolan did not under- <br>
              stand. You can say that I excuse you from your lessons for a <br>
              few days. <br></p> </p>
             <p class="textParagraph">  Stephen said quickly for fear his trembling would prevent <br>
-             him: <span class="tag lineNumber">11785</span><br>
+             him: <br>
              <p class="dialog"><span class="tag dialog">Stephen</span>―Yes, sir, but Father Dolan said he will come in tomorrow to <br>
              pandy me again for it. <br> </p>
              <p class="dialog"><span class="tag dialog">the rector</span>―Very well,</p> the rector said. <p class="dialog"><span class="tag dialog">the rector</span>It is a mistake and I shall speak to <br>
              Father Dolan myself. Will that do now? <br></p> </p>
-            <p class="textParagraph">  Stephen felt the tears wetting his eyes and murmured: <span class="tag lineNumber">11790</span><br>
+            <p class="textParagraph">  Stephen felt the tears wetting his eyes and murmured: <span class="tag lineNumber">1790</span><br>
              <p class="dialog"><span class="tag dialog">Stephen</span>―O yes, sir, thanks. <br></p> </p>
             <p class="textParagraph">  The rector held his hand across the side of the desk where <br>
              the skull was and Stephen, placing his hand in it for a moment, <br>
              felt a cool moist palm. <br>
-             <p class="dialog"><span class="tag dialog">the rector</span>―Good day now, said the rector, withdrawing his hand and <span class="tag lineNumber">11795</span><br>
+             <p class="dialog"><span class="tag dialog">the rector</span>―Good day now, said the rector, withdrawing his hand and <br>
              bowing. <br> </p>
              <p class="dialog"><span class="tag dialog">Stephen</span>―Good day, sir, said Stephen. <br></p> </p>
             <p class="textParagraph">  He bowed and walked quietly out of the room, closing the <br>
              doors carefully and slowly.<br> </p>
-            <p class="textParagraph">  But when he had passed the old servant on the landing and <span class="tag lineNumber">11800</span><br>
+            <p class="textParagraph">  But when he had passed the old servant on the landing and <span class="tag lineNumber">1800</span><br>
              was again in the low narrow dark corridor he began to walk <br>
              faster and faster. Faster and faster he hurried on through the <br>
              gloom, excitedly. He bumped his elbow against the door at the <br>
              end and, hurrying down the staircase, walked quickly through <br>
-             the two corridors and out into the air.<span class="tag lineNumber">11805</span><br> </p>
+             the two corridors and out into the air.<br> </p>
             <p class="textParagraph">  He could hear the cries of the fellows on the playgrounds. <br>
              He broke into a run and, running quicker and quicker, ran <br>
              across the cinderpath and reached the third line playground, <br>
              panting.<br> </p>
-            <p class="textParagraph">  The fellows had seen him running. They closed round him in <span class="tag lineNumber">11810</span><br>
+            <p class="textParagraph">  The fellows had seen him running. They closed round him in <span class="tag lineNumber">1810</span><br>
              a ring, pushing one against another to hear. <br>
              <p class="dialog"><span class="tag dialog">the fellows</span>―Tell us! Tell us! <br> </p>
              <p class="dialog"><span class="tag dialog">the fellows</span>―What did he say? <br> </p>
              <p class="dialog"><span class="tag dialog">the fellows</span>―Did you go in? <br> </p>
-             <p class="dialog"><span class="tag dialog">the fellows</span>―What did he say? <span class="tag lineNumber">11815</span><br> </p>
+             <p class="dialog"><span class="tag dialog">the fellows</span>―What did he say? <br> </p>
              <p class="dialog"><span class="tag dialog">the fellows</span>―Tell us! Tell us! <br></p> </p>
             <p class="textParagraph">  He told them what he had said and what the rector had said <br>
              and, when he had told them, all the fellows flung their caps <br>
              spinning up into the air and cried: <br>
-             <p class="dialog"><span class="tag dialog">the fellows</span>―Hurroo! <span class="tag lineNumber">11820</span><br></p> </p>
+             <p class="dialog"><span class="tag dialog">the fellows</span>―Hurroo! <span class="tag lineNumber">1820</span><br></p> </p>
             <p class="textParagraph">  They caught their caps and sent them up again spinning <br>
              skyhigh and cried again: <br>
              <p class="dialog"><span class="tag dialog">the fellows</span>―Hurroo! Hurroo! <br></p> </p>
             <p class="textParagraph">  They made a cradle of their locked hands and hoisted him <br>
-             up among them and carried him along till he struggled to get <span class="tag lineNumber">11825</span><br>
+             up among them and carried him along till he struggled to get <br>
              free. And when he had escaped from them they broke away in <br>
              all directions, flinging their caps again into the air and whis- <br>
              tling as they went spinning up and crying: <br>
              <p class="dialog"><span class="tag dialog">the fellows</span>―Hurroo! <br></p> </p>
-            <p class="textParagraph">  And they gave three groans for Baldyhead Dolan and three <span class="tag lineNumber">11830</span><br>
+            <p class="textParagraph">  And they gave three groans for Baldyhead Dolan and three <span class="tag lineNumber">1830</span><br>
              cheers for Conmee and they said he was the decentest rector <br>
              that was ever in Clongowes.<br> </p>
             <p class="textParagraph">  The cheers died away in the soft grey air. He was alone. He <br>
              was happy and free: but he would not be anyway proud with <br>
-             Father Dolan. He would be very quiet and obedient: and he <span class="tag lineNumber">11835</span><br>
+             Father Dolan. He would be very quiet and obedient: and he <br>
              wished that he could do something kind for him to show him <br>
              that he was not proud.<br> </p>
             <p class="textParagraph">  The air was soft and grey and mild and evening was coming. <br>
              There was the smell of evening in the air, the smell of the fields <br>
-             in the country where they digged up turnips to peel them and <span class="tag lineNumber">11840</span><br>
+             in the country where they digged up turnips to peel them and <span class="tag lineNumber">1840</span><br>
              eat them when they went out for a walk to <span class="hide">53.257926 -6.585225</span>Major Barton's, the <br>
              smell there was in the little wood beyond the pavilion where <br>
              the gallnuts were.<br> </p>
             <p class="textParagraph">  The fellows were practising long shies and bowling lobs and <br>
-             slow twisters. In the soft grey silence he could hear the bump of <span class="tag lineNumber">11845</span><br>
+             slow twisters. In the soft grey silence he could hear the bump of <br>
              the balls: and from here and from there through the quiet air <br>
              the sound of the cricket bats: pick, pack, pock, puck: like drops <br>
              of water in a fountain falling softly in the brimming bowl.<br> </p>
@@ -2030,190 +2030,190 @@
           spoken nephew suggested to him to enjoy his morning smoke <br>
           in a little outhouse at the end of the garden. <br>
            <p class="dialog"><span class="tag dialog">Uncle Charles</span>―Very good, Simon. All serene, Simon, said the old man tran- <br>
-          quilly. Anywhere you like. The outhouse will do me nicely: it <span class="tag lineNumber">20005</span><br>
+          quilly. Anywhere you like. The outhouse will do me nicely: it <br>
           will be more salubrious.<br> </p>
            <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Damn me, said Mr Dedalus frankly, if I know how you can <br>
           smoke such villainous awful tobacco. It's like gunpowder, by <br>
           God.<br> </p>
-           <p class="dialog"><span class="tag dialog">Uncle Charles</span>―It's very nice, Simon, replied the old man. Very cool and <span class="tag lineNumber">20010</span><br>
+           <p class="dialog"><span class="tag dialog">Uncle Charles</span>―It's very nice, Simon, replied the old man. Very cool and <span class="tag lineNumber">10</span><br>
           mollifying.<br></p> </p>
           <p class="textParagraph">  Every morning, therefore, uncle Charles repaired to his out- <br>
           house but not before he had creased and brushed scrupulously <br>
           his back hair and brushed and put on his tall hat. While he <br>
-          smoked the brim of his tall hat and the bowl of his pipe were <span class="tag lineNumber">20015</span><br>
+          smoked the brim of his tall hat and the bowl of his pipe were <br>
           just visible beyond the jambs of the outhouse door. His arbour, <br>
           as he called the reeking outhouse which he shared with the cat <br>
           and the garden tools, served him also as a soundingbox: and <br>
           every morning he hummed contentedly one of his favourite <br>
-          songs: <span class="emph">O, twine me a bower</span> or <span class="emph">Blue eyes and golden hair</span> or <span class="tag lineNumber">20020</span><br>
+          songs: <span class="emph">O, twine me a bower</span> or <span class="emph">Blue eyes and golden hair</span> or <span class="tag lineNumber">20</span><br>
           <span class="emph">The Groves of Blarney</span> while the grey and blue coils of smoke <br>
           rose slowly from his pipe and vanished in the pure air.<br> </p>
           <p class="textParagraph">  During the first part of the summer in Blackrock uncle <br>
           Charles was Stephen's constant companion. Uncle Charles was <br>
-          a hale old man with a well tanned skin, rugged features and <span class="tag lineNumber">20025</span><br>
+          a hale old man with a well tanned skin, rugged features and <br>
           white side whiskers. On week days he did messages between <br>
           the house in <span class="hide">53.293248, -6.180109</span>Carysfort Avenue and those shops in the main <br>
           street of the town with which the family dealt. Stephen was <br>
           glad to go with him on these errands for uncle Charles helped <br>
-          him very liberally to handfuls of whatever was exposed in open <span class="tag lineNumber">20030</span><br>
+          him very liberally to handfuls of whatever was exposed in open <span class="tag lineNumber">30</span><br>
           boxes and barrels outside the counter. He would seize a hand- <br>
           ful of grapes and sawdust or three or four American apples and <br>
           thrust them generously into his grandnephew's hand while the <br>
           shopman smiled uneasily; and on Stephen's feigning reluctance <br>
-          to take them, he would frown and say: <span class="tag lineNumber">20035</span><br>
+          to take them, he would frown and say: <br>
            <p class="dialog"><span class="tag dialog">Uncle Charles</span>―Take them, sir. Do you hear me, sir? They're good for your <br>
           bowels.<br></p> </p>
           <p class="textParagraph">  When the order list had been booked the two would go on <br>
           to the park where an old friend of Stephen's father, Mike <br>
-          Flynn, would be found seated on a bench, waiting for them. <span class="tag lineNumber">20040</span><br>
+          Flynn, would be found seated on a bench, waiting for them. <span class="tag lineNumber">40</span><br>
           Then would begin Stephen's run round the park. Mike Flynn <br>
           would stand at the gate near the railway station, watch in <br>
           hand, while Stephen ran round the track in the style Mike <br>
           Flynn favoured, his head high lifted, his knees well lifted and <br>
-          his hands held straight down by his sides. When the morning <span class="tag lineNumber">20045</span><br>
+          his hands held straight down by his sides. When the morning <br>
           practice was over the trainer would make his comments and <br>
           sometimes illustrate them by shuffling along for a yard or so <br>
           comically in an old pair of blue canvas shoes. A small ring of <br>
           wonderstruck children and nursemaids would gather to watch <br>
-          him and linger even when he and uncle Charles had sat down <span class="tag lineNumber">20050</span><br>
+          him and linger even when he and uncle Charles had sat down <span class="tag lineNumber">50</span><br>
           again and were talking athletics and politics. Though he had <br>
           heard his father say that Mike Flynn had put some of the best <br>
           runners of modern times through his hands Stephen often <br>
           glanced with mistrust at his trainer's flabby stubblecovered <br>
-          face, as it bent over the long stained fingers through which he <span class="tag lineNumber">20055</span><br>
+          face, as it bent over the long stained fingers through which he <br>
           rolled his cigarette, and with pity at the mild lustreless blue <br>
           eyes which would look up suddenly from the task and gaze <br>
           vaguely into the bluer distance while the long swollen fingers <br>
           ceased their rolling and grains and fibres of tobacco fell back <br>
-          into the pouch.<span class="tag lineNumber">20060</span><br> </p>
+          into the pouch.<span class="tag lineNumber">60</span><br> </p>
           <p class="textParagraph">  On the way home uncle Charles would often pay a visit to <br>
           the chapel and, as the font was above Stephen's reach, the old <br>
           man would dip his hand and then sprinkle the water briskly <br>
           about Stephen's clothes and on the floor of the porch. While he <br>
-          prayed he knelt on his red handkerchief and read above his <span class="tag lineNumber">20065</span><br>
+          prayed he knelt on his red handkerchief and read above his <br>
           breath from a thumbblackened prayerbook wherein catch- <br>
           words were printed at the foot of every page. Stephen knelt at <br>
           his side respecting, though he did not share, his piety. He often <br>
           wondered what his granduncle prayed for so seriously. Perhaps <br>
-          he prayed for the souls in purgatory or for the grace of a happy <span class="tag lineNumber">20070</span><br>
+          he prayed for the souls in purgatory or for the grace of a happy <span class="tag lineNumber">70</span><br>
           death: or perhaps he prayed that God might send him back a <br>
           part of the big fortune he had squandered in Cork.<br> </p>
           <p class="textParagraph">  On Sundays Stephen with his father and his granduncle took <br>
           their constitutional. The old man was a nimble walker in spite <br>
-          of his corns and often ten or twelve miles of the road were <span class="tag lineNumber">20075</span><br>
+          of his corns and often ten or twelve miles of the road were <br>
           covered. The little village of <span class="hide">53.287857, -6.203573</span>Stillorgan was the parting of the <br>
           ways. Either they went to the left towards the Dublin moun- <br>
           tains or along the <span class="hide">53.297702, -6.233964</span>Goatstown road and thence <br>
           into <span class="hide">53.289154, -6.243264</span>Dundrum,
           coming home by  <span class="hide">53.269979, -6.224923</span>Sandyford. Trudging along the road or <br>
-          standing in some grimy wayside publichouse his elders spoke <span class="tag lineNumber">20080</span><br>
+          standing in some grimy wayside publichouse his elders spoke <span class="tag lineNumber">80</span><br>
           constantly of the subjects nearest their hearts, of Irish politics, <br>
           of Munster and of the legends of their own family, to all of <br>
           which Stephen lent an avid ear. Words which he did not under- <br>
           stand he said over and over to himself till he had learned them <br>
-          by heart: and through them he had glimpses of the real world <span class="tag lineNumber">20085</span><br>
+          by heart: and through them he had glimpses of the real world <br>
           about him. The hour when he too would take his part in the <br>
           life of that world seemed drawing near and in secret he began <br>
           to make ready for the great part which he felt awaited him the <br>
           nature of which he only dimly apprehended.<br> </p>
-          <p class="textParagraph">  His evenings were his own; and he pored over a ragged <span class="tag lineNumber">20090</span><br>
+          <p class="textParagraph">  His evenings were his own; and he pored over a ragged <span class="tag lineNumber">90</span><br>
           translation of <span class="emph">The Count of Monte Cristo</span>. The figure of that <br>
           dark avenger stood forth in his mind for whatever he had heard <br>
           or divined in childhood of the strange and terrible. At night he <br>
           built up on the parlour table an image of the wonderful island <br>
-          cave out of transfers and paper flowers and coloured tissue <span class="tag lineNumber">20095</span><br>
+          cave out of transfers and paper flowers and coloured tissue <br>
           paper and strips of the silver and golden paper in which choc- <br>
           olate is wrapped. When he had broken up this scenery, weary <br>
           of its tinsel, there would come to his mind the bright picture of <br>
            <span class="hide">43.295207, <br>
           5.364077</span>Marseilles, of sunny trellisses and of Mercedes. Outside <span class="hide">53.300907,
           -6.177049</span>Black-
-           rock, on the road that led to the mountains, stood a small <span class="tag lineNumber">20100</span><br>
+           rock, on the road that led to the mountains, stood a small <span class="tag lineNumber">100</span><br>
           whitewashed house in the garden of which grew many rose- <br>
           bushes: and in this house, he told himself, another Mercedes <br>
           lived. Both on the outward and on the homeward journey he <br>
           measured distance by this landmark: and in his imagination he <br>
-          lived through a long train of adventures, marvellous as those in <span class="tag lineNumber">20105</span><br>
+          lived through a long train of adventures, marvellous as those in <br>
           the book itself, towards the close of which there appeared an <br>
           image of himself, grown older and sadder, standing in a <br>
           moonlit garden with Mercedes who had so many years before <br>
           slighted his love, and with a sadly proud gesture of refusal, <br>
-          saying: <span class="tag lineNumber">20110</span><br>
+          saying: <span class="tag lineNumber">110</span><br>
            <p class="dialog"><span class="tag dialog">Count of Monte Cristo</span>―Madam, I never eat muscatel grapes.<br></p> </p>
           <p class="textParagraph">  He became the ally of a boy named Aubrey Mills and <br>
           founded with him a gang of adventurers in the avenue. Aubrey <br>
           carried a whistle dangling from his buttonhole and a bicycle <br>
-          lamp attached to his belt while the others had short sticks <span class="tag lineNumber">20115</span><br>
+          lamp attached to his belt while the others had short sticks <br>
           thrust daggerwise through theirs. Stephen, who had read of <br>
           Napoleon's plain style of dress, chose to remain unadorned and <br>
           thereby heightened for himself the pleasure of taking counsel <br>
           with his lieutenant before giving orders. The gang made forays <br>
-          into the gardens of old maids or went down to the castle and <span class="tag lineNumber">20120</span><br>
+          into the gardens of old maids or went down to the castle and <span class="tag lineNumber">120</span><br>
           fought a battle on the shaggy weedgrown rocks, coming home <br>
           after it weary stragglers with the stale odours of the foreshore <br>
           in their nostrils and the rank oils of the seawrack upon their <br>
           hands and in their hair.<br> </p>
-          <p class="textParagraph">  Aubrey and Stephen had a common milkman and often they <span class="tag lineNumber">20125</span><br>
+          <p class="textParagraph">  Aubrey and Stephen had a common milkman and often they <br>
           drove out in the milkcar to <span class="hide">53.250224, -6.179926</span>Carrickmines where the cows were <br>
           at grass. While the men were milking the boys would take turns <br>
           in riding the tractable mare round the field. But when autumn <br>
           came the cows were driven home from the grass: and the first <br>
-          sight of the filthy cowyard at <span class="hide">53.300791 -6.177067</span>Stradbrook with its foul green <span class="tag lineNumber">20130</span><br>
+          sight of the filthy cowyard at <span class="hide">53.300791 -6.177067</span>Stradbrook with its foul green <span class="tag lineNumber">130</span><br>
           puddles and clots of liquid dung and steaming brantroughs <br>
           sickened Stephen's heart. The cattle which had seemed so beau- <br>
           tiful in the country on sunny days revolted him and he could <br>
           not even look at the milk they yielded.<br> </p>
-          <p class="textParagraph">  The coming of September did not trouble him this year for <span class="tag lineNumber">20135</span><br>
+          <p class="textParagraph">  The coming of September did not trouble him this year for <br>
           he knew he was not to be sent back to <span class="hide">53.310770, -6.684719</span>Clongowes. The practice <br>
           in the park came to an end when Mike Flynn went into hospi- <br>
           tal. Aubrey was at school and had only an hour or two free in <br>
           the evening. The gang fell asunder and there were no more <br>
-          nightly forays or battles on the rocks. Stephen sometimes went <span class="tag lineNumber">20140</span><br>
+          nightly forays or battles on the rocks. Stephen sometimes went <span class="tag lineNumber">140</span><br>
           round with the car which delivered the evening milk: and these <br>
           chilly drives blew away his memory of the filth of the cowyard <br>
           and he felt no repugnance at seeing the cowhairs and hayseeds <br>
           on the milkman's coat. Whenever the car drew up before a <br>
-          house he waited to catch a glimpse of a well scrubbed kitchen <span class="tag lineNumber">20145</span><br>
+          house he waited to catch a glimpse of a well scrubbed kitchen <br>
           or of a softly lighted hall and to see how the servant would <br>
           hold the jug and how she would close the door. He thought it <br>
           should be a pleasant life enough, driving along the roads every <br>
           evening to deliver milk, if he had warm gloves and a fat bag of <br>
-          gingernuts in his pocket to eat from. But the same foreknowl- <span class="tag lineNumber">20150</span><br>
+          gingernuts in his pocket to eat from. But the same foreknowl- <span class="tag lineNumber">150</span><br>
           edge which had sickened his heart and made his limbs sag <br>
           suddenly as he raced round the park, the same intuition which <br>
           had made him glance with mistrust at his trainer's flabby <br>
           stubblecovered face as it bent heavily over his long stained <br>
-          fingers, dissipated any vision of the future. In a vague way he <span class="tag lineNumber">20155</span><br>
+          fingers, dissipated any vision of the future. In a vague way he <br>
           understood that his father was in trouble and that this was the <br>
           reason why he himself had not been sent back to <span class="hide">53.310770, -6.684719</span>Clongowes. <br>
           For some time he had felt the slight changes in his house; and <br>
           these changes in what he had deemed unchangeable were so <br>
-          many slight shocks to his boyish conception of the world. The <span class="tag lineNumber">20160</span><br>
+          many slight shocks to his boyish conception of the world. The <span class="tag lineNumber">160</span><br>
           ambition which he felt astir at times in the darkness of his soul <br>
           sought no outlet. A dusk like that of the outer world obscured <br>
           his mind as he heard the mare's hoofs clattering along the <br>
           tramtrack on the Rock Road and the great can swaying and <br>
-          rattling behind him.<span class="tag lineNumber">20165</span><br> </p>
+          rattling behind him.<br> </p>
           <p class="textParagraph">  He returned to Mercedes and, as he brooded upon her im- <br>
           age, a strange unrest crept into his blood. Sometimes a fever <br>
           gathered within him and led him to rove alone in the evening <br>
           along the quiet avenues. The peace of the gardens and the <br>
-          kindly lights in the windows poured a tender influence into his <span class="tag lineNumber">20170</span><br>
+          kindly lights in the windows poured a tender influence into his <span class="tag lineNumber">170</span><br>
           restless heart. The noise of children at play annoyed him and <br>
           their silly voices made him feel, even more keenly than he had <br>
           felt at <span class="hide">53.310770, -6.684719</span>Clongowes, that he was different from others. He did <br>
           not want to play. He wanted to meet in the real world the <br>
-          unsubstantial image which his soul so constantly beheld. He <span class="tag lineNumber">20175</span><br>
+          unsubstantial image which his soul so constantly beheld. He <br>
           did not know where to seek it or how: but a premonition which <br>
           led him on told him that this image would, without any overt <br>
           act of his, encounter him. They would meet quietly as if they <br>
           had known each other and had made their tryst, perhaps at one <br>
-          of the gates or in some more secret place. They would be alone, <span class="tag lineNumber">20180</span><br>
+          of the gates or in some more secret place. They would be alone, <span class="tag lineNumber">180</span><br>
           surrounded by darkness and silence: and in that moment of <br>
           supreme tenderness he would be transfigured. He would fade <br>
           into something impalpable under her eyes and then, in a mo- <br>
           ment, he would be transfigured. Weakness and timidity and <br>
-          inexperience would fall from him in that magic moment.<span class="tag lineNumber">20185</span><br> </p>
+          inexperience would fall from him in that magic moment.<br> </p>
           <div class="divider">* * *</div>
          
         
@@ -2221,273 +2221,273 @@
           the door and men had come tramping into the house to dis- <br>
           mantle it. The furniture had been hustled out through the front <br>
           garden which was strewn with wisps of straw and rope ends <br>
-          and into the huge vans at the gate. When all had been safely <span class="tag lineNumber">20190</span><br>
+          and into the huge vans at the gate. When all had been safely <span class="tag lineNumber">190</span><br>
           stowed the vans had set off noisily down the avenue: and from <br>
           the window of the railway carriage, in which he had sat with <br>
           his redeyed mother, Stephen had seen them lumbering heavily <br>
           along the Merrion Road.<br> </p>
-          <p class="textParagraph">  The parlour fire would not draw that evening and Mr Deda- <span class="tag lineNumber">20195</span><br>
+          <p class="textParagraph">  The parlour fire would not draw that evening and Mr Deda- <br>
           lus rested the poker against the bars of the grate to attract the <br>
           flame. Uncle Charles dozed in a corner of the half furnished <br>
           uncarpeted room and near him the family portraits leaned <br>
           against the wall. The lamp on the table shed a weak light over <br>
-          the boarded floor, muddied by the feet of the vanmen. Stephen <span class="tag lineNumber">20200</span><br>
+          the boarded floor, muddied by the feet of the vanmen. Stephen <span class="tag lineNumber">200</span><br>
           sat on a footstool beside his father listening to a long and <br>
           incoherent monologue. He understood little or nothing of it at <br>
           first but he became slowly aware that his father had enemies <br>
           and that some fight was going to take place. He felt, too, that <br>
-          he was being enlisted for the fight, that some duty was being <span class="tag lineNumber">20205</span><br>
+          he was being enlisted for the fight, that some duty was being <br>
           laid upon his shoulders. The sudden flight from the comfort <br>
           and revery of <span class="hide">53.300907, -6.177049</span>Blackrock, the passage through the gloomy foggy <br>
           city, the thought of the bare cheerless house in which they were <br>
           now to live made his heart heavy: and again an intuition or <br>
-          foreknowledge of the future came to him. He understood also <span class="tag lineNumber">20210</span><br>
+          foreknowledge of the future came to him. He understood also <span class="tag lineNumber">210</span><br>
           why the servants had often whispered together in the hall and <br>
           why his father had often stood on the hearthrug, with his back <br>
           to the fire, talking loudly to uncle Charles who urged him to sit <br>
           down and eat his dinner. <br>
-           <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―There's a crack of the whip left in me yet, Stephen, old chap, <span class="tag lineNumber">20215</span><br>
+           <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―There's a crack of the whip left in me yet, Stephen, old chap, <br>
           said Mr Dedalus, poking at the dull fire with fierce energy. <br>
           We're not dead yet, sonny. No, by the Lord Jesus (God forgive <br>
           me) nor half dead. <br></p> </p>
           <p class="textParagraph">  <span class="hide">53.349307, -6.263654</span>Dublin was a new and complex sensation. Uncle Charles <br>
-          had grown so witless that he could no longer be sent out on <span class="tag lineNumber">20220</span><br>
+          had grown so witless that he could no longer be sent out on <span class="tag lineNumber">220</span><br>
           errands and the disorder in settling in the new house left Ste- <br>
           phen freer than he had been in <span class="hide">53.300907, -6.177049</span>Blackrock. In the beginning he <br>
           contented himself with circling timidly round the neighbouring <br>
           square or, at most, going half way down one of the side streets: <br>
-          but when he had made a skeleton map of the city in his mind he <span class="tag lineNumber">20225</span><br>
+          but when he had made a skeleton map of the city in his mind he <br>
           followed boldly one of its central lines until he reached the <br>
           customhouse. He passed unchallenged among the docks and <br>
           along the quays wondering at the multitude of corks that lay <br>
           bobbing on the surface of the water in a thick yellow scum, at <br>
-          the crowds of quay porters and the rumbling carts and the <span class="tag lineNumber">20230</span><br>
+          the crowds of quay porters and the rumbling carts and the <span class="tag lineNumber">230</span><br>
           illdressed bearded policeman. The vastness and strangeness of <br>
           the life suggested to him by the bales of merchandise stacked <br>
           along the walls or swung aloft out of the holds of steamers <br>
           wakened again in him the unrest which had sent him wan- <br>
-          dering in the evening from garden to garden in search of <span class="tag lineNumber">20235</span><br>
+          dering in the evening from garden to garden in search of <br>
           Mercedes. And amid this new bustling life he might have <br>
           fancied himself in another <span class="hide">43.295207, 5.364077</span>Marseilles but that he missed the <br>
           bright sky and the sunwarmed trellisses of the wineshops. A <br>
           vague dissatisfaction grew up within him as he looked on the <br>
-          quays and on the river and on the lowering skies and yet he <span class="tag lineNumber">20240</span><br>
+          quays and on the river and on the lowering skies and yet he <span class="tag lineNumber">240</span><br>
           continued to wander up and down day after day as if he really <br>
           sought someone that eluded him.<br> </p>
           <p class="textParagraph">  He went once or twice with his mother to visit their rela- <br>
           tives: and, though they passed a jovial array of shops lit up and <br>
-          adorned for Christmas, his mood of embittered silence did not <span class="tag lineNumber">20245</span><br>
+          adorned for Christmas, his mood of embittered silence did not <br>
           leave him. The causes of his embitterment were many, remote <br>
           and near. He was angry with himself for being young and the <br>
           prey of restless foolish impulses, angry also with the change of <br>
           fortune which was reshaping the world about him into a vision <br>
-          of squalor and insincerity. Yet his anger lent nothing to the <span class="tag lineNumber">20250</span><br>
+          of squalor and insincerity. Yet his anger lent nothing to the <span class="tag lineNumber">250</span><br>
           vision. He chronicled with patience what he saw, detaching <br>
           himself from it and tasting its mortifying flavour in secret.<br> </p>
           <p class="textParagraph">  He was sitting on the backless chair in his aunt's kitchen. A <br>
           lamp with a reflector hung on the japanned wall of the fire- <br>
-          place and by its light his aunt was reading the evening paper <span class="tag lineNumber">20255</span><br>
+          place and by its light his aunt was reading the evening paper <br>
           that lay on her knees. She looked a long time at a smiling <br>
           picture that was set in it and said musingly:<br> </p>
            <p class="dialog"><span class="tag dialog">his aunt</span>―The beautiful Mabel Hunter!<br> </p>
           <p class="textParagraph">  A ringletted girl stood on tiptoe to peer at the picture and <br>
-          said softly: <span class="tag lineNumber">20260</span><br>
+          said softly: <span class="tag lineNumber">260</span><br>
            <p class="dialog"><span class="tag dialog">ringletted girl</span>―What is she in, mud? <br> </p>
            <p class="dialog"><span class="tag dialog">ringletted girl's mother</span>―In the pantomime, love. <br></p> </p>
           <p class="textParagraph">  The child leaned her ringletted head against her mother's <br>
           sleeve, gazing on the picture and murmured, as if fascinated: <br>
-           <p class="dialog"><span class="tag dialog">ringletted girl</span>―The beautiful Mabel Hunter! <span class="tag lineNumber">20265</span><br></p> </p>
+           <p class="dialog"><span class="tag dialog">ringletted girl</span>―The beautiful Mabel Hunter! <br></p> </p>
           <p class="textParagraph">  As if fascinated, her eyes rested long upon those demurely <br>
           taunting eyes and she murmured again devotedly: <br>
            <p class="dialog"><span class="tag dialog">ringletted girl</span>―Isn't she an exquisite creature? <br></p> </p>
           <p class="textParagraph">  And the boy who came in from the street, stamping crook- <br>
-          edly under his stone of coal, heard her words. He dropped his <span class="tag lineNumber">20270</span><br>
+          edly under his stone of coal, heard her words. He dropped his <span class="tag lineNumber">270</span><br>
           load promptly on the floor and hurried to her side to see. But <br>
           she did not raise her easeful head to let him see. He mauled the <br>
           edges of the paper with his reddened and blackened hands, <br>
           shouldering her aside and complaining that he could not see.<br> </p>
-          <p class="textParagraph">  He was sitting in the narrow breakfast room high up in the <span class="tag lineNumber">20275</span><br>
+          <p class="textParagraph">  He was sitting in the narrow breakfast room high up in the <br>
           old darkwindowed house. The firelight flickered on the wall <br>
           and beyond the window a spectral dusk was gathering upon the <br>
           river. Before the fire an old woman was busy making tea and, <br>
           as she bustled at her task, she told in a low voice of what the <br>
-          priest and the doctor had said. She told too of certain changes <span class="tag lineNumber">20280</span><br>
+          priest and the doctor had said. She told too of certain changes <span class="tag lineNumber">280</span><br>
           that she had seen in her of late and of her odd ways and <br>
           sayings. He sat listening to the words and following the ways <br>
           of adventure that lay open in the coals, arches and vaults and <br>
           winding galleries and jagged caverns.<br> </p>
-          <p class="textParagraph">  Suddenly he became aware of something in the doorway. A <span class="tag lineNumber">20285</span><br>
+          <p class="textParagraph">  Suddenly he became aware of something in the doorway. A <br>
           skull appeared suspended in the gloom of the doorway. A <br>
           feeble creature like a monkey was there, drawn thither by the <br>
           sound of voices at the fire. A whining voice came from the <br>
           door, asking: <br>
-           <p class="dialog"><span class="tag dialog">Ellen</span>―Is that Josephine? <span class="tag lineNumber">20290</span><br></p> </p>
+           <p class="dialog"><span class="tag dialog">Ellen</span>―Is that Josephine? <span class="tag lineNumber">290</span><br></p> </p>
           <p class="textParagraph">  The old bustling woman answered cheerily from the fire- <br>
           place: <br>
            <p class="dialog"><span class="tag dialog">old woman</span>―No, Ellen. It's Stephen. <br> </p>
            <p class="dialog"><span class="tag dialog">Ellen</span>―O .... O, good evening, Stephen. <br></p> </p>
-          <p class="textParagraph">  He answered the greeting and saw a silly smile break out <span class="tag lineNumber">20295</span><br>
+          <p class="textParagraph">  He answered the greeting and saw a silly smile break out <br>
           over the face in the doorway. <br>
            <p class="dialog"><span class="tag dialog">old woman</span>―Do you want anything, Ellen? asked the old woman at the <br>
           fire.<br></p> </p>
           <p class="textParagraph">  But she did not answer the question and said: <br>
-           <p class="dialog"><span class="tag dialog">Ellen</span>―I thought it was Josephine. I thought you were Josephine, <span class="tag lineNumber">20300</span><br>
+           <p class="dialog"><span class="tag dialog">Ellen</span>―I thought it was Josephine. I thought you were Josephine, <span class="tag lineNumber">300</span><br>
           Stephen.<br></p> </p>
           <p class="textParagraph">  And, repeating this several times, she fell to laughing feebly.<br> </p>
           <p class="textParagraph">  He was sitting in the midst of a children's party at <span class="hide">53.324608, <br>
           -6.281580</span>Harold's
            Cross. His silent watchful manner had grown upon him and he <br>
-          took little part in the games. The children, wearing the spoils of <span class="tag lineNumber">20305</span><br>
+          took little part in the games. The children, wearing the spoils of <br>
           their crackers, danced and romped noisily and, though he tried <br>
           to share their merriment, he felt himself a gloomy figure amid <br>
           the gay cocked hats and sunbonnets.<br> </p>
           <p class="textParagraph">  But when he had sung his song and withdrawn into a snug <br>
-          corner of the room he began to taste the joy of his loneliness. <span class="tag lineNumber">20310</span><br>
+          corner of the room he began to taste the joy of his loneliness. <span class="tag lineNumber">310</span><br>
           The mirth, which in the beginning of the evening had seemed <br>
           to him false and trivial, was like a soothing air to him, passing <br>
           gaily by his senses, hiding from other eyes the feverish agitation <br>
           of his blood while through the circling of the dancers and amid <br>
-          the music and laughter her glances travelled to his corner, <span class="tag lineNumber">20315</span><br>
+          the music and laughter her glances travelled to his corner, <br>
           flattering, taunting, searching, exciting his heart.<br> </p>
           <p class="textParagraph">  In the hall the children who had stayed latest were putting <br>
           on their things: the party was over. She had thrown a shawl <br>
           about her and, as they went together towards the tram, sprays <br>
-          of her fresh warm breath flew gaily above her cowled head and <span class="tag lineNumber">20320</span><br>
+          of her fresh warm breath flew gaily above her cowled head and <span class="tag lineNumber">320</span><br>
           her shoes tapped blithely on the glassy road.<br> </p>
           <p class="textParagraph">  It was the last tram. The lank brown horses knew it and <br>
           shook their bells to the clear night in admonition. The conductor <br>
           tor talked with the driver, both nodding often in the green light <br>
-          of the lamp. On the empty seats of the tram were scattered a <span class="tag lineNumber">20325</span><br>
+          of the lamp. On the empty seats of the tram were scattered a <br>
           few coloured tickets. No sound of footsteps came up or down <br>
           the road. No sound broke the peace of the night save when the <br>
           lank brown horses rubbed their noses together and shook their <br>
           bells.<br> </p>
-          <p class="textParagraph">  They seemed to listen, he on the upper step and she on the <span class="tag lineNumber">20330</span><br>
+          <p class="textParagraph">  They seemed to listen, he on the upper step and she on the <span class="tag lineNumber">330</span><br>
           lower. She came up to his step many times and went down to <br>
           hers again between their phrases and once or twice stood close <br>
           beside him for some moments on the upper step, forgetting to <br>
           go down, and then went down. His heart danced upon her <br>
-          movements like a cork upon a tide. He heard what her eyes <span class="tag lineNumber">20335</span><br>
+          movements like a cork upon a tide. He heard what her eyes <br>
           said to him from beneath their cowl and knew that in some dim <br>
           past, whether in life or in revery, he had heard their tale before. <br>
           He saw her urge her vanities, her fine dress and sash and long <br>
           black stockings, and knew that he had yielded to them a thou- <br>
-          sand times. Yet a voice within him spoke above the noise of his <span class="tag lineNumber">20340</span><br>
+          sand times. Yet a voice within him spoke above the noise of his <span class="tag lineNumber">340</span><br>
           dancing heart, asking him would he take her gift to which he <br>
           had only to stretch out his hand. And he remembered the day <br>
           when he and Eileen had stood looking into the hotel grounds, <br>
           watching the waiters running up a trail of bunting on the <br>
-          flagstaff and the foxterrier scampering to and fro on the sunny <span class="tag lineNumber">20345</span><br>
+          flagstaff and the foxterrier scampering to and fro on the sunny <br>
           lawn, and how, all of a sudden, she had broken out into a peal <br>
           of laughter and had run down the sloping curve of the path. <br>
           Now, as then, he stood listlessly in his place, seemingly a <br>
           tranquil watcher of the scene before him.<br> </p>
-          <p class="textParagraph"> ―She too wants me to catch hold of her, he thought. That's <span class="tag lineNumber">20350</span><br>
+          <p class="textParagraph"> ―She too wants me to catch hold of her, he thought. That's <span class="tag lineNumber">350</span><br>
           why she came with me to the tram. I could easily catch hold of <br>
           her when she comes up to my step: nobody is looking. I could <br>
           hold her and kiss her.<br> </p>
           <p class="textParagraph">  But he did neither: and, when he was sitting alone in the <br>
-          deserted tram, he tore his ticket into shreds and stared gloomily <span class="tag lineNumber">20355</span><br>
+          deserted tram, he tore his ticket into shreds and stared gloomily <br>
           at the corrugated footboard.<br> </p>
           <p class="textParagraph">  The next day he sat at his table in the bare upper room for <br>
           many hours. Before him lay a new pen, a new bottle of ink and <br>
           a new emerald exercise. From force of habit he had written at <br>
-          the top of the first page the initial letters of the jesuit motto: <span class="tag lineNumber">20360</span><br>
+          the top of the first page the initial letters of the jesuit motto: <span class="tag lineNumber">360</span><br>
           A. M. D. G. On the first line of the page appeared the title of <br>
           the verses he was trying to write: To E-- C--. He knew it was <br>
           right to begin so for he had seen similar titles in the collected <br>
           poems of Lord Byron. When he had written this title and <br>
-          drawn an ornamental line underneath he fell into a daydream <span class="tag lineNumber">20365</span><br>
+          drawn an ornamental line underneath he fell into a daydream <br>
           and began to draw diagrams on the cover of the book. He saw <br>
           himself sitting at his table in Bray the morning after the dis- <br>
           cussion at the Christmas dinnertable, trying to write a poem <br>
           about Parnell on the back of one of his father's second moiety <br>
-          notices. But his brain had then refused to grapple with the <span class="tag lineNumber">20370</span><br>
+          notices. But his brain had then refused to grapple with the <span class="tag lineNumber">370</span><br>
           theme and, desisting, he had covered the page with the names <br>
           and addresses of certain of his classmates: <br>
            Roderick Kickham <br>
           John Lawton <br>
-          Anthony MacSwiney <span class="tag lineNumber">20375</span><br>
+          Anthony MacSwiney <br>
           Simon Moonan<br> </p>
           <p class="textParagraph">  Now it seemed as if he would fail again but, by dint of <br>
           brooding on the incident, he thought himself into confidence. <br>
           During this process all those elements which he deemed com- <br>
-          mon and insignificant fell out of the scene. There remained no <span class="tag lineNumber">20380</span><br>
+          mon and insignificant fell out of the scene. There remained no <span class="tag lineNumber">380</span><br>
           trace of the tram itself nor of the trammen nor of the horses: <br>
           nor did he and she appear vividly. The verses told only of the <br>
           night and the balmy breeze and the maiden lustre of the moon. <br>
           Some undefined sorrow was hidden in the hearts of the protag- <br>
-          onists as they stood in silence beneath the leafless trees and <span class="tag lineNumber">20385</span><br>
+          onists as they stood in silence beneath the leafless trees and <br>
           when the moment of farewell had come the kiss, which had <br>
           been withheld by one, was given by both. After this the letters <br>
           L. D. S. were written at the foot of the page and, having hidden <br>
           the book, he went into his mother's bedroom and gazed at his <br>
-          face for a long time in the mirror of her dressingtable.<span class="tag lineNumber">20390</span><br> </p>
+          face for a long time in the mirror of her dressingtable.<span class="tag lineNumber">390</span><br> </p>
           <p class="textParagraph">  But his long spell of leisure and liberty was drawing to its <br>
           end. One evening his father came home full of news which kept <br>
           his tongue busy all through dinner. Stephen had been awaiting <br>
           his father's return for there had been mutton hash that day and <br>
-          he knew that his father would make him dip his bread in the <span class="tag lineNumber">20395</span><br>
+          he knew that his father would make him dip his bread in the <br>
           gravy. But he did not relish the hash for the mention of <br>
            <span class="hide">53.310770, -6.684719</span>Clongowes had coated his palate with a scum of disgust. <br>
            <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―I walked bang into him, said Mr Dedalus for the fourth <br>
           time, just at the corner of the square.<br> </p>
-           <p class="dialog"><span class="tag dialog">Mary Dedalus</span>―Then I suppose, said Mrs Dedalus, he will be able to arrange <span class="tag lineNumber">20400</span><br>
+           <p class="dialog"><span class="tag dialog">Mary Dedalus</span>―Then I suppose, said Mrs Dedalus, he will be able to arrange <span class="tag lineNumber">400</span><br>
           it. I mean, about Belvedere.<br> </p>
            <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Of course  he will, said Mr Dedalus. Don't I tell you he's <br>
           provincial of the order now? <br> </p>
            <p class="dialog"><span class="tag dialog">Mary Dedalus</span>―I never liked the idea of sending him to the christian brothers <br>
-          myself, said Mrs Dedalus. <span class="tag lineNumber">20405</span><br> </p>
+          myself, said Mrs Dedalus. <br> </p>
            <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Christian brothers be damned! said Mr Dedalus. Is it with <br>
           Paddy Stink and Mickey Mud? No, let him stick to the jesuits <br>
           in God's name since he began with them. They'll be of service <br>
           to him in after years. Those are the fellows that can get you a <br>
-          position.<span class="tag lineNumber">20410</span><br> </p>
+          position.<span class="tag lineNumber">410</span><br> </p>
            <p class="dialog"><span class="tag dialog">Mary Dedalus</span>―And they're a very rich order, aren't they, Simon? <br> </p>
            <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Rather. They live well, I tell you. You saw their table at <br>
            <span class="hide">53.310770, -6.684719</span>Clongowes. Fed up, by God, like gamecocks. <br></p> </p>
           <p class="textParagraph">  Mr Dedalus pushed his plate over to Stephen and bade him <br>
-          finish what was on it. <span class="tag lineNumber">20415</span><br>
+          finish what was on it. <br>
               <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Now then, Stephen,</p> he said. <p class="dialog"><span class="tag dialog">Simon Dedalus</span>You must put your shoulder to <br>
           the wheel, old chap. You've had a fine long holiday. <br> </p>
            <p class="dialog"><span class="tag dialog">Mary Dedalus</span>―O, I'm sure  he'll work very hard now,</p> said Mrs Dedalus. <br>
            <p class="dialog"><span class="tag dialog">Mary Dedalus</span>Especially when he has Maurice with him. <br> </p>
-           <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―O, Holy Paul, I forgot about Maurice,</p> said Mr Dedalus. <span class="tag lineNumber">20420</span><br>
+           <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―O, Holy Paul, I forgot about Maurice,</p> said Mr Dedalus. <span class="tag lineNumber">420</span><br>
            <p class="dialog"><span class="tag dialog">Simon Dedalus</span>Here, Maurice! Come here, you thickheaded ruffian! Do you <br>
           know I'm going to send you to a college where they'll teach you <br>
           to spell c.a.t: cat. And I'll buy you a nice little penny handker- <br>
           chief to keep your nose dry. Won't that be grand fun? <br></p> </p>
-          <p class="textParagraph">  Maurice grinned at his father and then at his brother. Mr <span class="tag lineNumber">20425</span><br>
+          <p class="textParagraph">  Maurice grinned at his father and then at his brother. Mr <br>
           Dedalus screwed his glass into his eye and stared hard at both <br>
           his sons. Stephen mumbled his bread without answering his <br>
           father's gaze. <br></p>
            <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―By the bye,</p> said Mr Dedalus at length, <p class="dialog"><span class="tag dialog">Simon Dedalus</span>the rector, or provin- <br>
-          cial, rather, was telling me that story about you and Father <span class="tag lineNumber">20430</span><br>
+          cial, rather, was telling me that story about you and Father <span class="tag lineNumber">430</span><br>
           Dolan. You're an impudent thief, he said. <br> </p>
            <p class="dialog"><span class="tag dialog">Mary Dedalus</span>―O, he didn't, Simon! <br> </p>
            <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Not he! said Mr Dedalus. But he gave me a great account of <br>
           the whole affair. We were chatting, you know, and one word <br>
-          borrowed another. And, by the way, who do you think he told <span class="tag lineNumber">20435</span><br>
+          borrowed another. And, by the way, who do you think he told <br>
           me will get that job in the corporation? But I'll tell you that <br>
           after. Well, as I was saying, we were chatting away quite <br>
           friendly and he asked me did our friend here wear glasses still <br>
           and then he told me the whole story. <br> </p>
-           <p class="dialog"><span class="tag dialog">Mary Dedalus</span>―And was he annoyed, Simon? <span class="tag lineNumber">20440</span><br> </p>
+           <p class="dialog"><span class="tag dialog">Mary Dedalus</span>―And was he annoyed, Simon? <span class="tag lineNumber">440</span><br> </p>
               <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Annoyed! Not he! <span class="emph">Manly little chap!</span></p> he said. <br>
           <p class="textParagraph">  Mr Dedalus imitated the mincing nasal tone of the provin- <br>
           cial. <br>
           <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Father Dolan and I, when I told them all at dinner about it, <br>
-          Father Dolan and I had a great laugh over it. <span class="emph">You better mind <span class="tag lineNumber">20445</span><br>
+          Father Dolan and I had a great laugh over it. <span class="emph">You better mind <br>
           yourself, Father Dolan</span>, said I, <span class="emph">or young Dedalus will send you <br>
           up for twice nine</span>. We had a famous laugh together over it. Ha! <br>
           Ha! Ha!<br></p> </p>
           <p class="textParagraph">  Mr Dedalus turned to his wife and interjected in his natural <br>
-          voice: <span class="tag lineNumber">20450</span><br>
+          voice: <span class="tag lineNumber">450</span><br>
            <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Shows you the spirit in which they take the boys there. O, a <br>
           jesuit for your life, for diplomacy! <br></p> </p>
           <p class="textParagraph">  He reassumed the provincial's voice and repeated: <br>
            <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―<span class="emph">I told them all at dinner about it and Father Dolan and I and <br>
-          all of us we all had a hearty laugh together over it. Ha! Ha! Ha!</span><span class="tag lineNumber">20455</span><br></p> </p>
+          all of us we all had a hearty laugh together over it. Ha! Ha! Ha!</span><br></p> </p>
           <div class="divider">* * *</div> 
           
         
@@ -2495,496 +2495,496 @@
           from the window of the dressingroom looked out on  the small <br>
           grassplot across which lines of Chinese lanterns were stretched. <br>
           He watched the visitors come down the steps from the house <br>
-          and pass into the theatre. Stewards in evening dress, old Belve- <span class="tag lineNumber">20460</span><br>
+          and pass into the theatre. Stewards in evening dress, old Belve- <span class="tag lineNumber">460</span><br>
           dereans, loitered in groups about the entrance to the theatre <br>
           and ushered in the visitors with ceremony. Under the sudden <br>
           glow of a lantern he could recognise the smiling face of a priest.<br> </p>
           <p class="textParagraph">  The Blessed Sacrament had been removed from the taber- <br>
-          nacle and the first benches had been driven back so as to leave <span class="tag lineNumber">20465</span><br>
+          nacle and the first benches had been driven back so as to leave <br>
           the dais of the altar and the space before it free. Against the <br>
           walls stood companies of barbells and Indian clubs; the dumb- <br>
           bells were piled in one corner: and in the midst of countless <br>
           hillocks of gymnasium shoes and sweaters and singlets in <br>
-          untidy brown parcels there stood the stout leatherjacketed <span class="tag lineNumber">20470</span><br>
+          untidy brown parcels there stood the stout leatherjacketed <span class="tag lineNumber">470</span><br>
           vaulting horse waiting its turn to be carried up on to the stage. <br>
           A large bronze shield, tipped with silver, leaned against the <br>
           panel of the altar also waiting its turn to be carried up on to the <br>
           stage and set in the middle of the winning team at the end of <br>
-          the gymnastic  display.<span class="tag lineNumber">20475</span><br> </p>
+          the gymnastic  display.<br> </p>
           <p class="textParagraph">  Stephen, though in deference to his reputation for essay- <br>
           writing he had been elected secretary to the gymnasium, had }omit{ no <br>
           part in the first section of the programme: but in the play <br>
           which formed the second section he had the chief part, that of a <br>
-          farcical pedagogue. He had been cast for it on account of his <span class="tag lineNumber">20480</span><br>
+          farcical pedagogue. He had been cast for it on account of his <span class="tag lineNumber">480</span><br>
           stature and grave manners for he was now at the end of his <br>
           second year at Belvedere and in number two.<br> </p>
           <p class="textParagraph">  A score of the younger boys in white knickers and singlets <br>
           came pattering down from the stage, through the vestry and <br>
-          into the chapel. The vestry and chapel were peopled with eager <span class="tag lineNumber">20485</span><br>
+          into the chapel. The vestry and chapel were peopled with eager <br>
           masters and boys. The plump bald sergeantmajor was testing <br>
           with his foot the springboard of the vaulting horse. The lean <br>
           young man in a long overcoat, who was to give a special <br>
           display of intricate club swinging, stood near watching with <br>
-          interest, his silvercoated clubs peeping out of his deep side- <span class="tag lineNumber">20490</span><br>
+          interest, his silvercoated clubs peeping out of his deep side- <span class="tag lineNumber">490</span><br>
           pockets. The hollow rattle of the wooden dumbbells was heard <br>
           as another team made ready to go up on the stage: and in <br>
           another moment the excited prefect was hustling the boys <br>
           through the vestry like a flock of geese, flapping the wings of <br>
-          his soutane nervously and crying to the laggards to make haste. <span class="tag lineNumber">20495</span><br>
+          his soutane nervously and crying to the laggards to make haste. <br>
           A little troop  of Neapolitan peasants were practising their steps <br>
           at the end of the chapel, some arching their arms above their <br>
           heads, some swaying their baskets of paper violets and curtsey- <br>
           ing. In a dark corner of the chapel at the gospel side of the altar <br>
-          a stout old lady knelt amid her copious black skirts. When she <span class="tag lineNumber">20500</span><br>
+          a stout old lady knelt amid her copious black skirts. When she <span class="tag lineNumber">500</span><br>
           stood up a pinkdressed figure, wearing a curly golden wig and <br>
           an oldfashioned straw sunbonnet, with black pencilled eye- <br>
           brows and cheeks delicately rouged and powdered, was dis- <br>
           covered. A low murmur of curiosity ran round the chapel at the <br>
-          discovery of this girlish figure. One of the prefects, smiling and <span class="tag lineNumber">20505</span><br>
+          discovery of this girlish figure. One of the prefects, smiling and <br>
           nodding his head, approached the dark corner and, having <br>
           bowed to the stout old lady, said pleasantly: <br>
            <p class="dialog"><span class="tag dialog">a prefect</span>―Is this a beautiful young lady or a doll that you have here, <br>
           Mrs Tallon?<br></p> </p>
-          <p class="textParagraph">  Then, bending down to peer at the smiling painted face un- <span class="tag lineNumber">20510</span><br>
+          <p class="textParagraph">  Then, bending down to peer at the smiling painted face un- <span class="tag lineNumber">510</span><br>
           der the leaf of the bonnet, he exclaimed: <br>
            <p class="dialog"><span class="tag dialog">a prefect</span>―No! Upon my word I believe it's little Bertie Tallon after all! <br></p> </p>
           <p class="textParagraph">  Stephen at his post by the window heard the old lady and <br>
           the priest laugh together and heard the boys' murmur of ad- <br>
-          miration behind him as they pressed forward to see the little <span class="tag lineNumber">20515</span><br>
+          miration behind him as they pressed forward to see the little <br>
           boy who had to dance the sunbonnet dance by himself. A <br>
           movement of impatience escaped him. He let the edge of the <br>
           blind fall and, stepping down from the bench on which he had <br>
           been standing, walked out of the chapel.<br> </p>
-          <p class="textParagraph">  He passed out of the schoolhouse and halted under the shed <span class="tag lineNumber">20520</span><br>
+          <p class="textParagraph">  He passed out of the schoolhouse and halted under the shed <span class="tag lineNumber">520</span><br>
           that flanked the garden. From the theatre opposite came the <br>
           muffled noise of the audience and sudden brazen clashes of the <br>
           soldiers' band. The light spread upwards from the glass roof <br>
           making the theatre seem a festive ark, anchored amid the hulks <br>
-          of houses, her frail cables of lanterns looping her to her moor- <span class="tag lineNumber">20525</span><br>
+          of houses, her frail cables of lanterns looping her to her moor- <br>
           ings. A sidedoor of the theatre opened suddenly and a shaft of <br>
           light flew across the grassplots. A sudden burst of music issued <br>
           from the ark, the prelude of a waltz: and when the sidedoor <br>
           closed again the listener could hear the faint rhythm of the <br>
-          music. The sentiment of the opening bars, their languor and <span class="tag lineNumber">20530</span><br>
+          music. The sentiment of the opening bars, their languor and <span class="tag lineNumber">530</span><br>
           supple movement, evoked the incommunicable emotion which <br>
           had been the cause of all his day's unrest and of his impatient <br>
           movement of a moment before. His unrest issued from him like <br>
           a wave of sound: and on the tide of flowing music the ark was <br>
-          journeying, trailing her cables of lanterns in her wake. Then a <span class="tag lineNumber">20535</span><br>
+          journeying, trailing her cables of lanterns in her wake. Then a <br>
           noise like dwarf artillery broke the movement. It was the <br>
           clapping that greeted the entry of the dumbbell team on the <br>
           stage.<br> </p>
           <p class="textParagraph">  At the far end of the shed near the street a speck of pink <br>
-          light showed in the darkness and as he walked towards it he <span class="tag lineNumber">20540</span><br>
+          light showed in the darkness and as he walked towards it he <span class="tag lineNumber">540</span><br>
           became aware of a faint aromatic odour. Two boys were <br>
           standing in the shelter of the doorway, smoking, and before he <br>
           reached them he had recognised Heron by his voice. <br>
           <p class="dialog"><span class="tag dialog">Heron</span>―Here comes the noble Dedalus!</p> cried a high throaty voice. <br>
-          <p class="dialog"><span class="tag dialog">heron</span>Welcome to our trusty friend! <span class="tag lineNumber">20545</span><br></p> </p>
+          <p class="dialog"><span class="tag dialog">heron</span>Welcome to our trusty friend! <br></p> </p>
           <p class="textParagraph">  This welcome ended in a soft peal of mirthless laughter as <br>
           Heron salaamed and then began to poke the ground with his <br>
           cane. <br>
           <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Here I am</p>, said Stephen, halting and glancing from Heron to <br>
-          his friend. <span class="tag lineNumber">20550</span><br> </p>
+          his friend. <span class="tag lineNumber">550</span><br> </p>
           <p class="textParagraph">  The latter was a stranger to him but in the darkness, by the <br>
           aid of the glowing cigarette tips, he could make out a pale <br>
           dandyish face, over which a smile was travelling slowly, a tall <br>
           overcoated figure and a hard hat. Heron did not trouble him- <br>
-          self about an introduction but said instead: <span class="tag lineNumber">20555</span><br>
+          self about an introduction but said instead: <br>
            <p class="dialog"><span class="tag dialog">Heron</span>―I was just telling my friend Wallis what a lark it would be <br>
           tonight if you took off the rector in the part of the school- <br>
           master. It would be a ripping good joke. <br></p> </p>
           <p class="textParagraph">  Heron made a poor attempt to imitate for his friend Wallis <br>
-          the rector's pedantic bass and then, laughing at his failure, <span class="tag lineNumber">20560</span><br>
+          the rector's pedantic bass and then, laughing at his failure, <span class="tag lineNumber">560</span><br>
           asked Stephen to do it. <br>
           <p class="dialog"><span class="tag dialog">Heron</span>―Go on, Dedalus</p>, he urged. <p class="dialog"><span class="tag dialog">Heron</span>You can take him off rippingly.</p><br>
           <p class="lg">
           <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>He that will not hear the churcha let him be to theea as the <br>
           heathena and the publicana.</p><br>
           </p></p>
-          <p class="textParagraph">  The imitation was prevented by a mild expression of anger <span class="tag lineNumber">20565</span><br>
+          <p class="textParagraph">  The imitation was prevented by a mild expression of anger <br>
           from Wallis in whose mouthpiece the cigarette had become too <br>
           tightly wedged. <br>
           <p class="dialog"><span class="tag dialog">Wallis</span>―Damn this blankety blank holder</p>, he said, taking it from his <br>
           mouth and smiling and frowning upon it tolerantly. <p class="dialog"><span class="tag dialog">Wallis</span>It's always <br>
-          getting stuck like that. Do you use a holder? <span class="tag lineNumber">20570</span><br> </p>
+          getting stuck like that. Do you use a holder? <span class="tag lineNumber">570</span><br> </p>
            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I don't smoke, answered Stephen. <br> </p>
            <p class="dialog"><span class="tag dialog">Heron</span>―No,</p> said Heron, <p class="dialog"><span class="tag dialog">Heron</span>Dedalus is a model youth. He doesn't <br>
           smoke and he doesn't go to bazaars and he doesn't flirt and he <br>
           doesn't damn anything or damn all. <br></p> </p>
-          <p class="textParagraph">  Stephen shook his head and smiled in his rival's flushed and <span class="tag lineNumber">20575</span><br>
+          <p class="textParagraph">  Stephen shook his head and smiled in his rival's flushed and <br>
           mobile face, beaked like a bird's. He had often thought it <br>
           strange that Vincent Heron had a bird's face as well as a bird's <br>
           name. A shock of pale hair lay on the forehead like a ruffled <br>
           crest: the forehead was narrow and bony and a thin hooked <br>
-          nose stood out between the closeset prominent eyes which were <span class="tag lineNumber">20580</span><br>
+          nose stood out between the closeset prominent eyes which were <span class="tag lineNumber">580</span><br>
           light and inexpressive. The rivals were school friends. They sat <br>
           together in class, knelt together in the chapel, talked together <br>
           after beads over their lunches. As the fellows in number one <br>
           were undistinguished dullards Stephen and Heron had been <br>
-          during the year the virtual heads of the school. It was they who <span class="tag lineNumber">20585</span><br>
+          during the year the virtual heads of the school. It was they who <br>
           went up to the rector together to ask for a free day or to get a <br>
           fellow off. <br>
           <p class="dialog"><span class="tag dialog">Heron</span>―O by the way</p>, said Heron suddenly, <p class="dialog"><span class="tag dialog">Heron</span>I saw your governor <br>
           going in. <br></p> </p>
-          <p class="textParagraph">  The smile waned on Stephen's face. Any allusion made to his <span class="tag lineNumber">20590</span><br>
+          <p class="textParagraph">  The smile waned on Stephen's face. Any allusion made to his <span class="tag lineNumber">590</span><br>
           father by a fellow or by a master put his calm to rout in a <br>
           moment. He waited in timorous silence to hear what Heron <br>
           might say next. Heron, however, nudged him expressively with <br>
           his elbow and said: <br>
-           <p class="dialog"><span class="tag dialog">Heron</span>―You're a sly dog, Dedalus! <span class="tag lineNumber">20595</span><br> </p>
+           <p class="dialog"><span class="tag dialog">Heron</span>―You're a sly dog, Dedalus! <br> </p>
            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Why so?</p> said Stephen. <br>
            <p class="dialog"><span class="tag dialog">Heron</span>―You'd think butter wouldn't melt in your mouth</p>, said <br>
            Heron. <p class="dialog"><span class="tag dialog">Heron</span>But I'm afraid you're a sly dog. <br> </p>
            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Might I ask you what you are talking about?</p> said Stephen <br>
-          urbanely.<span class="tag lineNumber">20600</span><br>
+          urbanely.<span class="tag lineNumber">600</span><br>
           <p class="dialog"><span class="tag dialog">Heron</span>―Indeed  you might</p>, answered Heron. <p class="dialog"><span class="tag dialog">Heron</span>&gt;We saw her, Wallis, <br>
           didn't we? And deucedly pretty she is too. And so inquisitive! <br>
           <span class="emph">And what part does Stephen take, Mr Dedalus? And will <br>
           Stephen not sing, Mr Dedalus?</span> Your governor was staring at <br>
-          her through that eyeglass of his for all he was worth so that I <span class="tag lineNumber">20605</span><br>
+          her through that eyeglass of his for all he was worth so that I <br>
           think the old man has found you out too. I wouldn't care a bit, <br>
           by Jove. She's  ripping, isn't she, Wallis? <br> </p>
            <p class="dialog"><span class="tag dialog">Wallis</span>―Not half bad</p>, answered Wallis quietly as he placed his <br>
           holder once more in a corner of his mouth. <br> </p>
-          <p class="textParagraph">  A shaft of momentary anger flew through Stephen's mind at <span class="tag lineNumber">20610</span><br>
+          <p class="textParagraph">  A shaft of momentary anger flew through Stephen's mind at <span class="tag lineNumber">610</span><br>
           these indelicate allusions in the hearing of a stranger. For him <br>
           there was nothing amusing in a girl's interest and regard. All <br>
           day he had thought of nothing but their leavetaking on the <br>
           steps of the tram at <span class="hide">53.324608, -6.281580</span>Harold's Cross, the stream of moody <br>
-          emotions it had made to course through him and the poem he <span class="tag lineNumber">20615</span><br>
+          emotions it had made to course through him and the poem he <br>
           had written about it. All day he had imagined a new meeting <br>
           with her for he knew that she was to come to the play. The old <br>
           restless moodiness had again filled his heart as it had done on <br>
           the night of the party but had not found  an outlet in verse. The <br>
-          growth and knowledge of two years of boyhood stood between <span class="tag lineNumber">20620</span><br>
+          growth and knowledge of two years of boyhood stood between <span class="tag lineNumber">620</span><br>
           then and now, forbidding such an outlet: and all day the stream <br>
           of gloomy tenderness within him had started forth and re- <br>
           turned upon itself in dark courses and eddies, wearying him in <br>
           the end until the pleasantry of the prefect and the painted little <br>
-          boy had drawn from him a movement of impatience. <span class="tag lineNumber">20625</span><br>
+          boy had drawn from him a movement of impatience. <br>
           <p class="dialog"><span class="tag dialog">Heron</span>―So you may as well admit</p>, Heron went on, <p class="dialog"><span class="tag dialog">Heron</span>that we've fairly <br>
           found you out this time. You can't play the saint on me any <br>
           more, that's one sure five. <br></p> </p>
           <p class="textParagraph">  A soft peal of mirthless laughter escaped from his lips and, <br>
-          bending down as before, he struck Stephen lightly across the <span class="tag lineNumber">20630</span><br>
+          bending down as before, he struck Stephen lightly across the <span class="tag lineNumber">630</span><br>
           calf of the leg with his cane, as if in jesting reproof.<br> </p>
           <p class="textParagraph">  Stephen's moment of anger had already passed. He was nei- <br>
           ther flattered nor confused but simply wished the banter to <br>
           end. He scarcely resented what had seemed to him at first a <br>
-          silly indelicateness for he knew that the adventure in his mind <span class="tag lineNumber">20635</span><br>
+          silly indelicateness for he knew that the adventure in his mind <br>
           stood in no danger from their words: and his face mirrored his <br>
           rival's false smile. <br>
           <p class="dialog"><span class="tag dialog">Heron</span>―Admit!</p> repeated Heron, striking him again with his cane <br>
           across the calf of the leg. <br></p>
-          <p class="textParagraph">  The stroke was playful but not so lightly given as the first <span class="tag lineNumber">20640</span><br>
+          <p class="textParagraph">  The stroke was playful but not so lightly given as the first <span class="tag lineNumber">640</span><br>
           one had been. Stephen felt the skin tingle and glow slightly and <br>
           almost painlessly; and bowing submissively, as if to meet his <br>
           companion's jesting mood, began to recite the Confiteor. The <br>
           episode ended well for both Heron and Wallis laughed indul- <br>
-          gently at the irreverence.<span class="tag lineNumber">20645</span><br> </p>
+          gently at the irreverence.<br> </p>
           <p class="textParagraph">  The confession came only from Stephen's lips and, while <br>
           they spoke the words, a sudden memory had carried him to <br>
           another scene called up, as if by magic, at the moment when he <br>
           had noted the faint cruel dimples at the corners of Heron's <br>
-          smiling lips and had felt the familiar stroke of the cane against <span class="tag lineNumber">20650</span><br>
+          smiling lips and had felt the familiar stroke of the cane against <span class="tag lineNumber">650</span><br>
           his calf and had heard the familiar word of admonition: <br>
           <p class="dialog"><span class="tag dialog">Heron</span>―Admit!<br></p> </p>
           <p class="textParagraph">  It was towards the close of his first term in the college when <br>
           he was in number six. His sensitive nature was still smarting <br>
-          under the lashes of an undivined and squalid way of life. His <span class="tag lineNumber">20655</span><br>
+          under the lashes of an undivined and squalid way of life. His <br>
           soul was still disquieted and cast down by the dull phenom- <br>
           enon of <span class="hide">53.349307, -6.263654</span>Dublin. He had emerged from a two years' spell of <br>
           revery to find himself in the midst of a new scene, every event <br>
           and figure of which affected him intimately, disheartened him <br>
-          or allured him and, whether alluring or disheartening, filled <span class="tag lineNumber">20660</span><br>
+          or allured him and, whether alluring or disheartening, filled <span class="tag lineNumber">660</span><br>
           him always with unrest and bitter thoughts. All the leisure that <br>
           his school life left him was passed in the company of subversive <br>
           writers whose gibes and violence of speech set up a ferment in <br>
           his brain before they passed out of it into his crude writings.<br> </p>
-          <p class="textParagraph">  The essay was for him the chief labour of his week and every <span class="tag lineNumber">20665</span><br>
+          <p class="textParagraph">  The essay was for him the chief labour of his week and every <br>
           Tuesday, as he marched from home to the school, he read his <br>
           fate in the incidents of the way, pitting himself against some <br>
           figure ahead of him and quickening his pace to outstrip it be- <br>
           fore a certain goal was reached or planting his steps scrupu- <br>
-          lously in the spaces of the patchwork of the footpath and <span class="tag lineNumber">20670</span><br>
+          lously in the spaces of the patchwork of the footpath and <span class="tag lineNumber">670</span><br>
           telling himself that he would be first and not first in the weekly <br>
           essay.<br> </p>
           <p class="textParagraph">  On a certain Tuesday the course of his triumphs was rudely <br>
           broken. Mr Tate, the English master, pointed his finger at him <br>
-          and said bluntly: <span class="tag lineNumber">20675</span><br>
+          and said bluntly: <br>
            <p class="dialog"><span class="tag dialog">Mr Tate</span>―This fellow has heresy in his essay. <br></p> </p>
           <p class="textParagraph">  A hush fell on the class. Mr Tate did not break it but dug <br>
           with his hand between his crossed thighs while his heavily <br>
           starched linen creaked about his neck and wrists. Stephen did <br>
-          not look up. It was a raw spring morning and his eyes were still <span class="tag lineNumber">20680</span><br>
+          not look up. It was a raw spring morning and his eyes were still <span class="tag lineNumber">680</span><br>
           smarting and weak. He was conscious of failure and of detec- <br>
           tion, of the squalor of his own mind and home, and felt against <br>
           his neck the raw edge of his turned and jagged collar.<br> </p>
           <p class="textParagraph">  A short loud laugh from Mr Tate set the class more at ease. <br>
-           <p class="dialog"><span class="tag dialog">Mr Tate</span>―Perhaps you didn't know that</p>, he said. <span class="tag lineNumber">20685</span><br>
+           <p class="dialog"><span class="tag dialog">Mr Tate</span>―Perhaps you didn't know that</p>, he said. <br>
            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Where?</p> asked Stephen. <br> </p>
           <p class="textParagraph">  Mr Tate withdrew his delving hand and spread out the es- <br>
           say. <br>
            <p class="dialog"><span class="tag dialog">Mr Tate</span>―Here. It's about the Creator and the soul. Rrm ... rrm ..... <br>
-          rrm ...  Ah! <span class="emph">without a possibility of ever approaching nearer</span>. <span class="tag lineNumber">20690</span><br>
+          rrm ...  Ah! <span class="emph">without a possibility of ever approaching nearer</span>. <span class="tag lineNumber">690</span><br>
           That's heresy. <br></p> </p>
           <p class="textParagraph">  Stephen murmured: <br>
            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I meant <span class="emph">without a possibility of ever reaching</span>. <br></p> </p>
           <p class="textParagraph">  It was a submission and Mr Tate, appeased, folded up the <br>
-          essay and passed it across to him, saying: <span class="tag lineNumber">20695</span><br>
+          essay and passed it across to him, saying: <br>
            <p class="dialog"><span class="tag dialog">Mr Tate</span>―O ... Ah! <span class="emph">ever reaching</span>. That's another story. <br></p> </p>
           <p class="textParagraph">  But the class was not so soon appeased. Though nobody <br>
           spoke to him of the affair after class he could feel about him a <br>
           vague general malignant joy.<br> </p>
-          <p class="textParagraph">  A few nights after this public chiding  he was walking with a <span class="tag lineNumber">20700</span><br>
+          <p class="textParagraph">  A few nights after this public chiding  he was walking with a <span class="tag lineNumber">700</span><br>
           letter along the <span class="hide">53.36324, -6.25800</span>Drumcondra Road when he heard a voice cry: <br>
            <p class="dialog"><span class="tag dialog">Heron</span>―Halt! <br></p> </p>
           <p class="textParagraph">  He turned and saw three boys of his own class coming to- <br>
           wards him in the dusk. It was Heron who had called out and, <br>
-          as he marched forward between his two attendants, he cleft the <span class="tag lineNumber">20705</span><br>
+          as he marched forward between his two attendants, he cleft the <br>
           air before him with a thin cane, in time to their steps. Boland, <br>
           his friend, marched beside him, a large grin on his face, while <br>
           Nash came on a few steps behind, blowing from the pace and <br>
           wagging his great red head.<br> </p>
-          <p class="textParagraph">  As soon as the boys had turned into <span class="hide">53.362304, -6.249867</span>Clonliffe Roadtogether <span class="tag lineNumber">20710</span><br>
+          <p class="textParagraph">  As soon as the boys had turned into <span class="hide">53.362304, -6.249867</span>Clonliffe Roadtogether <span class="tag lineNumber">710</span><br>
           they began to speak about books and writers, saying what <br>
           books they were reading and how many books there were in <br>
           their fathers' bookcases at home. Stephen listened to them in <br>
           some wonderment for Boland was the dunce and Nash the idler <br>
-          of the class. In fact after some talk about their favourite writers <span class="tag lineNumber">20715</span><br>
+          of the class. In fact after some talk about their favourite writers <br>
           Nash declared for Captain Marryat who, he said, was the <br>
           greatest writer. <br>
           <p class="dialog"><span class="tag dialog">Heron</span>―Fudge!</p> said Heron. <p class="dialog"><span class="tag dialog">Heron</span>Ask Dedalus. Who is the greatest writer, <br>
           Dedalus?<br></p> </p>
-          <p class="textParagraph">  Stephen noted the mockery in the question and said: <span class="tag lineNumber">20720</span><br>
+          <p class="textParagraph">  Stephen noted the mockery in the question and said: <span class="tag lineNumber">720</span><br>
            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Of prose, do you mean? <br> </p>
            <p class="dialog"><span class="tag dialog">Heron</span>―Yes.<br> </p>
            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Newman, I think. <br> </p>
            <p class="dialog"><span class="tag dialog">Boland</span>―Is it Cardinal Newman?</p> asked Boland. <br> 
-           <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Yes</p>, answered Stephen. <span class="tag lineNumber">20725</span><br></p>
+           <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Yes</p>, answered Stephen. <br></p>
           <p class="textParagraph">  The grin broadened on Nash's freckled face as he turned to <br>
           Stephen and said: <br>
            <p class="dialog"><span class="tag dialog">Nash</span>―And do you like Cardinal Newman, Dedalus? <br> </p>
            <p class="dialog"><span class="tag dialog">Heron</span>―O, many people say that Newman has the best prose style,</p> <br>
-          Heron said to the other two in explanation. <p class="dialog"><span class="tag dialog">Heron</span>Of course, he's not <span class="tag lineNumber">20730</span><br>
+          Heron said to the other two in explanation. <p class="dialog"><span class="tag dialog">Heron</span>Of course, he's not <span class="tag lineNumber">730</span><br>
           a poet. <br> </p>
            <p class="dialog"><span class="tag dialog">Boland</span>―And who is the best poet, Heron?</p> asked Boland. <br>
            <p class="dialog"><span class="tag dialog">Heron</span>―Lord Tennyson, of course</p>, answered Heron. <br> 
            <p class="dialog"><span class="tag dialog">Nash</span>―O, yes, Lord Tennyson</p>, said Nash. <p class="dialog"><span class="tag dialog">Nash</span>We have all his poetry at <br>
-          home in a book. <span class="tag lineNumber">20735</span><br></p> </p>
+          home in a book. <br></p> </p>
           <p class="textParagraph">  At this Stephen forgot the silent vows he had been making <br>
           and burst out: <br>
            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Tennyson a poet! Why, he's only a rhymester! <br> </p>
            <p class="dialog"><span class="tag dialog">Heron</span>―O, get out!</p> said Heron. <p class="dialog"><span class="tag dialog">Heron</span>Everyone knows that Tennyson is <br>
-          the greatest poet. <span class="tag lineNumber">20740</span><br> </p>
+          the greatest poet. <span class="tag lineNumber">740</span><br> </p>
            <p class="dialog"><span class="tag dialog">Boland</span>―And who do you think is the greatest poet?</p> asked Boland, <br>
           nudging his neighbour. <br>
            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Byron, of course</p>, answered Stephen. <br> </p>
           <p class="textParagraph">  Heron gave the lead and all three joined in a scornful laugh. <br>
-           <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―What are you laughing at?</p> asked Stephen. <span class="tag lineNumber">20745</span><br>
+           <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―What are you laughing at?</p> asked Stephen. <br>
            <p class="dialog"><span class="tag dialog">Heron</span>―You</p>, said Heron. <p class="dialog"><span class="tag dialog">Heron</span>Byron the greatest poet! He's only a poet <br>
           for uneducated people. <br> </p>
            <p class="dialog"><span class="tag dialog">Boland</span>―He must be a fine poet!</p> said Boland. <br>
            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―You may keep your mouth shut, said Stephen, turning on <br>
-          him boldly. All you know about poetry is what you wrote up <span class="tag lineNumber">20750</span><br>
+          him boldly. All you know about poetry is what you wrote up <span class="tag lineNumber">750</span><br>
           on the slates in the yard and were going to be sent to the loft <br>
           for.<br></p> </p>
           <p class="textParagraph">  Boland, in fact, was said to have written on the slates in the <br>
           yard a couplet about a classmate of his who often rode home <br>
-          from the college on a pony:<span class="tag lineNumber">20755</span><br> </p>
+          from the college on a pony:<br> </p>
           <p class="lg">
              As Tyson was riding into Jerusalem <br>
              He fell and hurt his Alec Kafoozelum. <br>
           </p>
           <p class="textParagraph">  This thrust put the two lieutenants to silence but Heron <br>
           went on: <br>
-           <p class="dialog"><span class="tag dialog">Heron</span>―In any case Byron was a heretic and immoral too. <span class="tag lineNumber">20760</span><br> </p>
+           <p class="dialog"><span class="tag dialog">Heron</span>―In any case Byron was a heretic and immoral too. <span class="tag lineNumber">760</span><br> </p>
            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I don't care what he was, cried Stephen hotly. <br> </p>
            <p class="dialog"><span class="tag dialog">Nash</span>―You don't care whether he was a heretic or not? said Nash. <br> </p>
            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―What do you know about it? shouted Stephen. You never <br>
           read a line of anything in your life except a trans or Boland <br>
-          either.<span class="tag lineNumber">20765</span><br> </p>
+          either.<br> </p>
            <p class="dialog"><span class="tag dialog">Boland</span>―I know that Byron was a bad man, said Boland. <br> </p>
            <p class="dialog"><span class="tag dialog">Heron</span>―Here, Catch hold of this heretic, Heron called out. <br></p> </p>
           <p class="textParagraph">  In a moment Stephen was a prisoner. <br>
            <p class="dialog"><span class="tag dialog">Heron</span>―Tate made you buck up the other day, Heron went on, about <br>
-          the heresy in your essay. <span class="tag lineNumber">20770</span><br> </p>
+          the heresy in your essay. <span class="tag lineNumber">770</span><br> </p>
            <p class="dialog"><span class="tag dialog">Boland</span>―I'll tell him tomorrow, said Boland. <br> </p>
            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Will you? said Stephen. You'd be afraid to open your lips. <br> </p>
            <p class="dialog"><span class="tag dialog">Boland</span>―Afraid?<br> </p>
            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Ay. Afraid of your life. <br> </p>
-           <p class="dialog"><span class="tag dialog">Heron</span>―Behave yourself! cried Heron, cutting at Stephen's legs with <span class="tag lineNumber">20775</span><br>
+           <p class="dialog"><span class="tag dialog">Heron</span>―Behave yourself! cried Heron, cutting at Stephen's legs with <br>
           his cane. <br></p> </p>
           <p class="textParagraph">  It was the signal for their  onset. Nash pinioned his arms <br>
           behind while Boland seized a long cabbage stump which was <br>
           lying in the gutter. Struggling and kicking under the cuts of the <br>
-          cane and the blows of the knotty stump Stephen was borne <span class="tag lineNumber">20780</span><br>
+          cane and the blows of the knotty stump Stephen was borne <span class="tag lineNumber">780</span><br>
           back against a barbed wire fence. <br>
            <p class="dialog"><span class="tag dialog">Heron</span>―Admit that Byron was no good. <br> </p>
            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―No.<br> </p>
            <p class="dialog"><span class="tag dialog">Heron</span>―Admit.<br> </p>
-           <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―No.<span class="tag lineNumber">20785</span><br> </p>
+           <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―No.<br> </p>
            <p class="dialog"><span class="tag dialog">Heron</span>―Admit.<br> </p>
            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―No. No. <br></p> </p>
           <p class="textParagraph">  At last after a fury of plunges he wrenched himself free. His <br>
           tormentors set off towards <span class="hide">53.360891, -6.251230</span>Jones's Road, laughing and jeering <br>
-          at him, while he, }omit{ half blinded with tears, stumbled on, clench- <span class="tag lineNumber">20790</span><br>
+          at him, while he, }omit{ half blinded with tears, stumbled on, clench- <span class="tag lineNumber">790</span><br>
           ing his fists madly and sobbing.<br> </p>
           <p class="textParagraph">  While he was still repeating the Confiteor amid the indul- <br>
           gent laughter of his hearers and while the scenes of that <br>
           malignant episode were still passing sharply and swiftly before <br>
-          his mind he wondered why he bore no malice now to those <span class="tag lineNumber">20795</span><br>
+          his mind he wondered why he bore no malice now to those <br>
           who had tormented him. He had not forgotten a whit of their <br>
           cowardice and cruelty but the memory of it called forth no <br>
           anger from him. All the descriptions of fierce love and hatred <br>
           which he had met in books had  seemed to him therefore unreal. <br>
-          Even that night as he stumbled homewards along <span class="hide">53.360891, -6.251230</span>Jones's Road <span class="tag lineNumber">20800</span><br>
+          Even that night as he stumbled homewards along <span class="hide">53.360891, -6.251230</span>Jones's Road <span class="tag lineNumber">800</span><br>
           he had felt that some power was divesting him of that sudden- <br>
           woven anger as easily as a fruit is divested of her soft ripe peel.<br> </p>
           <p class="textParagraph">  He remained standing with his two companions at the end <br>
           of the shed, listening idly to their talk or to the bursts of <br>
-          applause in the theatre. She was sitting there among the others, <span class="tag lineNumber">20805</span><br>
+          applause in the theatre. She was sitting there among the others, <br>
           perhaps waiting for him to appear. He tried to recall her ap- <br>
           pearance but could not. He could remember only that she had <br>
           worn a shawl about her head like a cowl and that her dark eyes <br>
           had invited and unnerved him. He wondered had he been in her <br>
-          thoughts as she had been in his. Then in the dark and unseen <span class="tag lineNumber">20810</span><br>
+          thoughts as she had been in his. Then in the dark and unseen <span class="tag lineNumber">810</span><br>
           by the other two he rested the tips of the fingers of one hand <br>
           upon the palm of the other hand, scarcely touching it and yet <br>
           pressing upon it lightly. But the pressure of her fingers had <br>
           been lighter and steadier: and suddenly the memory of their <br>
-          touch traversed his brain and body like an invisible warm <span class="tag lineNumber">20815</span><br>
+          touch traversed his brain and body like an invisible warm <br>
           wave.<br> </p>
           <p class="textParagraph">  A boy came towards them, running along under the shed. <br>
           He was excited and breathless. <br>
            <p class="dialog"><span class="tag dialog">a boy</span>―O, Dedalus, he cried, Doyle is in a great bake about you. <br>
-          You're to go in at once and get dressed for the play. Hurry up, <span class="tag lineNumber">20820</span><br>
+          You're to go in at once and get dressed for the play. Hurry up, <span class="tag lineNumber">820</span><br>
           you better. <br> </p>
            <p class="dialog"><span class="tag dialog">Heron</span>―He's coming now, said Heron to the messenger with a <br>
           haughty drawl, when he wants to. <br></p> </p>
           <p class="textParagraph">  The boy turned to Heron and repeated: <br>
-           <p class="dialog"><span class="tag dialog">a boy</span>―But Doyle is in an awful bake. <span class="tag lineNumber">20825</span><br> </p>
+           <p class="dialog"><span class="tag dialog">a boy</span>―But Doyle is in an awful bake. <br> </p>
            <p class="dialog"><span class="tag dialog">Heron</span>―Will you tell Doyle with my best compliments that I damned <br>
           his eyes? answered Heron. <br> </p>
            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Well, I must go now, said Stephen who cared little for such <br>
           points of honour. <br> </p>
-           <p class="dialog"><span class="tag dialog">Heron</span>―I wouldn't, said Heron, damn me if I would. That's no way <span class="tag lineNumber">20830</span><br>
+           <p class="dialog"><span class="tag dialog">Heron</span>―I wouldn't, said Heron, damn me if I would. That's no way <span class="tag lineNumber">830</span><br>
           to send for one of the senior boys. In a bake, indeed! I think it's <br>
           quite enough that you're taking a part in his bally old play. <br></p> </p>
           <p class="textParagraph">  This spirit of quarrelsome comradeship which he had ob- <br>
           served lately in his rival had not seduced Stephen from his <br>
-          habits of quiet obedience. He mistrusted the turbulence and <span class="tag lineNumber">20835</span><br>
+          habits of quiet obedience. He mistrusted the turbulence and <br>
           doubted the sincerity of such comradeship which seemed to <br>
           him a sorry anticipation of manhood. The question of honour <br>
           here raised was, like all such questions, trivial to him. While his <br>
           mind had been pursuing its intangible phantoms and turning in <br>
-          irresolution from such pursuit he had heard about him the <span class="tag lineNumber">20840</span><br>
+          irresolution from such pursuit he had heard about him the <span class="tag lineNumber">840</span><br>
           constant voices of his father and of his masters, urging him to <br>
           be a gentleman above all things and urging him to be a good <br>
           catholic above all things. These voices had now come to be <br>
           hollowsounding in his ears. When the gymnasium had been <br>
-          opened he had heard another voice urging him to be strong and <span class="tag lineNumber">20845</span><br>
+          opened he had heard another voice urging him to be strong and <br>
           manly and healthy and when the movement towards national <br>
           revival had begun to be felt in the college yet another voice had <br>
           bidden him  be true to his country and help to raise up her <br>
           fallen language and tradition. In the profane world, as he <br>
-          foresaw, a worldly voice would bid him raise up his father's <span class="tag lineNumber">20850</span><br>
+          foresaw, a worldly voice would bid him raise up his father's <span class="tag lineNumber">850</span><br>
           fallen state by his labours and, meanwhile, the voice of his <br>
           schoolcomrades urged him to be a decent fellow, to shield <br>
           others from blame or to beg them off and to do his best to get <br>
           free days for the school. And it was the din of all these hollow- <br>
-          sounding voices that made him halt irresolutely in the pursuit <span class="tag lineNumber">20855</span><br>
+          sounding voices that made him halt irresolutely in the pursuit <br>
           of phantoms. He gave them ear only for a time but he was <br>
           happy only when he was far from them, beyond their call, <br>
           alone or in the company of phantasmal comrades.<br> </p>
           <p class="textParagraph">  In the vestry a plump freshfaced jesuit and an elderly man, in <br>
-          shabby blue clothes, were dabbling in a case of paints and <span class="tag lineNumber">20860</span><br>
+          shabby blue clothes, were dabbling in a case of paints and <span class="tag lineNumber">860</span><br>
           chalks. The boys who had been painted walked about or stood <br>
           still awkwardly, touching their faces in a gingerly fashion with <br>
           their furtive fingertips. In the middle of the vestry a young <br>
           jesuit, who was then on a visit to the college, stood rocking <br>
-          himself rhythmically from the tips of his toes to his heels and <span class="tag lineNumber">20865</span><br>
+          himself rhythmically from the tips of his toes to his heels and <br>
           back again, his hands thrust well forward into his sidepockets. <br>
           His small head set off with glossy red curls and his newly <br>
           shaven face agreed well with the spotless decency of his soutane <br>
           and with his spotless shoes.<br> </p>
-          <p class="textParagraph">  As he watched this swaying form and tried to read for him- <span class="tag lineNumber">20870</span><br>
+          <p class="textParagraph">  As he watched this swaying form and tried to read for him- <span class="tag lineNumber">870</span><br>
           self the legend of the priest's mocking smile there came into <br>
           Stephen's memory a saying which he had heard from his father <br>
           before he had been sent to <span class="hide">53.310770, -6.684719</span>Clongowes, that you could always <br>
           tell a jesuit by the style of his clothes. At the same moment he <br>
-          thought he saw a likeness between his father's mind and that of <span class="tag lineNumber">20875</span><br>
+          thought he saw a likeness between his father's mind and that of <br>
           this smiling welldressed priest: and he was aware of some des- <br>
           ecration of the priest's office or of the vestry itself, whose si- <br>
           lence was now routed by loud talk and joking and its air <br>
           pungent with the smells of the gasjets and the grease.<br> </p>
-          <p class="textParagraph">  While his forehead was being wrinkled and his jaws painted <span class="tag lineNumber">20880</span><br>
+          <p class="textParagraph">  While his forehead was being wrinkled and his jaws painted <span class="tag lineNumber">880</span><br>
           black and blue by the elderly man he listened distractedly to the <br>
           voice of the plump young jesuit which bade him speak up and <br>
           make his points clearly. He could hear the band playing <span class="emph">The <br>
           Lily of Killarney</span> and knew that in a few moments the curtain <br>
-          would go up. He felt no stage fright but the thought of the part <span class="tag lineNumber">20885</span><br>
+          would go up. He felt no stage fright but the thought of the part <br>
           he had to play humiliated him. A remembrance  of some of his <br>
           lines made a sudden flush rise to his painted cheeks. He saw her <br>
           serious alluring eyes watching him from among the audience <br>
           and their image at once swept away his scruples, leaving his <br>
-          will compact. Another nature seemed to have been lent him: <span class="tag lineNumber">20890</span><br>
+          will compact. Another nature seemed to have been lent him: <span class="tag lineNumber">890</span><br>
           the infection of the excitement and youth about him entered <br>
           into and transformed his moody mistrustfulness. For one rare <br>
           moment he seemed to be clothed in the real apparel of boy- <br>
           hood: and, as he stood in the wings among the other players, he <br>
-          shared the common mirth amid which the drop scene was <span class="tag lineNumber">20895</span><br>
+          shared the common mirth amid which the drop scene was <br>
           hauled upwards by two ablebodied priests with violent jerks <br>
           and all awry.<br> </p>
           <p class="textParagraph">  A few moments after he found himself on the stage amid the <br>
           garish gas and the dim scenery, acting before the innumerable <br>
-          faces of the void. It surprised him to see that the play which he <span class="tag lineNumber">20900</span><br>
+          faces of the void. It surprised him to see that the play which he <span class="tag lineNumber">900</span><br>
           had known at rehearsals for a disjointed lifeless thing had <br>
           suddenly assumed a life of its own. It seemed now to play itself, <br>
           he and his fellow actors aiding it with their parts. When the <br>
           curtain fell on the last scene he heard the void filled with <br>
-          applause and, through a rift in the side scene, saw the simple <span class="tag lineNumber">20905</span><br>
+          applause and, through a rift in the side scene, saw the simple <br>
           body before which he had acted magically deformed, the void <br>
           of faces breaking at all points and falling asunder into busy <br>
           groups.<br> </p>
           <p class="textParagraph">  He left the stage quickly and rid himself of his mummery <br>
-          and passed out through the chapel into the college garden. <span class="tag lineNumber">20910</span><br>
+          and passed out through the chapel into the college garden. <span class="tag lineNumber">910</span><br>
           Now that the play was over his nerves cried for some further <br>
           adventure. He hurried onwards as if to overtake it. The doors <br>
           of the theatre were all open and the audience had emptied out. <br>
           On the lines which he had fancied the moorings of an ark a few <br>
-          lanterns swung in the night breeze, flickering cheerlessly. He <span class="tag lineNumber">20915</span><br>
+          lanterns swung in the night breeze, flickering cheerlessly. He <br>
           mounted the steps from the garden in haste, eager that some <br>
           prey should not elude him, and forced his way through the <br>
           crowd in the hall and past the two jesuits who stood watching <br>
           the exodus and bowing and shaking hands with the visitors. He <br>
-          pushed onward nervously, feigning a still greater haste and <span class="tag lineNumber">20920</span><br>
+          pushed onward nervously, feigning a still greater haste and <span class="tag lineNumber">920</span><br>
           faintly conscious of the smiles and stares and nudges which his <br>
           powdered head left in its wake.<br> </p>
           <p class="textParagraph">  When he came out on the steps he saw his family waiting for <br>
           him at the first lamp. In a glance he noted that every figure of <br>
-          the group was familiar and ran down the steps angrily. <span class="tag lineNumber">20925</span><br></p>
+          the group was familiar and ran down the steps angrily. <br></p>
           <p class="textParagraph"><p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I have to leave a message down in George's Street,</p> he said to <br>
           his father quickly. <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>I'll be home after you. <br></p></p>
           <p class="textParagraph">  Without waiting for his father's questions  he ran across the <br>
           road and began to walk at breakneck speed down the hill. He <br>
-          hardly knew where he was walking. Pride and hope and desire <span class="tag lineNumber">20930</span><br>
+          hardly knew where he was walking. Pride and hope and desire <span class="tag lineNumber">930</span><br>
           like crushed herbs in his heart sent up vapours of maddening <br>
           incense before the eyes of his mind. He strode down the hill <br>
           amid the tumult of suddenrisen vapours of wounded pride and <br>
           fallen hope and baffled desire. They streamed upwards before <br>
-          his anguished eyes in dense and maddening fumes and passed <span class="tag lineNumber">20935</span><br>
+          his anguished eyes in dense and maddening fumes and passed <br>
           away above him till at last the air was clear and cold again.<br> </p>
           <p class="textParagraph">  A film still veiled his eyes but they burned no longer. A <br>
           power, akin to that which had often made anger or resentment <br>
           fall from him, brought his steps to rest. He stood still and <br>
-          gazed up at the sombre porch of the morgue and from that to <span class="tag lineNumber">20940</span><br>
+          gazed up at the sombre porch of the morgue and from that to <span class="tag lineNumber">940</span><br>
           the dark cobbled laneway at its side. He saw the word <span class="emph">Lotts</span> on <br>
           the wall of the lane and breathed slowly the rank heavy air.<br> </p>
           <p class="textParagraph"> ―That is horse piss and rotted straw, he thought. It is a good <br>
           odour to breathe. It will calm my heart. My heart is quite calm <br>
-          now. I will go back.<span class="tag lineNumber">20945</span><br> </p>
+          now. I will go back.<br> </p>
       <div class="divider">* * *</div> 
         
       
@@ -2992,64 +2992,64 @@
           of a railway carriage at Kingsbridge. He was travelling with his <br>
           father by the night mail to Cork. As the train steamed out of <br>
           the station he recalled his childish wonder of years before and <br>
-          every event of his first day at <span class="hide">53.310770, -6.684719</span>Clongowes. But he felt no wonder <span class="tag lineNumber">20950</span><br>
+          every event of his first day at <span class="hide">53.310770, -6.684719</span>Clongowes. But he felt no wonder <span class="tag lineNumber">950</span><br>
           now. He saw the darkening lands slipping past him, the silent <br>
           telegraphpoles passing his window swiftly every four seconds, <br>
           the little glimmering stations, manned by a few silent sentries, <br>
           flung by the mail behind her and twinkling for a moment in the <br>
-          darkness like fiery grains flung backwards by a runner.<span class="tag lineNumber">20955</span><br> </p>
+          darkness like fiery grains flung backwards by a runner.<br> </p>
           <p class="textParagraph">  He listened without sympathy to his father's evocation of <br>
           Cork and of scenes of his youth, a tale broken by sighs or <br>
           draughts from his pocket flask whenever the image of some <br>
           dead friend appeared in it or whenever the evoker remembered <br>
-          suddenly the purpose of his actual visit. Stephen heard but <span class="tag lineNumber">20960</span><br>
+          suddenly the purpose of his actual visit. Stephen heard but <span class="tag lineNumber">960</span><br>
           could feel no pity. The images of the dead were all strange to <br>
           him save that of uncle Charles, an image which had lately been <br>
           fading out of memory. He knew, however, that his father's <br>
           property was going to be sold by auction and in the manner of <br>
-          his own dispossession he felt the world give the lie rudely to his <span class="tag lineNumber">20965</span><br>
+          his own dispossession he felt the world give the lie rudely to his <br>
           phantasy.<br> </p>
           <p class="textParagraph">  At Maryborough he fell asleep. When he awoke the train <br>
           had passed out of Mallow and his father was stretched asleep <br>
           on the other seat. The cold light of the dawn lay over the <br>
-          country, over the unpeopled fields and the closed cottages. The <span class="tag lineNumber">20970</span><br>
+          country, over the unpeopled fields and the closed cottages. The <span class="tag lineNumber">970</span><br>
           terror of sleep fascinated his mind as he watched the silent <br>
           country or heard from time to time his father's deep breath or <br>
           sudden sleepy movement. The neighbourhood of unseen <br>
           sleepers filled him with strange dread as though they could <br>
-          harm him; and he prayed that the day might come quickly. His <span class="tag lineNumber">20975</span><br>
+          harm him; and he prayed that the day might come quickly. His <br>
           prayer, addressed neither to God nor saint, began with a shiver, <br>
           as the chilly morning breeze crept through the chink of the <br>
           carriage door to his feet, and ended in a trail of foolish words <br>
           which he made to fit the insistent rhythm of the train: and <br>
-          silently, at intervals of four seconds, the telegraphpoles held the <span class="tag lineNumber">20980</span><br>
+          silently, at intervals of four seconds, the telegraphpoles held the <span class="tag lineNumber">980</span><br>
           galloping notes of the music between punctual bars. This furi- <br>
           ous music allayed his dread and, leaning against the window- <br>
           ledge, he let his eyelids close again.<br> </p>
           <p class="textParagraph">  They drove in a jingle across Cork while it was still early <br>
-          morning and Stephen finished his sleep in a bedroom of the <span class="tag lineNumber">20985</span><br>
+          morning and Stephen finished his sleep in a bedroom of the <br>
           Victoria Hotel. The bright warm sunlight was streaming <br>
           through the window and he could hear the din of traffic. His <br>
           father was standing before the dressingtable, examining his <br>
           hair and face and moustache with great care, craning his neck <br>
-          across the waterjug and drawing it back sideways to see the <span class="tag lineNumber">20990</span><br>
+          across the waterjug and drawing it back sideways to see the <span class="tag lineNumber">990</span><br>
           better. While he did so he sang softly to himself with quaint <br>
           accent and phrasing: <br>
           <p class="dialog"><span class="tag dialog">Simon Dedalus</span>
             <p class="lg">
                'Tis youth and folly  <br>
               Makes young men marry,  <br>
-              So here, my love, I'll  <span class="tag lineNumber">20995</span><br>
+              So here, my love, I'll  <br>
               No longer stay. <br>
               What can't be cured, sure,  <br>
               Must be injured, sure,  <br>
               So I'll go to  <br>
-              Amerikay. <span class="tag lineNumber">21000</span><br>
+              Amerikay. <span class="tag lineNumber">1000</span><br>
               My love she's handsome,  <br>
               My love she's boney:  <br>
               She's like good whisky  <br>
               When it is new; <br>
-              But when 'tis old  <span class="tag lineNumber">21005</span><br>
+              But when 'tis old  <br>
               And growing cold  <br>
               It fades and dies like  <br>
               The mountain dew. <br>
@@ -3057,274 +3057,274 @@
           </p>
           </p>
           <p class="textParagraph">  The consciousness of the warm sunny city outside his win- <br>
-          dow and the tender tremors with which his father's voice <span class="tag lineNumber">21010</span><br>
+          dow and the tender tremors with which his father's voice <span class="tag lineNumber">1010</span><br>
           festooned the strange sad happy air drove off all the mists of <br>
           the night's ill humour from Stephen's brain. He got up quickly <br>
           to dress and, when the song had ended, said: <br>
            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―That's much prettier than any of your other <span class="emph">come-all-yous</span>. <br> </p>
-           <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Do you think so? asked Mr Dedalus. <span class="tag lineNumber">21015</span><br> </p>
+           <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Do you think so? asked Mr Dedalus. <br> </p>
            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I like it, said Stephen. <br> </p>
            <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―It's a pretty old air, said Mr Dedalus, twirling the points of <br>
           his moustache. Ah, but you should have heard Mick Lacy sing <br>
           it! Poor Mick Lacy! He had little turns for it, grace notes he <br>
-          used to put in that I haven't got. That was the boy }omit{ could sing a <span class="tag lineNumber">21020</span><br>
+          used to put in that I haven't got. That was the boy }omit{ could sing a <span class="tag lineNumber">1020</span><br>
           <span class="emph">come-all-you</span>, if you like. <br></p> </p>
           <p class="textParagraph">  Mr Dedalus had ordered drisheens for breakfast and during <br>
           the meal he crossexamined the waiter for local news. For the <br>
           most part they spoke at cross purposes when a name was <br>
-          mentioned, the waiter having in mind its present holder and Mr <span class="tag lineNumber">21025</span><br>
+          mentioned, the waiter having in mind its present holder and Mr <br>
           Dedalus his father or perhaps his grandfather. <br>
            <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Well, I hope they haven't moved the Queen's College any- <br>
           how, said Mr Dedalus, for I want to show it to this youngster <br>
           of mine. <br></p> </p>
-          <p class="textParagraph">  Along the Mardyke the trees were in bloom. They entered <span class="tag lineNumber">21030</span><br>
+          <p class="textParagraph">  Along the Mardyke the trees were in bloom. They entered <span class="tag lineNumber">1030</span><br>
           the grounds of the college and were led by the garrulous porter <br>
           across the quadrangle. But their progress across the gravel was <br>
           brought to a halt after  every dozen or so paces by some reply of <br>
           the porter's. <br>
-           <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Ah, do you tell me so? And is poor Pottlebelly dead? <span class="tag lineNumber">21035</span><br> </p>
+           <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Ah, do you tell me so? And is poor Pottlebelly dead? <br> </p>
            <p class="dialog"><span class="tag dialog">porter</span>―Yes, sir. Dead, sir. <br></p> </p>
           <p class="textParagraph">  During these halts Stephen stood awkwardly behind the two <br>
           men, weary of the subject and waiting restlessly for the slow <br>
           march to begin again. By the time they had crossed the quad- <br>
-          rangle his restlessness had risen to fever. He wondered how his <span class="tag lineNumber">21040</span><br>
+          rangle his restlessness had risen to fever. He wondered how his <span class="tag lineNumber">1040</span><br>
           father, whom he knew for a shrewd suspicious man, could be <br>
           duped by the servile manners of the porter: and the lively <br>
           southern speech which had entertained him all the morning <br>
           now irritated his ears.<br> </p>
-          <p class="textParagraph">  They passed into the anatomy theatre where Mr Dedalus, <span class="tag lineNumber">21045</span><br>
+          <p class="textParagraph">  They passed into the anatomy theatre where Mr Dedalus, <br>
           the porter aiding him, searched the desks for his initials. Ste- <br>
           phen remained in the background, depressed more than ever by <br>
           the darkness and silence of the theatre and by the air it wore of <br>
           jaded and formal study. On the desk before him he read the <br>
-          word <span class="emph">Foetus</span>  cut several times in the dark stained wood. The <span class="tag lineNumber">21050</span><br>
+          word <span class="emph">Foetus</span>  cut several times in the dark stained wood. The <span class="tag lineNumber">1050</span><br>
           sudden legend startled his blood: he seemed to feel the absent <br>
           students of the college about him and to shrink from their <br>
           company. A vision of their life, which his father's words had <br>
           been powerless to evoke, sprang up before him out of the word <br>
-          cut in the desk. A broadshouldered student with a moustache <span class="tag lineNumber">21055</span><br>
+          cut in the desk. A broadshouldered student with a moustache <br>
           was cutting in the letters with a jackknife, seriously. Other <br>
           students stood or sat near him laughing at his handiwork. One <br>
           jogged his elbow. The big student turned on him, frowning. He <br>
           was dressed in loose grey clothes and had tan boots.<br> </p>
-          <p class="textParagraph">  Stephen's name was called. He hurried down the steps of the <span class="tag lineNumber">21060</span><br>
+          <p class="textParagraph">  Stephen's name was called. He hurried down the steps of the <span class="tag lineNumber">1060</span><br>
           theatre so as to be as far away from the vision as he could be <br>
           and, peering closely at his father's initials, hid his flushed face.<br> </p>
           <p class="textParagraph">  But the word and the vision capered before his eyes as he <br>
           walked back across the quadrangle and towards the college <br>
-          gate. It shocked him to find in the outer world a trace of what <span class="tag lineNumber">21065</span><br>
+          gate. It shocked him to find in the outer world a trace of what <br>
           he had deemed till then a brutish and individual malady of his <br>
           own mind. His recent monstrous reveries came thronging into <br>
           his memory. They too had sprung up before him, suddenly and <br>
           furiously, out of mere words. He had soon given in to them and <br>
-          allowed them to sweep across and abase his intellect, wonder- <span class="tag lineNumber">21070</span><br>
+          allowed them to sweep across and abase his intellect, wonder- <span class="tag lineNumber">1070</span><br>
           ing always where they came from, from what den of monstrous <br>
           images, and always weak and humble towards others, restless <br>
           and sickened of himself when they had swept over him. <br>
            <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Ay, bedad! And there's the Groceries sure enough! cried Mr <br>
-          Dedalus. You often heard me speak of the Groceries, didn't <span class="tag lineNumber">21075</span><br>
+          Dedalus. You often heard me speak of the Groceries, didn't <br>
           you, Stephen. Many's the time we went down there when our <br>
           names had been marked, a crowd of us, Harry Peard and little <br>
           Jack Mountain and Bob Dyas and Maurice Moriarty, the <br>
           Frenchman, and Tom O'Grady and Mick Lacy that I told you <br>
-          of this morning and Joey Corbet and poor little goodhearted <span class="tag lineNumber">21080</span><br>
+          of this morning and Joey Corbet and poor little goodhearted <span class="tag lineNumber">1080</span><br>
           Johnny Keevers of the Tantiles. <br></p> </p>
           <p class="textParagraph">  The leaves of the trees along the Mardyke were astir and <br>
           whispering in the sunlight. A team of cricketers passed, agile <br>
           young men in flannels and blazers, one of them carrying the <br>
-          long green wicketbag. In a quiet bystreet a German band of five <span class="tag lineNumber">21085</span><br>
+          long green wicketbag. In a quiet bystreet a German band of five <br>
           players in faded uniforms and with battered brass instruments <br>
           was playing to an audience of street arabs and leisurely mess- <br>
           enger boys. A maid in a white cap and apron was watering a <br>
           box of plants on a sill which shone like a slab of limestone in <br>
-          the warm glare. From another window open to the air came the <span class="tag lineNumber">21090</span><br>
+          the warm glare. From another window open to the air came the <span class="tag lineNumber">1090</span><br>
           sound of a piano, scale after scale rising into the treble.<br> </p>
           <p class="textParagraph">  Stephen walked on at his father's side, listening to stories he <br>
           had heard before, hearing again the names of the scattered and <br>
           dead revellers who had been the companions of his father's <br>
-          youth. And a faint sickness sighed in his heart. He recalled his <span class="tag lineNumber">21095</span><br>
+          youth. And a faint sickness sighed in his heart. He recalled his <br>
           own equivocal position in Belvedere, a free boy, a leader afraid <br>
           of his own authority, proud and sensitive and suspicious, bat- <br>
           tling against the squalor of his life and against the riot of his <br>
           mind. The letters cut in the stained wood of the desk stared <br>
-          upon him, mocking his bodily weakness and futile enthusiasms <span class="tag lineNumber">21100</span><br>
+          upon him, mocking his bodily weakness and futile enthusiasms <span class="tag lineNumber">1100</span><br>
           and making him loathe himself for his own mad and filthy <br>
           orgies. The spittle in his throat grew bitter and foul to swallow <br>
           and the faint sickness climbed to his brain so that for a moment <br>
           he closed his eyes and walked on in darkness.<br> </p>
-          <p class="textParagraph">  He could still hear his father's voice. <span class="tag lineNumber">21105</span><br>
+          <p class="textParagraph">  He could still hear his father's voice. <br>
            <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―When you kick out for yourself, Stephen, }omit{ (as I daresay you <br>
           will one of those days) }omit{ remember, whatever you do, to mix <br>
           with gentlemen. When I was a young fellow I tell you I enjoyed <br>
           myself. I mixed with fine decent fellows. Everyone of us could <br>
-          do something. One fellow had a good voice, another fellow <span class="tag lineNumber">21110</span><br>
+          do something. One fellow had a good voice, another fellow <span class="tag lineNumber">1110</span><br>
           was a good actor, another could sing a good comic song, an- <br>
           other was a good oarsman or a good racketplayer, another <br>
           could tell a good story and so on. We kept the ball rolling <br>
           anyhow and enjoyed ourselves and saw a bit of life and we <br>
-          were none the worse of it either. But we were all gentlemen, <span class="tag lineNumber">21115</span><br>
+          were none the worse of it either. But we were all gentlemen, <br>
           Stephen, (at least I hope we were) }omit{ and bloody good honest <br>
           Irishmen too. That's the kind of fellows I want you to associate <br>
           with, fellows of the right kidney. I'm talking to you as a friend, <br>
           Stephen. I don't believe in playing the stern father. I don't <br>
-          believe a son should be afraid of his father. No, I treat you as <span class="tag lineNumber">21120</span><br>
+          believe a son should be afraid of his father. No, I treat you as <span class="tag lineNumber">1120</span><br>
           your grandfather treated me when I was a young chap. We <br>
           were more like brothers than father and son. I'll never forget <br>
           the first day he caught me smoking. I was standing at the end <br>
           of the South Terrace one day with some maneens like myself <br>
-          and sure we thought we were grand fellows because we had <span class="tag lineNumber">21125</span><br>
+          and sure we thought we were grand fellows because we had <br>
           pipes stuck in the corners of our mouths. Suddenly the gov- <br>
           ernor passed. He didn't say a word or stop even. But the next <br>
           day, Sunday, we were out for a walk together and when we <br>
           were coming home he took out his cigar case and said: <span class="emph">By the <br>
-          bye, Simon, I didn't know you smoked:</span> or something like that. <span class="tag lineNumber">21130</span><br>
+          bye, Simon, I didn't know you smoked:</span> or something like that. <span class="tag lineNumber">1130</span><br>
           – Of course I tried to carry it off as best I could. <span class="emph">If you want a <br>
           good smoke</span>, he said, <span class="emph">try one of these cigars. An American <br>
           captain made me a present of them last night in Queenstown</span>. <br></p> </p>
           <p class="textParagraph">  Stephen heard his father's voice break into a laugh which <br>
-          was almost a sob. <span class="tag lineNumber">21135</span><br>
+          was almost a sob. <br>
            <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―He was the handsomest man in Cork at that time, by God he <br>
           was! The women used to stand to look after him in the street. <br></p> </p>
           <p class="textParagraph">  He heard the sob passing loudly down his father's throat <br>
           and opened his eyes with a nervous impulse. The sunlight <br>
-          breaking suddenly on his sight turned the sky and clouds into a <span class="tag lineNumber">21140</span><br>
+          breaking suddenly on his sight turned the sky and clouds into a <span class="tag lineNumber">1140</span><br>
           fantastic world of sombre masses with lakelike spaces of dark <br>
           rosy light. His very brain was sick and powerless. He could <br>
           scarcely interpret the letters of the signboards of the shops. By <br>
           his monstrous way of life he seemed to have put himself be- <br>
-          yond the limits of reality. Nothing moved him or spoke to him <span class="tag lineNumber">21145</span><br>
+          yond the limits of reality. Nothing moved him or spoke to him <br>
           from the real world unless he heard in it an echo of the <br>
           infuriated cries within him. He could respond to no earthly or <br>
           human appeal, dumb and insensible to the call of summer and <br>
           gladness and companionship, wearied and dejected by his fa- <br>
-          ther's voice. He could scarcely recognise as his his own <span class="tag lineNumber">21150</span><br>
+          ther's voice. He could scarcely recognise as his his own <span class="tag lineNumber">1150</span><br>
           thoughts, and repeated slowly to himself:<br> </p>
           <p class="textParagraph"> ―I am Stephen Dedalus. I am walking beside my father whose <br>
           name is Simon Dedalus. We are in Cork, in Ireland. Cork is a <br>
           city. Our room is in the Victoria Hotel. Victoria and Stephen <br>
-          and Simon. Simon and Stephen and Victoria. Names.<span class="tag lineNumber">21155</span><br> </p>
+          and Simon. Simon and Stephen and Victoria. Names.<br> </p>
           <p class="textParagraph">  The memory of his childhood suddenly grew dim. He tried <br>
           to call forth some of its vivid moments but could not. He <br>
           recalled only names: Dante, Parnell, Clane, <span class="hide">53.310770, -6.684719</span>Clongowes. A little <br>
           boy had been taught geography by an old woman who kept <br>
-          two brushes in her wardrobe. Then he had been sent away <span class="tag lineNumber">21160</span><br>
+          two brushes in her wardrobe. Then he had been sent away <span class="tag lineNumber">1160</span><br>
           from home to a college. In the college he had made his first <br>
           communion and eaten slim jim out of his cricket cap and <br>
           watched the firelight leaping and dancing on the wall of a little <br>
           bedroom in the infirmary and dreamed of being dead, of mass <br>
-          being said for him by the rector in a black and gold cope, of <span class="tag lineNumber">21165</span><br>
+          being said for him by the rector in a black and gold cope, of <br>
           being buried then in the little graveyard of the community off <br>
           the main avenue of limes. But he had not died then. Parnell had <br>
           died. There had been no mass for the dead in the chapel and no <br>
           procession. He had not died but he had faded out like a film in <br>
-          the sun. He had been lost or had wandered out of existence for <span class="tag lineNumber">21170</span><br>
+          the sun. He had been lost or had wandered out of existence for <span class="tag lineNumber">1170</span><br>
           he no longer existed. How strange to think of him passing out <br>
           of existence in such a way, not by death but by fading out in <br>
           the sun or by being lost and forgotten somewhere in the uni- <br>
           verse! It was strange to see his small body appear again for a <br>
-          moment: a little boy in a grey belted suit. His hands were in his <span class="tag lineNumber">21175</span><br>
+          moment: a little boy in a grey belted suit. His hands were in his <br>
           sidepockets and his trousers were tucked in at the  knees by <br>
           elastic bands.<br> </p>
           <p class="textParagraph">  On the evening of the day on which the property was sold <br>
           Stephen followed his father meekly about the city from bar to <br>
-          bar. To the sellers in the market, to the barmen and barmaids, <span class="tag lineNumber">21180</span><br>
+          bar. To the sellers in the market, to the barmen and barmaids, <span class="tag lineNumber">1180</span><br>
           to the beggars who importuned him for a lob Mr Dedalus told <br>
           the same tale, that he was an old Corkonian, that he had been <br>
           trying for thirty years to get rid of his Cork accent up in Dublin <br>
           and that Peter Pickackafox beside him was his eldest son but <br>
-          that he was only a Dublin jackeen.<span class="tag lineNumber">21185</span><br> </p>
+          that he was only a Dublin jackeen.<br> </p>
           <p class="textParagraph">  They had set out early in the morning from Newcombe's <br>
           coffeehouse where Mr Dedalus' cup had rattled noisily against <br>
           its saucer and Stephen had tried to cover that shameful sign of <br>
           his father's drinkingbout of the night before by moving his <br>
-          chair and coughing. One humiliation had succeeded another: <span class="tag lineNumber">21190</span><br>
+          chair and coughing. One humiliation had succeeded another: <span class="tag lineNumber">1190</span><br>
           the false smiles of the market sellers, the curvettings and <br>
           oglings of the barmaids with whom his father flirted, the com- <br>
           pliments and encouraging words of his father's friends. They <br>
           had told him that he had a great look of his grandfather and <br>
-          Mr Dedalus had agreed that he was an ugly likeness. They had <span class="tag lineNumber">21195</span><br>
+          Mr Dedalus had agreed that he was an ugly likeness. They had <br>
           unearthed traces of a Cork accent in his speech and made him <br>
           admit that the Lee was a much finer river than the Liffey. One <br>
           of them in order to put his Latin to the proof had made him <br>
           translate short passages from Dilectus and asked him whether <br>
-          it was correct to say: Tempora mutantur nos et mutamur in illis <span class="tag lineNumber">21200</span><br>
+          it was correct to say: Tempora mutantur nos et mutamur in illis <span class="tag lineNumber">1200</span><br>
           or Tempora mutantur et nos mutamur in illis. Another, a brisk <br>
           old man, whom Mr Dedalus called Johnny Cashman, had <br>
           covered him with confusion by asking him to say which were <br>
           prettier, the Dublin girls or the Cork girls. <br>
-           <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―He's not that way built, said Mr Dedalus. Leave him alone. <span class="tag lineNumber">21205</span><br>
+           <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―He's not that way built, said Mr Dedalus. Leave him alone. <br>
           He's a levelheaded thinking boy who doesn't bother his head <br>
           about that kind of nonsense. <br> </p>
            <p class="dialog"><span class="tag dialog">little old man</span>―Then he's not his father's son, said the little old man. <br> </p>
            <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―I don't know, I'm sure, said Mr Dedalus, smiling com- <br>
-          placently.<span class="tag lineNumber">21210</span><br> </p>
+          placently.<span class="tag lineNumber">1210</span><br> </p>
            <p class="dialog"><span class="tag dialog">little old man</span>―Your father, said the little old man to Stephen, was the <br>
           boldest flirt in the city of Cork in his day. Do you know that? <br></p> </p>
           <p class="textParagraph">  Stephen looked down and studied the tiled floor of the bar <br>
           into which they had drifted. <br>
-           <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Now don't be putting ideas into his head, said Mr Dedalus. <span class="tag lineNumber">21215</span><br>
+           <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Now don't be putting ideas into his head, said Mr Dedalus. <br>
           Leave him to his Maker. <br> </p>
            <p class="dialog"><span class="tag dialog">little old man</span>―Yerra, sure I wouldn't put any ideas into his head. I'm old <br>
           enough to be his grandfather. And I am a grandfather, said the <br>
           little old man to Stephen. Do you know that? <br> </p>
-           <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Are you? asked Stephen. <span class="tag lineNumber">21220</span><br> </p>
+           <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Are you? asked Stephen. <span class="tag lineNumber">1220</span><br> </p>
            <p class="dialog"><span class="tag dialog">little old man</span>―Bedad I am, said the little old man. I have two bouncing <br>
           grandchildren out at Sunday's Well. Now then! What age do <br>
           you think I am? And I remember seeing your grandfather in his <br>
           red coat riding out to hounds. That was before you were born. <br> </p>
-           <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Ay, or thought of, said Mr Dedalus. <span class="tag lineNumber">21225</span><br> </p>
+           <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Ay, or thought of, said Mr Dedalus. <br> </p>
            <p class="dialog"><span class="tag dialog">little old man</span>―Bedad I did! repeated the little old man. And, more than <br>
           that, I can remember even your greatgrandfather, old John Ste- <br>
           phen Dedalus, and a fierce old fireeater he was. Now then! <br>
           There's a memory for you! <br> </p>
-           <p class="dialog"><span class="tag dialog">another of the company</span>―That's three generations - four generations, said another of <span class="tag lineNumber">21230</span><br>
+           <p class="dialog"><span class="tag dialog">another of the company</span>―That's three generations - four generations, said another of <span class="tag lineNumber">1230</span><br>
           the company. Why, Johnny Cashman, you must be nearing the <br>
           century.<br> </p>
            <p class="dialog"><span class="tag dialog">little old man</span>―Well, I'll tell you the truth, said the little old man. I'm just <br>
           twentyseven years of age. <br> </p>
-           <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―We're as old as we feel, Johnny, said Mr Dedalus. And just <span class="tag lineNumber">21235</span><br>
+           <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―We're as old as we feel, Johnny, said Mr Dedalus. And just <br>
           finish what you have there and we'll have another. Here, Tim <br>
           or Tom or whatever your name is, give us the same again here. <br>
           By God, I don't feel more than eighteen myself. There's that <br>
           son of mine there not half my age and I'm a better man than he <br>
-          is any day of the week. <span class="tag lineNumber">21240</span><br> </p>
+          is any day of the week. <span class="tag lineNumber">1240</span><br> </p>
            <p class="dialog"><span class="tag dialog">another of the company</span>―Draw it mild now, Dedalus. I think it's about time for you to <br>
           take a back seat, said the gentleman who had spoken before. <br> </p>
            <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―No, by God! asserted Mr Dedalus. I'll sing a tenor song <br>
           against him or I'll vault a fivebarred gate against him or I'll run <br>
-          with him after the hounds across the country as I did thirty <span class="tag lineNumber">21245</span><br>
+          with him after the hounds across the country as I did thirty <br>
           years ago along with the Kerry Boy and the best man for it. <br> </p>
            <p class="dialog"><span class="tag dialog">little old man</span>―But he'll beat you here, said the little old man, tapping his <br>
           forehead and raising his glass to drain it. <br> </p>
            <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Well, I hope he'll be as good a man as his father. That's all I <br>
-          can say, said Mr Dedalus. <span class="tag lineNumber">21250</span><br> </p>
+          can say, said Mr Dedalus. <span class="tag lineNumber">1250</span><br> </p>
            <p class="dialog"><span class="tag dialog">little old man</span>―If he is, he'll do, said the little old man. <br> </p>
            <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―And thanks be to God, Johnny, said Mr Dedalus, that we <br>
           lived so long and did so little harm. <br> </p>
            <p class="dialog"><span class="tag dialog">little old man</span>―But did so much good, Simon, said the little old man <br>
-          gravely. Thanks be to God we lived so long and did so much <span class="tag lineNumber">21255</span><br>
+          gravely. Thanks be to God we lived so long and did so much <br>
           good.<br></p> </p>
           <p class="textParagraph">  Stephen watched the three glasses being raised from the <br>
           counter as his father and his two cronies drank to the memory <br>
           of their past. An abyss of fortune or of temperament sundered <br>
-          him from them. His mind seemed older than theirs: it shone <span class="tag lineNumber">21260</span><br>
+          him from them. His mind seemed older than theirs: it shone <span class="tag lineNumber">1260</span><br>
           coldly on their strifes and happiness and regrets like a moon <br>
           upon a younger earth. No life or youth stirred in him as it had <br>
           stirred in them. He had known neither the pleasure of compan- <br>
           ionship with others nor the vigour of rude male health nor filial <br>
-          piety. Nothing stirred within his soul but a cold and cruel and <span class="tag lineNumber">21265</span><br>
+          piety. Nothing stirred within his soul but a cold and cruel and <br>
           loveless lust. His childhood was dead or lost and with it his <br>
           soul capable of simple joys: and he was drifting amid life like <br>
           the barren shell of the moon.<br> </p>
           <p class="lg">
              Art thou pale for weariness  <br>
-             Of climbing heaven and gazing on the earth  <span class="tag lineNumber">21270</span><br>
+             Of climbing heaven and gazing on the earth  <span class="tag lineNumber">1270</span><br>
              Wandering companionless ....? <br>
           </p>
           <p class="textParagraph">  He repeated to himself the lines of Shelley's fragment. Its <br>
           alternation of sad human ineffectiveness with vast inhuman <br>
           cycles of activity chilled him: and he forgot his own human and <br>
-          ineffectual grieving.<span class="tag lineNumber">21275</span><br> </p>
+          ineffectual grieving.<br> </p>
           <div class="divider">* * *</div>
          
         
@@ -3332,182 +3332,182 @@
           waited at the corner of quiet Foster Place while he and his <br>
           father went up the steps and along the colonnade where the <br>
           highland sentry was parading. When they had passed into the <br>
-          great hall and stood at the counter Stephen drew forth his <span class="tag lineNumber">21280</span><br>
+          great hall and stood at the counter Stephen drew forth his <span class="tag lineNumber">1280</span><br>
           orders on the governor of the bank of Ireland for thirty and <br>
           three pounds; and these sums, the moneys of his exhibition and <br>
           essay prize, were paid over to him rapidly by the teller in notes <br>
           and in coin respectively. He bestowed them in his pockets with <br>
-          feigned composure and suffered the friendly teller, to whom his <span class="tag lineNumber">21285</span><br>
+          feigned composure and suffered the friendly teller, to whom his <br>
           father chatted, to take his hand across the broad counter and <br>
           wish him a brilliant career in after life. He was impatient of <br>
           their voices and could not keep his feet at rest. But the teller <br>
           still deferred the serving of others to say that he was living in <br>
-          changed times and that there was nothing like giving a boy the <span class="tag lineNumber">21290</span><br>
+          changed times and that there was nothing like giving a boy the <span class="tag lineNumber">1290</span><br>
           best education that money could buy. Mr Dedalus lingered in <br>
           the hall gazing about him and up at the roof and telling Ste- <br>
           phen, who urged him to come out, that they were standing in <br>
           the house of commons of the old Irish parliament. <br>
-          <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―God help us!</p> he said piously. <p class="dialog"><span class="tag dialog">Simon Dedalus</span>To think of the men of those <span class="tag lineNumber">21295</span><br>
+          <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―God help us!</p> he said piously. <p class="dialog"><span class="tag dialog">Simon Dedalus</span>To think of the men of those <br>
           times, Stephen, Hely Hutchinson and Flood and Henry Grattan <br>
           and Charles Kendal Bushe, and the noblemen we have now, <br>
           leaders of the Irish people at home and abroad. Why, by God, <br>
           they wouldn't be seen dead in a ten acre field with them. No, <br>
-          Stephen, old chap, I'm sorry to say that they are only as I roved <span class="tag lineNumber">21300</span><br>
+          Stephen, old chap, I'm sorry to say that they are only as I roved <span class="tag lineNumber">1300</span><br>
           out one fine May morning in the merry month of sweet July. <br></p> </p>
           <p class="textParagraph">  A keen October wind was blowing round the bank. The <br>
           three figures standing at the edge of the muddy path had <br>
           pinched cheeks and watery eyes. Stephen looked at his thinly <br>
-          clad mother and remembered that a few days before he had <span class="tag lineNumber">21305</span><br>
+          clad mother and remembered that a few days before he had <br>
           seen a mantle priced at twenty guineas in the window of Bar- <br>
           nardo's. <br>
            <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Well that's done, said Mr Dedalus. <br> </p>
            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―We had better go to dinner, said Stephen. Where? <br> </p>
-           <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Dinner? said Mr Dedalus. Well, I suppose we had better, <span class="tag lineNumber">21310</span><br>
+           <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Dinner? said Mr Dedalus. Well, I suppose we had better, <span class="tag lineNumber">1310</span><br>
           what?<br> </p>
            <p class="dialog"><span class="tag dialog">Mary Dedalus</span>―Some place that's not too dear, said Mrs Dedalus. <br> </p>
            <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Underdone's?<br> </p>
            <p class="dialog"><span class="tag dialog">Mary Dedalus</span>―Yes. Some quiet place. <br> </p>
-           <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Come along, said Stephen quickly. It doesn't matter about <span class="tag lineNumber">21315</span><br>
+           <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Come along, said Stephen quickly. It doesn't matter about <br>
           the dearness. <br></p> </p>
           <p class="textParagraph">  He walked on before them with short nervous steps, smiling. <br>
           They tried to keep up with him, smiling also at his eagerness. <br>
            <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Take it easy like a good young fellow, said his father. We're <br>
-          not out for the half mile, are we? <span class="tag lineNumber">21320</span><br></p> </p>
+          not out for the half mile, are we? <span class="tag lineNumber">1320</span><br></p> </p>
           <p class="textParagraph">  For a swift season of merrymaking the money of his prizes <br>
           ran through Stephen's  fingers. Great parcels of groceries and <br>
           delicacies and dried fruits arrived from the city. Every day he <br>
           drew up a bill of fare for the family and every night led a party <br>
-          of three or four to the theatre to see <span class="emph">Ingomar</span> or <span class="emph">The Lady of <span class="tag lineNumber">21325</span><br>
+          of three or four to the theatre to see <span class="emph">Ingomar</span> or <span class="emph">The Lady of <br>
           Lyons</span>. In his coat pockets he carried squares of Vienna choc- <br>
           olate for his guests while his trousers' pockets bulged with <br>
           masses of silver and copper coins. He bought presents for <br>
           everyone, overhauled his room, wrote out resolutions, marshal- <br>
-          led his books up and down their shelves, pored upon all kinds <span class="tag lineNumber">21330</span><br>
+          led his books up and down their shelves, pored upon all kinds <span class="tag lineNumber">1330</span><br>
           of price lists, drew up a form of commonwealth for the <br>
           household by which every member of it held some office, <br>
           opened a loan bank for his family and pressed loans on willing <br>
           borrowers so that he might have the pleasure of making out <br>
-          receipts and reckoning the interests on the sums lent. When he <span class="tag lineNumber">21335</span><br>
+          receipts and reckoning the interests on the sums lent. When he <br>
           could do no more he drove up and down the city in trams. <br>
           Then the season of pleasure came to an end. The pot of pink <br>
           enamel paint gave out and the wainscot of his bedroom re- <br>
           mained with its unfinished and illplastered coat.<br> </p>
-          <p class="textParagraph">  His household returned to its usual way of life. His mother <span class="tag lineNumber">21340</span><br>
+          <p class="textParagraph">  His household returned to its usual way of life. His mother <span class="tag lineNumber">1340</span><br>
           had no further occasion to upbraid him for squandering his <br>
           money. He too returned to his old life at school and all his <br>
           novel enterprises fell to pieces. The commonwealth fell, the <br>
           loan bank closed its coffers and its books on a sensible loss, the <br>
-          rules of life which he had drawn about himself fell into desue- <span class="tag lineNumber">21345</span><br>
+          rules of life which he had drawn about himself fell into desue- <br>
           tude.<br> </p>
           <p class="textParagraph">  How foolish his aim had been! He had tried to build a <br>
           breakwater of order and elegance against the sordid tide of life <br>
           without him and to dam up, by rules of conduct and active <br>
-          interests and new filial relations, the powerful recurrence of the <span class="tag lineNumber">21350</span><br>
+          interests and new filial relations, the powerful recurrence of the <span class="tag lineNumber">1350</span><br>
           tides within him. Useless. From without as from within the <br>
           waters had flowed over his barriers: their tides began once <br>
           more to jostle fiercely above the crumbled mole.<br> </p>
           <p class="textParagraph">  He saw clearly too his own futile isolation. He had not gone <br>
-          one step nearer the lives he had sought to approach nor bridged <span class="tag lineNumber">21355</span><br>
+          one step nearer the lives he had sought to approach nor bridged <br>
           the restless shame and rancour that divided him from father <br>
           and mother and brother and sister. He felt that he was hardly <br>
           of the one blood with them but stood to them rather in the <br>
           mystical kinship of fosterage, fosterchild and fosterbrother.<br> </p>
-          <p class="textParagraph">  He burned to appease the fierce longings of his heart before <span class="tag lineNumber">21360</span><br>
+          <p class="textParagraph">  He burned to appease the fierce longings of his heart before <span class="tag lineNumber">1360</span><br>
           which everything else was idle and alien. He cared little that he <br>
           was in mortal sin, that his life had grown to be a tissue of <br>
           subterfuges and falsehood. Beside the savage desire within him <br>
           to realise the enormities which he brooded on nothing was <br>
-          sacred. He bore cynically with the shameful details of his secret <span class="tag lineNumber">21365</span><br>
+          sacred. He bore cynically with the shameful details of his secret <br>
           riots in which he exulted to defile with patience whatever im- <br>
           age had attracted his eyes. By day and by night he moved <br>
           among distorted images of the outer world. A figure that had <br>
           seemed to him by day demure and innocent  came towards him <br>
-          by night through the winding darkness of sleep, her face trans- <span class="tag lineNumber">21370</span><br>
+          by night through the winding darkness of sleep, her face trans- <span class="tag lineNumber">1370</span><br>
           figured by a lecherous cunning, her eyes bright with brutish <br>
           joy. Only the morning pained him with its dim memory of dark <br>
           orgiastic riot, its keen and humiliating sense of transgression.<br> </p>
           <p class="textParagraph">  He returned to his wanderings. The veiled autumnal even- <br>
-          ings led him from street to street as they had led him years <span class="tag lineNumber">21375</span><br>
+          ings led him from street to street as they had led him years <br>
           before along the quiet avenues of Blackrock. But no vision of <br>
           trim front gardens or of kindly lights in the windows poured a <br>
           tender influence upon him now. Only at times, in the pauses of <br>
           his desire, when the luxury that was wasting him gave room to <br>
-          a softer languor, the image of Mercedes traversed the back- <span class="tag lineNumber">21380</span><br>
+          a softer languor, the image of Mercedes traversed the back- <span class="tag lineNumber">1380</span><br>
           ground of his memory. He saw again the small white house and <br>
           the garden of rosebushes on the road that led to the mountains <br>
           and he remembered the sadly proud gesture of refusal which he <br>
           was to make there, standing with her in the moonlit garden <br>
-          after years of estrangement and adventure. At those moments <span class="tag lineNumber">21385</span><br>
+          after years of estrangement and adventure. At those moments <br>
           the soft speeches of Claude Melnotte rose to his lips and eased <br>
           his unrest. A tender premonition touched him of the tryst he <br>
           had then looked forward to and, in spite of the horrible reality <br>
           which lay between his hope of then and now, of the holy <br>
-          encounter he had then imagined at which weakness and timid- <span class="tag lineNumber">21390</span><br>
+          encounter he had then imagined at which weakness and timid- <span class="tag lineNumber">1390</span><br>
           ity and inexperience were to fall from him.<br> </p>
           <p class="textParagraph">  Such moments passed and the wasting fires of lust sprang up <br>
           again. The verses passed from his lips and the inarticulate cries <br>
           and the unspoken brutal words rushed forth from his brain to <br>
-          force a passage. His blood was in revolt. He wandered up and <span class="tag lineNumber">21395</span><br>
+          force a passage. His blood was in revolt. He wandered up and <br>
           down the dark slimy streets peering into the gloom of lanes and <br>
           doorways, listening eagerly for any sound. He moaned to him- <br>
           self like some baffled prowling beast. He wanted to sin with <br>
           another of his kind, to force another being to sin with him and <br>
-          to exult with her in sin. He felt some dark presence moving <span class="tag lineNumber">21400</span><br>
+          to exult with her in sin. He felt some dark presence moving <span class="tag lineNumber">1400</span><br>
           irresistibly upon him from the  darkness, a presence subtle and <br>
           murmurous as a flood filling him wholly with itself. Its mur- <br>
           mur besieged his ears like the murmur of some multitude in <br>
           sleep; its subtle streams penetrated his being. His hands <br>
-          clenched convulsively and his teeth set together as he suffered <span class="tag lineNumber">21405</span><br>
+          clenched convulsively and his teeth set together as he suffered <br>
           the agony of its penetration. He stretched out his arms in the <br>
           street to hold fast the frail swooning form that eluded him and <br>
           incited him: and the cry that he had strangled for so long in his <br>
           throat issued from his lips. It broke from him like a wail of <br>
-          despair from a hell of sufferers and died in a wail of furious <span class="tag lineNumber">21410</span><br>
+          despair from a hell of sufferers and died in a wail of furious <span class="tag lineNumber">1410</span><br>
           entreaty, a cry for an iniquitous abandonment, a cry which was <br>
           but the echo of an obscene scrawl which he had read on the <br>
           oozing wall of a urinal.<br> </p>
           <p class="textParagraph">  He had wandered into a maze of narrow and dirty streets. <br>
-          From the foul laneways he heard bursts of hoarse riot and <span class="tag lineNumber">21415</span><br>
+          From the foul laneways he heard bursts of hoarse riot and <br>
           wrangling and the drawling of drunken singers. He walked <br>
           onward, undismayed, wondering whether he had strayed into <br>
           the quarter of the jews. Women and girls dressed in long vivid <br>
           gowns traversed the street from house to house. They were <br>
-          leisurely and perfumed. A trembling seized him and his eyes <span class="tag lineNumber">21420</span><br>
+          leisurely and perfumed. A trembling seized him and his eyes <span class="tag lineNumber">1420</span><br>
           grew dim. The yellow gasflames arose before his troubled vi- <br>
           sion against the vapoury sky, burning as if before an altar. <br>
           Before the doors and in the lighted halls groups were gathered, <br>
           arrayed as for some rite. He was in another world: he had <br>
-          awakened from a slumber of centuries.<span class="tag lineNumber">21425</span><br> </p>
+          awakened from a slumber of centuries.<br> </p>
           <p class="textParagraph">  He stood still in the middle of the roadway, his heart clam- <br>
           ouring against his bosom in a tumult. A young woman dressed <br>
           in a long pink gown laid her hand on his arm to detain him and <br>
           gazed into his face. She said gaily: <br>
-           <p class="dialog"><span class="tag dialog">prostitute</span>―Good night, Willie dear! <span class="tag lineNumber">21430</span><br></p> </p>
+           <p class="dialog"><span class="tag dialog">prostitute</span>―Good night, Willie dear! <span class="tag lineNumber">1430</span><br></p> </p>
           <p class="textParagraph">  Her room was warm and lightsome. A huge doll sat with her <br>
           legs apart in the copious easychair beside the bed. He tried to <br>
           bid his tongue speak that he might seem at ease, watching her <br>
           as she undid her gown, noting the proud conscious movements <br>
-          of her perfumed head.<span class="tag lineNumber">21435</span><br> </p>
+          of her perfumed head.<br> </p>
           <p class="textParagraph">  As he stood silent in the middle of the room she came over <br>
           to him and embraced him gaily and gravely. Her round arms <br>
           held him firmly to her and he, seeing her face lifted to him in <br>
           serious calm and feeling the warm calm rise and fall of her <br>
-          breast, all but burst into hysterical weeping. Tears of joy and <span class="tag lineNumber">21440</span><br>
+          breast, all but burst into hysterical weeping. Tears of joy and <span class="tag lineNumber">1440</span><br>
           relief shone in his delighted eyes and his lips parted though they <br>
           would not speak.<br> </p>
           <p class="textParagraph">  She passed her tinkling hand through his hair, calling him a <br>
           little rascal. <br></p>
-          <p class="textParagraph"><p class="dialog"><span class="tag dialog">prostitute</span>―Give me a kiss,</p> she said. <span class="tag lineNumber">21445</span><br></p>
+          <p class="textParagraph"><p class="dialog"><span class="tag dialog">prostitute</span>―Give me a kiss,</p> she said. <br></p>
           <p class="textParagraph">  His lips would not bend to kiss her. He wanted to be held <br>
           firmly in her arms, to be caressed slowly, slowly, slowly. In her <br>
           arms he felt that he had suddenly become strong and fearless <br>
           and sure of himself. But his lips would not bend to kiss her.<br> </p>
-          <p class="textParagraph">  With a sudden movement she bowed his head and joined her <span class="tag lineNumber">21450</span><br>
+          <p class="textParagraph">  With a sudden movement she bowed his head and joined her <span class="tag lineNumber">1450</span><br>
           lips to his and he read the meaning of her movements in her <br>
           frank uplifted eyes. It was too much for him. He closed his <br>
           eyes, surrendering himself to her, body and mind, conscious of <br>
           nothing in the world but the dark pressure of her softly parting <br>
-          lips. They pressed upon his brain as upon his lips as though <span class="tag lineNumber">21455</span><br>
+          lips. They pressed upon his brain as upon his lips as though <br>
           they were the vehicle of a vague speech; and between them he <br>
           felt an unknown and timid pressure, darker than the swoon of <br>
           sin, softer than sound or odour.<br> </p>
@@ -3521,233 +3521,233 @@
           its dull day and as he stared through the dull square of the <br>
           window of the schoolroom he felt his belly crave for its food. <br>
           He hoped there would be stew for dinner, turnips and carrots <br>
-          and bruised potatoes and fat mutton pieces to be ladled out in <span class="tag lineNumber">30005</span><br>
+          and bruised potatoes and fat mutton pieces to be ladled out in <br>
           thick peppered flourfattened sauce. Stuff it into you, his belly <br>
           counselled him.<br> </p>
           <p class="textParagraph"> It would be a gloomy secret night. After early nightfall the <br>
           yellow lamps would light up here and there the squalid quarter <br>
-          of the brothels. He would follow a devious course up and down <span class="tag lineNumber">30010</span><br>
+          of the brothels. He would follow a devious course up and down <span class="tag lineNumber">10</span><br>
           the streets, circling always nearer and nearer in a tremor of fear <br>
           and joy, until his feet led him suddenly round a dark corner. <br>
           The whores would be just coming out of their houses making <br>
           ready for the night, yawning lazily after their sleep and settling <br>
-          the hairpins in their clusters of hair. He would pass by them <span class="tag lineNumber">30015</span><br>
+          the hairpins in their clusters of hair. He would pass by them <br>
           calmly waiting for a sudden movement of his own will or a <br>
           sudden call to his sinloving soul from their soft perfumed flesh. <br>
           Yet as he prowled in quest of that call his senses, stultified only <br>
           by his desire, would note keenly all that wounded and shamed <br>
-          them, his eyes a ring of porter froth on a clothless table or a <span class="tag lineNumber">30020</span><br>
+          them, his eyes a ring of porter froth on a clothless table or a <span class="tag lineNumber">20</span><br>
           photograph of two soldiers standing to attention or a gaudy <br>
           playbill, his ears the drawling jargon of greeting: <br>
            <p class="dialog"><span class="tag dialog">a whore</span>―Hello, Bertie, any good in your mind?<br> </p>
            <p class="dialog"><span class="tag dialog">a whore</span>―Is that you, pigeon?<br> </p>
-           <p class="dialog"><span class="tag dialog">a whore</span>―Number ten. Fresh Nelly is waiting on you.<span class="tag lineNumber">30025</span><br> </p>
+           <p class="dialog"><span class="tag dialog">a whore</span>―Number ten. Fresh Nelly is waiting on you.<br> </p>
            <p class="dialog"><span class="tag dialog">a whore</span>―Goodnight, husband! Coming in to have a short time?<br></p> </p>
           <p class="textParagraph"> The equation on the page of his scribbler began to spread <br>
           out a widening tail, eyed and starred like a peacock's: and <br>
           when the eyes and stars of its indices had been eliminated be- <br>
-          gan slowly to fold itself together again. The indices appearing <span class="tag lineNumber">30030</span><br>
+          gan slowly to fold itself together again. The indices appearing <span class="tag lineNumber">30</span><br>
           and disappearing were eyes opening and closing; the eyes <br>
           opening and closing were stars being born and being quenched. <br>
           The vast cycle of starry life bore his weary  mind outward to its <br>
           verge and inward to its centre, a distant music accompanying <br>
-          him outward and inward. What music? The music came nearer <span class="tag lineNumber">30035</span><br>
+          him outward and inward. What music? The music came nearer <br>
           and he recalled the words, the words of Shelley's fragment <br>
           upon the moon wandering companionless, pale for weariness. <br>
           The stars began to crumble and a cloud of fine stardust fell <br>
           through space.<br> </p>
-          <p class="textParagraph"> The dull light fell more faintly upon the page whereon an- <span class="tag lineNumber">30040</span><br>
+          <p class="textParagraph"> The dull light fell more faintly upon the page whereon an- <span class="tag lineNumber">40</span><br>
           other equation began to unfold itself slowly and to spread <br>
           abroad its widening tail. It was his own soul going forth to <br>
           experience, unfolding itself sin by sin, spreading abroad the <br>
           balefire of its burning stars and folding back upon itself, fading <br>
-          slowly, quenching its own lights and fires. They were <span class="tag lineNumber">30045</span><br>
+          slowly, quenching its own lights and fires. They were <br>
           quenched: and the cold darkness filled chaos.<br> </p>
           <p class="textParagraph"> A cold lucid indifference reigned in his soul. At his first <br>
           violent sin he had felt a wave of vitality pass out of him and <br>
           had feared to find his body or his soul maimed by the excess. <br>
-          Instead the vital wave had carried him on its bosom out of <span class="tag lineNumber">30050</span><br>
+          Instead the vital wave had carried him on its bosom out of <span class="tag lineNumber">50</span><br>
           himself and back again when it receded: and no part of body or <br>
           soul had been maimed but a dark peace had been established <br>
           between them. The chaos in which his ardour extinguished <br>
           itself was a cold indifferent knowledge of himself. He had <br>
-          sinned mortally not once but many times and he knew that, <span class="tag lineNumber">30055</span><br>
+          sinned mortally not once but many times and he knew that, <br>
           while he stood in danger of eternal damnation for the first sin <br>
           alone, by every succeeding sin he multiplied his guilt and his <br>
           punishment. His days and works and thoughts could make no <br>
           atonement for him, the fountains of sanctifying grace having <br>
-          ceased to refresh his soul. At most by an alms given to a <span class="tag lineNumber">30060</span><br>
+          ceased to refresh his soul. At most by an alms given to a <span class="tag lineNumber">60</span><br>
           beggar, whose blessing he fled from, he might hope wearily to <br>
           win for himself some measure of actual grace. Devotion had <br>
           gone by the board. What did it avail to pray when he knew that <br>
           his soul lusted after its own destruction? A certain pride, a <br>
-          certain awe, withheld him from offering to God even one <span class="tag lineNumber">30065</span><br>
+          certain awe, withheld him from offering to God even one <br>
           prayer at night though he knew it was in God's power to take <br>
           away his life while he slept and hurl his soul hellward ere he <br>
           could beg for mercy. His pride in his own sin, his loveless awe <br>
           of God told him that his offence was too grievous to be atoned <br>
-          for in whole or in part by a false homage to the Allseeing and <span class="tag lineNumber">30070</span><br>
+          for in whole or in part by a false homage to the Allseeing and <span class="tag lineNumber">70</span><br>
           Allknowing. <p class="dialog"><span class="tag dialog">a voice</span>―Well now, Ennis, I declare you have a head and so has my <br>
           stick! Do you mean to say that you are not able to tell me what <br>
           a surd is?<br></p> </p>
-          <p class="textParagraph"> The blundering answer stirred the embers of his contempt of <span class="tag lineNumber">30075</span><br>
+          <p class="textParagraph"> The blundering answer stirred the embers of his contempt of <br>
           his fellows. Towards others he felt neither shame nor fear. On <br>
           Sunday mornings as he passed the churchdoor he glanced <br>
           coldly at the worshippers who stood bareheaded, four deep, <br>
           outside the church, morally present at the mass which they <br>
-          could neither see nor hear. Their dull piety and the sickly smell <span class="tag lineNumber">30080</span><br>
+          could neither see nor hear. Their dull piety and the sickly smell <span class="tag lineNumber">80</span><br>
           of the cheap hairoil with which they had anointed their heads <br>
           repelled him from the altar they prayed at. He stooped to the <br>
           evil of hypocrisy with others, sceptical of their innocence which <br>
           he could cajole so easily.<br> </p>
-          <p class="textParagraph"> On the wall of his bedroom hung an illuminated scroll, the <span class="tag lineNumber">30085</span><br>
+          <p class="textParagraph"> On the wall of his bedroom hung an illuminated scroll, the <br>
           certificate of his prefecture in the college of the sodality of the <br>
           Blessed Virgin Mary. On Saturday mornings when the sodality <br>
           met in the chapel to recite the little office his place was a <br>
           cushioned kneelingdesk at the right of the altar from which he <br>
-          led his wing of boys through the responses. The falsehood of <span class="tag lineNumber">30090</span><br>
+          led his wing of boys through the responses. The falsehood of <span class="tag lineNumber">90</span><br>
           his position did not pain him. If at moments he felt an impulse <br>
           to rise from his post of honour and, confessing before them all <br>
           his unworthiness, to leave the chapel, a glance at their faces <br>
           restrained him. The imagery of the psalms of prophecy soothed <br>
-          his barren pride. The glories of Mary held his soul captive: <span class="tag lineNumber">30095</span><br>
+          his barren pride. The glories of Mary held his soul captive: <br>
           spikenard and myrrh and frankincense, symbolising the <br>
           preciousness of God's gifts to her soul, rich garments, symbol- <br>
           ising her royal lineage, her emblems, the lateflowering plant <br>
           and lateblossoming tree, symbolising the agelong gradual <br>
-          growth of her cultus among men. When it fell to him to read <span class="tag lineNumber">30100</span><br>
+          growth of her cultus among men. When it fell to him to read <span class="tag lineNumber">100</span><br>
           the lesson towards the close of the office he read it in a veiled <br>
           voice, lulling his conscience to its music:<br> </p>
           <p class="lg">
             <p class="textParagraph"> <span class="emph">Quasi cedrus exaltata sum in Libanon et quasi cu- <br>
             pressus in  monte Sion. Quasi palma exaltata sum in <br>
-            Gades et quasi  plantatio rosae in Jericho. Quasi uliva <span class="tag lineNumber">30105</span><br>
+            Gades et quasi  plantatio rosae in Jericho. Quasi uliva <br>
             speciosa in campis et  quasi platanus exaltata sum juxta <br>
             aquam in plateis. Sicut  cinnamomum et balsamum aro- <br>
             matizans odorem dedi et quasi  myrrha electa dedi <br>
             suavitatem odoris.</span><br> </p>
           </p>
-          <p class="textParagraph"> His sin, which had covered him from the sight of God, had <span class="tag lineNumber">30110</span><br>
+          <p class="textParagraph"> His sin, which had covered him from the sight of God, had <span class="tag lineNumber">110</span><br>
           led him nearer to the refuge of sinners. Her eyes seemed to <br>
           regard him with mild pity; her holiness, a strange light glowing <br>
           faintly upon her frail flesh, did not humiliate the sinner who <br>
           approached her. If ever he was impelled to cast sin from him <br>
-          and to repent the impulse that moved him was the wish to be <span class="tag lineNumber">30115</span><br>
+          and to repent the impulse that moved him was the wish to be <br>
           her knight. If ever his soul, reentering her dwelling shyly after <br>
           the frenzy of his body's lust had spent itself, was turned to- <br>
           wards her whose emblem is the morning star, <span class="emph">bright and</span> <br>
           <span class="emph">musical, telling of heaven and infusing peace</span>, it was when her <br>
-          names were murmured softly by lips whereon there still lin- <span class="tag lineNumber">30120</span><br>
+          names were murmured softly by lips whereon there still lin- <span class="tag lineNumber">120</span><br>
           gered foul and shameful words, the savour itself of a lewd kiss.<br> </p>
           <p class="textParagraph"> That was strange. He tried to think how it could be but the <br>
           dusk, deepening in the schoolroom, covered over his thought. <br>
           The bell rang. The master marked the sums and cuts to be done <br>
-          for the next lesson and went out. Heron, beside Stephen, began <span class="tag lineNumber">30125</span><br>
+          for the next lesson and went out. Heron, beside Stephen, began <br>
           to hum tunelessly:<br> </p>
           <p class="textParagraph"> <span class="emph">My excellent friend Bombados.</span> <br>
           <p class="textParagraph"> Ennis, who had gone to the yard, came back, saying: <br>
            <p class="dialog"><span class="tag dialog">Ennis</span>―The boy from the house is coming up for the rector.<br></p> </p>
-          A tall boy behind Stephen rubbed his hands and said: <span class="tag lineNumber">30130</span><br>
+          A tall boy behind Stephen rubbed his hands and said: <span class="tag lineNumber">130</span><br>
            <p class="dialog"><span class="tag dialog">a tall boy</span>―That's game ball. We can scut the whole hour. He won't be <br>
           in till after half two. Then you can ask him questions on the <br>
           catechism, Dedalus.<br></p> </p>
           <p class="textParagraph"> Stephen, leaning back and drawing idly on his scribbler, <br>
-          listened to the talk about him which Heron checked from time <span class="tag lineNumber">30135</span><br>
+          listened to the talk about him which Heron checked from time <br>
           to time by saying: <br>
            <p class="dialog"><span class="tag dialog">Vincent Heron</span>―Shut up, will you. Don't make such a bally racket!<br></p> </p>
           <p class="textParagraph">It was strange too that he found an arid pleasure in follow- <br>
           ing up to the end the rigid lines of the doctrines of the church <br>
-          and penetrating into obscure silences  only to hear and feel the <span class="tag lineNumber">30140</span><br>
+          and penetrating into obscure silences  only to hear and feel the <span class="tag lineNumber">140</span><br>
           more deeply his own condemnation. The sentence of saint <br>
           James which says that he who offends against one command- <br>
           ment becomes guilty of all had seemed to him first a swollen <br>
           phrase until he had begun to grope in the darkness of his own <br>
-          state. From the evil seed of lust all other deadly sins had sprung <span class="tag lineNumber">30145</span><br>
+          state. From the evil seed of lust all other deadly sins had sprung <br>
           forth: pride in himself and contempt of others, covetousness in <br>
           using money for the purchase of unlawful pleasure, envy of <br>
           those whose vices he could not reach to and calumnious <br>
           murmuring against the pious, gluttonous  enjoyment of food, <br>
-          the dull glowering anger amid which he brooded upon his <span class="tag lineNumber">30150</span><br>
+          the dull glowering anger amid which he brooded upon his <span class="tag lineNumber">150</span><br>
           longing, the swamp of spiritual and bodily sloth in which his <br>
           whole being had sunk.<br> </p>
           <p class="textParagraph"> As he sat in his bench gazing calmly at the rector's shrewd <br>
           harsh face his mind wound itself in and out of the curious <br>
-          questions proposed to it. If a man had stolen a pound in his <span class="tag lineNumber">30155</span><br>
+          questions proposed to it. If a man had stolen a pound in his <br>
           youth and had used that pound to amass a huge fortune how <br>
           much was he obliged to give back, the pound he had stolen <br>
           only or the pound together with the compound interest accru- <br>
           ing upon it or all his huge fortune? If a layman in giving <br>
-          baptism pour the water before saying the words is the child <span class="tag lineNumber">30160</span><br>
+          baptism pour the water before saying the words is the child <span class="tag lineNumber">160</span><br>
           baptised? Is baptism with a mineral water valid? How comes it <br>
           that while the first beatitude promises the kingdom of heaven <br>
           to the poor of heart the second beatitude promises also to the <br>
           meek that they shall possess the land? Why was the sacrament <br>
-          of the eucharist instituted under the two species of bread and <span class="tag lineNumber">30165</span><br>
+          of the eucharist instituted under the two species of bread and <br>
           wine if Jesus Christ be present body and blood, soul and divin- <br>
           ity, in the bread alone and in the wine alone? Does a tiny <br>
           particle of the consecrated bread contain all the body and <br>
           blood of Jesus Christ or a part only of the body and blood? If <br>
-          the wine change into vinegar and the host crumble  into cor- <span class="tag lineNumber">30170</span><br>
+          the wine change into vinegar and the host crumble  into cor- <span class="tag lineNumber">170</span><br>
           ruption after they have been consecrated is Jesus Christ still <br>
           present under their species as God and as man? <br>
            <p class="dialog"><span class="tag dialog">a boy</span>―Here he is! Here he is!<br></p> </p>
           <p class="textParagraph"> A boy from his post at the window had seen the rector come <br>
-          from the house. All the catechisms were opened and all heads <span class="tag lineNumber">30175</span><br>
+          from the house. All the catechisms were opened and all heads <br>
           bent upon them silently. The rector entered and took his seat <br>
           on the dais. A gentle kick from the tall boy in the bench behind <br>
           urged Stephen to ask a difficult question.<br> </p>
           <p class="textParagraph"> The rector did not ask for a catechism to hear the lesson <br>
-          from. He clasped his hands on the desk and said: <span class="tag lineNumber">30180</span><br>
+          from. He clasped his hands on the desk and said: <span class="tag lineNumber">180</span><br>
            <p class="dialog"><span class="tag dialog">Father Conmee</span>―The retreat will begin on Wednesday afternoon in honour of <br>
           saint Francis Xavier whose feast day is Saturday. The retreat <br>
           will go on from Wednesday to Friday. On Friday confessions <br>
           will be heard all the afternoon after beads. If any boys have <br>
-          special confessors perhaps it will be better for them not to <span class="tag lineNumber">30185</span><br>
+          special confessors perhaps it will be better for them not to <br>
           change. Mass will be on Saturday morning at nine o'clock and <br>
           general communion for the whole college. Saturday will be a <br>
           free day. Sunday of course. But Saturday and Sunday being free <br>
           days some boys might be inclined to think that Monday is a <br>
-          free day also. Beware of making that mistake. I think you, <span class="tag lineNumber">30190</span><br>
+          free day also. Beware of making that mistake. I think you, <span class="tag lineNumber">190</span><br>
           Lawless, are likely to make that mistake.<br> </p>
            <p class="dialog"><span class="tag dialog">Lawless</span>―I, sir? Why,  sir?<br></p> </p>
           <p class="textParagraph"> A little wave of quiet mirth broke forth over the class of <br>
           boys from the rector's grim smile. Stephen's heart began slowly <br>
-          to fold and fade with fear like a withering flower.<span class="tag lineNumber">30195</span><br> </p>
+          to fold and fade with fear like a withering flower.<br> </p>
           <p class="textParagraph"> The rector went on gravely: <br>
            <p class="dialog"><span class="tag dialog">Father Conmee</span>―You are all familiar with the story of the life of saint Francis <br>
           Xavier, I suppose, the patron of your college. He came of an <br>
           old and illustrious Spanish family and you remember that he <br>
-          was one of the first followers of saint Ignatius. They met in <span class="hide">48.853157 2.343094</span> <span class="tag lineNumber">30200</span><br>
+          was one of the first followers of saint Ignatius. They met in <span class="hide">48.853157 2.343094</span> <span class="tag lineNumber">200</span><br>
           Paris where Francis Xavier was professor of philosophy at the <br>
           university. This young and brilliant nobleman and man of let- <br>
           ters entered heart and soul into the ideas of our glorious <br>
           founder and you know that he, at his own desire, was sent by <br>
-          saint Ignatius to preach to the Indians. He is called, as you <span class="tag lineNumber">30205</span><br>
+          saint Ignatius to preach to the Indians. He is called, as you <br>
           know, the apostle of the Indies. He went from country to <br>
           country in the east, from Africa to India, from India to Japan, <br>
           baptising the people. He is said to have baptised as many as ten <br>
           thousand idolaters in one month. It is said that his right arm <br>
-          had grown powerless from having been raised so often over the <span class="tag lineNumber">30210</span><br>
+          had grown powerless from having been raised so often over the <span class="tag lineNumber">210</span><br>
           heads of those whom he baptised. He wished then to go to <br>
           China to win still more souls for God but he died of fever on <br>
           the <span class="hide">21.705010 112.791206</span>island of Sancian. A great saint, saint Francis Xavier! A <br>
           great soldier of God!<br></p> </p>
-          <p class="textParagraph"> The rector paused and then, shaking his clasped hands be- <span class="tag lineNumber">30215</span><br>
+          <p class="textParagraph"> The rector paused and then, shaking his clasped hands be- <br>
           fore him, went on: <br>
            <p class="dialog"><span class="tag dialog">Father Conmee</span>―He had the faith in him that moves mountains. Ten thou- <br>
           sand souls won for God in a single month! That is a true <br>
           conqueror, true to the motto of our order ad majorem Dei <br>
-          gloriam! A saint who has great power in heaven, remember: <span class="tag lineNumber">30220</span><br>
+          gloriam! A saint who has great power in heaven, remember: <span class="tag lineNumber">220</span><br>
           power to intercede for us in our grief, power to obtain what- <br>
           ever we pray for if it be for the good of our souls, power above <br>
           all to obtain for us the grace to repent if we be in sin. A great <br>
           saint, saint Francis Xavier! A great fisher of souls!<br></p> </p>
-          <p class="textParagraph"> He ceased to shake his clasped hands and, resting them <span class="tag lineNumber">30225</span><br>
+          <p class="textParagraph"> He ceased to shake his clasped hands and, resting them <br>
           against his forehead, looked right and left of them keenly at his <br>
           listeners out of his dark stern eyes.<br> </p>
           <p class="textParagraph"> In the silence their dark fire kindled the dusk into a tawny <br>
           glow. Stephen's heart had withered up like a flower of the <br>
-          desert that feels the simoom  coming from afar.<span class="tag lineNumber">30230</span><br> </p>
+          desert that feels the simoom  coming from afar.<span class="tag lineNumber">230</span><br> </p>
         <div class="divider">* * *</div> 
           
         
@@ -3755,974 +3755,974 @@
             <span class="emph">ever</span> – words taken, my dear little brothers in Christ, from the <br>
             book of Ecclesiastes, seventh chapter, fortieth verse. In the <br>
             name of the Father and of the Son and of the Holy Ghost. <br>
-            Amen.<span class="tag lineNumber">30235</span><br></p> </p>
+            Amen.<br></p> </p>
             <p class="textParagraph"> Stephen sat in the front bench of the chapel. Father Arnall <br>
             sat at a table to the left of the altar. He wore about his shoul- <br>
             ders a heavy cloak; his pale face was drawn and his voice <br>
             broken with rheum. The figure of his old master, so strangely <br>
-            rearisen, brought back to Stephen's mind his life at <span class="hide">53.310624 -6.684096</span>Clongowes: <span class="tag lineNumber">30240</span><br>
+            rearisen, brought back to Stephen's mind his life at <span class="hide">53.310624 -6.684096</span>Clongowes: <span class="tag lineNumber">240</span><br>
             the wide playgrounds, swarming with boys, the square ditch, <br>
             the little cemetery off the main avenue of limes where he had <br>
             dreamed of being buried, the firelight on the wall of the infirm- <br>
             ary where he lay sick, the sorrowful face of Brother Michael. <br>
-            His soul, as these memories came back to him, became again a <span class="tag lineNumber">30245</span><br>
+            His soul, as these memories came back to him, became again a <br>
             child's soul. <br>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―We are assembled here today, my dear little brothers in <br>
             Christ, for one brief moment far away from the busy bustle of <br>
             the outer world to celebrate and to honour one of the greatest <br>
-            of saints, the apostle of the Indies, the patron saint also of your <span class="tag lineNumber">30250</span><br>
+            of saints, the apostle of the Indies, the patron saint also of your <span class="tag lineNumber">250</span><br>
             college, saint Francis Xavier. Year after year for much longer <br>
             than any of you, my dear little boys, can remember or than I <br>
             can remember the boys of this college have met in this very <br>
             chapel to make their annual retreat before the feast day of their <br>
-            patron saint. Time has gone on and brought with it its changes. <span class="tag lineNumber">30255</span><br>
+            patron saint. Time has gone on and brought with it its changes. <br>
             Even in the last few years what changes can most of you not <br>
             remember? Many of the boys who sat in those front benches a <br>
             few short years ago are perhaps now in distant lands, in the <br>
             burning tropics or immersed in professional duties or in sem- <br>
-            inaries or voyaging over the vast expanse of the deep or, it may <span class="tag lineNumber">30260</span><br>
+            inaries or voyaging over the vast expanse of the deep or, it may <span class="tag lineNumber">260</span><br>
             be, already called by the great God to another life and to the <br>
             rendering up of their stewardship. And still as the years roll by, <br>
             bringing with them changes for good and bad, the memory of <br>
             the great saint is honoured by the boys of his college who make <br>
-            every year their annual retreat on the days preceding the feast <span class="tag lineNumber">30265</span><br>
+            every year their annual retreat on the days preceding the feast <br>
             day set apart by our holy mother  the church to transmit to all <br>
             the ages the name and fame of one of the greatest sons of <br>
             catholic Spain.<br> </p>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―Now what is the meaning of this word <span class="emph">retreat</span> and why is it <br>
-            allowed on all hands to be a most salutary practice for all who <span class="tag lineNumber">30270</span><br>
+            allowed on all hands to be a most salutary practice for all who <span class="tag lineNumber">270</span><br>
             desire to lead before God and in the eyes of men a truly chris- <br>
             tian life? A retreat, my dear boys, signifies a withdrawal for a <br>
             while from the cares of our life, the cares of this workaday <br>
             world, in order to examine the state of our conscience, to <br>
-            reflect on the mysteries of holy religion and to understand <span class="tag lineNumber">30275</span><br>
+            reflect on the mysteries of holy religion and to understand <br>
             better why we are here in this world. During these few days I <br>
             intend to put before you some thoughts concerning the four <br>
             last things. They are, as you know from your catechism, death, <br>
             judgment, hell and heaven. We shall try to understand them <br>
-            fully during these few days so that we may derive from the <span class="tag lineNumber">30280</span><br>
+            fully during these few days so that we may derive from the <span class="tag lineNumber">280</span><br>
             understanding of them a lasting benefit to our souls. And re- <br>
             member, my dear boys, that we have been sent into this world <br>
             for one thing and for one thing alone: to do God's holy will <br>
             and to save our immortal souls. All else is worthless. One thing <br>
-            alone is needful, the salvation of one's soul. What doth it profit <span class="tag lineNumber">30285</span><br>
+            alone is needful, the salvation of one's soul. What doth it profit <br>
             a man to gain the whole world if he suffer the loss of his <br>
             immortal soul? Ah, my dear boys, believe me there is nothing in <br>
             this wretched world that can make up for such a loss.<br> </p>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―I will ask you therefore, my dear boys, to put away from <br>
-            your minds during these few days all worldly thoughts, <span class="tag lineNumber">30290</span><br>
+            your minds during these few days all worldly thoughts, <span class="tag lineNumber">290</span><br>
             whether of study or pleasure or ambition, and to give all your <br>
             attention to the state of your souls. I need hardly remind you <br>
             that during the days of the retreat all boys are expected to <br>
             preserve a quiet and pious demeanour and to shun all loud <br>
-            unseemly pleasure. The elder boys, of course, will see that this <span class="tag lineNumber">30295</span><br>
+            unseemly pleasure. The elder boys, of course, will see that this <br>
             custom is not infringed and I look especially to the prefects and <br>
             officers of the sodality of Our Blessed Lady and of the sodality <br>
             of the holy angels to set a good example to their fellowstu- <br>
             dents.<br></p> </p>
-            <p class="textParagraph"><p class="dialog"><span class="tag dialog">Father Arnall</span>―Let us try therefore to make this retreat in honour of saint <span class="tag lineNumber">30300</span><br>
+            <p class="textParagraph"><p class="dialog"><span class="tag dialog">Father Arnall</span>―Let us try therefore to make this retreat in honour of saint <span class="tag lineNumber">300</span><br>
             Francis with our whole heart and our whole mind. God's bless- <br>
             ing will then be upon all your year's studies. But, above and <br>
             beyond all, let this retreat be one to which you can look back in <br>
             after years when maybe you are far from this college and <br>
-            among very different surroundings, to which you can look back <span class="tag lineNumber">30305</span><br>
+            among very different surroundings, to which you can look back <br>
             with joy and thankfulness and give thanks to God for having <br>
             granted you this occasion of laying the first foundation of a <br>
             pious honourable zealous christian life. And if, as may so <br>
             happen, there be at this moment in these benches any poor soul <br>
-            which has had the unutterable misfortune to lose God's holy <span class="tag lineNumber">30310</span><br>
+            which has had the unutterable misfortune to lose God's holy <span class="tag lineNumber">310</span><br>
             grace and to fall into grievous sin I fervently trust and pray that <br>
             this retreat may be the turningpoint in the life of that soul. I <br>
             pray to God  through the merits of His zealous servant Francis <br>
             Xavier that such a soul may be led to sincere repentance and <br>
-            that the holy communion on saint Francis' day of this year may <span class="tag lineNumber">30315</span><br>
+            that the holy communion on saint Francis' day of this year may <br>
             be a lasting covenant between God and that soul. For just and <br>
             unjust, for saint and sinner alike, may this retreat be a mem- <br>
             orable one.<br> </p>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―Help me, my dear little brothers in Christ. Help me by your <br>
-            pious attention, by your own devotion, by your outward de- <span class="tag lineNumber">30320</span><br>
+            pious attention, by your own devotion, by your outward de- <span class="tag lineNumber">320</span><br>
             meanour. Banish from your minds all worldly thoughts and <br>
             think only of the last things, death, judgment, hell and heaven. <br>
             He who remembers these things, says Ecclesiastes, shall not sin <br>
             for ever. He who remembers the last things will act and think <br>
-            with them always before his eyes. He will live a good life and <span class="tag lineNumber">30325</span><br>
+            with them always before his eyes. He will live a good life and <br>
             die a good death, believing and knowing that, if he has sacri- <br>
             ficed much in this earthly life, it will be given to him a <br>
             hundredfold and a thousandfold more in the life to come, in the <br>
             kingdom without end – a blessing, my dear boys, which I wish <br>
-            you from my heart; one and all, in the name of the Father and <span class="tag lineNumber">30330</span><br>
+            you from my heart; one and all, in the name of the Father and <span class="tag lineNumber">330</span><br>
             of the Son and of the Holy Ghost. Amen.<br></p> </p>
             <p class="textParagraph"> As he walked home with silent companions a thick fog <br>
             seemed to compass his mind. He waited in stupor of mind till it <br>
             should lift and reveal what it had hidden. He ate his dinner <br>
-            with surly appetite and, when the meal was over and the <span class="tag lineNumber">30335</span><br>
+            with surly appetite and, when the meal was over and the <br>
             greasestrewn plates lay abandoned on the table, he rose and <br>
             went to the window, clearing the thick scum from his mouth <br>
             with his tongue and licking it from his lips. So he had sunk to <br>
             the state of a beast that licks his chaps after meat. This was the <br>
-            end: and a faint glimmer of fear began to pierce the fog of his <span class="tag lineNumber">30340</span><br>
+            end: and a faint glimmer of fear began to pierce the fog of his <span class="tag lineNumber">340</span><br>
             mind. He pressed his face against the pane of the window and <br>
             gazed out into the darkening street. Forms passed this way and <br>
             that way through the dull light. And that was life. The letters <br>
             of the name of Dublin lay heavily upon his mind, pushing one <br>
-            another surlily hither and thither with slow boorish insistence. <span class="tag lineNumber">30345</span><br>
+            another surlily hither and thither with slow boorish insistence. <br>
             His soul was fattening and congealing into a gross grease, <br>
             plunging ever deeper in its dull fear into a sombre threatening <br>
             dusk, while the body that was his stood, listless and dishon- <br>
             oured, gazing out of darkened eyes, helpless, perturbed and <br>
-            human for a bovine god to stare upon.<span class="tag lineNumber">30350</span><br> </p>
+            human for a bovine god to stare upon.<span class="tag lineNumber">350</span><br> </p>
             <p class="textParagraph"> The next day brought death and judgment, stirring his soul <br>
             slowly from its listless despair. The faint glimmer of fear be- <br>
             came a terror of spirit as the hoarse voice of the preacher blew <br>
             death into his soul. He suffered its agony. He felt the deathchill <br>
-            touch the extremities and creep onward towards the heart, the <span class="tag lineNumber">30355</span><br>
+            touch the extremities and creep onward towards the heart, the <br>
             film of death veiling the eyes, the bright centres of the brain <br>
             extinguished one by one like lamps, the last sweat oozing upon <br>
             the skin, the powerlessness of the dying limbs, the speech <br>
             thickening and wandering and failing, the heart throbbing <br>
-            faintly and more faintly, all but vanquished, the breath, the <span class="tag lineNumber">30360</span><br>
+            faintly and more faintly, all but vanquished, the breath, the <span class="tag lineNumber">360</span><br>
             poor timid breath, the poor helpless human spirit, sobbing and <br>
             sighing, gurgling  and rattling in the throat. No help! No help! <br>
             He, he himself, his body to which he had yielded was dying. <br>
             Into the grave with it! Nail it down into a wooden box, the <br>
-            corpse. Carry it out of the house on the shoulders of hirelings. <span class="tag lineNumber">30365</span><br>
+            corpse. Carry it out of the house on the shoulders of hirelings. <br>
             Thrust it out of men's sight into a long hole in the ground, into <br>
             the grave, to rot, to feed the mass of its creeping worms and to <br>
             be devoured by scuttling plumpbellied rats.<br> </p>
             <p class="textParagraph"> And while the friends were still standing in tears by the <br>
-            bedside the soul of the sinner was judged. At the last moment <span class="tag lineNumber">30370</span><br>
+            bedside the soul of the sinner was judged. At the last moment <span class="tag lineNumber">370</span><br>
             of consciousness the whole earthly life passed before the vision <br>
             of the soul and, ere it had time to reflect, the body had died and <br>
             the soul stood terrified before the judgmentseat. God, who had <br>
             long been merciful, would then be just. He had long been <br>
-            patient, pleading with the sinful soul, giving it time to repent, <span class="tag lineNumber">30375</span><br>
+            patient, pleading with the sinful soul, giving it time to repent, <br>
             sparing it yet awhile. But that time had gone. Time was to sin <br>
             and to enjoy, time was to scoff at God and at  the warnings of <br>
             His holy church, time was to defy His majesty, to disobey His <br>
             commands, to hoodwink one's fellow men, to commit sin after <br>
-            sin and sin after sin and to hide one's corruption from the sight <span class="tag lineNumber">30380</span><br>
+            sin and sin after sin and to hide one's corruption from the sight <span class="tag lineNumber">380</span><br>
             of men. But that time was over. Now it was God's turn: and He <br>
             was not to be hoodwinked or deceived. Every sin would then <br>
             come forth from its lurkingplace, the most rebellious against <br>
             the divine will and the most degrading to our poor corrupt <br>
-            nature, the tiniest imperfection and the most heinous atrocity. <span class="tag lineNumber">30385</span><br>
+            nature, the tiniest imperfection and the most heinous atrocity. <br>
             What did it avail then to have been a great emperor, a great <br>
             general, a marvellous inventor, the most learned of the learned? <br>
             All were as one before the judgmentseat of God. He would <br>
             reward the good and punish the wicked. One single instant was <br>
-            enough for the trial of a man's soul. One single instant after the <span class="tag lineNumber">30390</span><br>
+            enough for the trial of a man's soul. One single instant after the <span class="tag lineNumber">390</span><br>
             body's death, the soul had been weighed in the balance. The <br>
             particular judgment was over and the soul had passed to the <br>
             abode of bliss or to the prison of purgatory or had been hurled <br>
             howling into hell.<br> </p>
-            <p class="textParagraph"> Nor was that all. God's justice had still to be vindicated <span class="tag lineNumber">30395</span><br>
+            <p class="textParagraph"> Nor was that all. God's justice had still to be vindicated <br>
             before men: after the particular there still remained the general <br>
             judgment. The last day had come. The doomsday was at hand. <br>
             The stars of heaven were falling upon the earth like the figs <br>
             cast by the figtree which the wind has shaken. The sun, the <br>
-            great luminary of the universe, had become as sackcloth of <span class="tag lineNumber">30400</span><br>
+            great luminary of the universe, had become as sackcloth of <span class="tag lineNumber">400</span><br>
             hair. The moon was bloodred. The firmament was as a scroll <br>
             rolled away. The archangel Michael, the prince of the heavenly <br>
             host, appeared glorious and terrible against the sky. With one <br>
             foot on the sea and one foot on the land he blew from the <br>
-            archangelical trumpet the brazen death of time. The three <span class="tag lineNumber">30405</span><br>
+            archangelical trumpet the brazen death of time. The three <br>
             blasts of the angel filled all the universe. Time is, time was but <br>
             time shall be no more. At the last blast the souls of universal <br>
             humanity throng towards the valley of Jehoshaphat, rich and <br>
             poor, gentle and simple, wise and foolish, good and wicked. <br>
-            The soul of every human being that has ever existed, the souls <span class="tag lineNumber">30410</span><br>
+            The soul of every human being that has ever existed, the souls <span class="tag lineNumber">410</span><br>
             of all those who shall yet be born, all the sons and daughters of <br>
             Adam, all are assembled on that supreme day. And lo the <br>
             supreme judge is coming! No longer the lowly Lamb of God, <br>
             no longer the meek Jesus of Nazareth, no longer the Man of <br>
-            Sorrows, no longer the Good Shepherd,  He is seen now coming <span class="tag lineNumber">30415</span><br>
+            Sorrows, no longer the Good Shepherd,  He is seen now coming <br>
             upon the clouds, in great power and majesty, attended by nine <br>
             choirs of angels, angels and archangels, principalities, powers <br>
             and virtues, thrones and dominations, cherubim and seraphim, <br>
             God Omnipotent, God Everlasting. He speaks: and His voice is <br>
-            heard even at the farthest limits of space, even in the bottom- <span class="tag lineNumber">30420</span><br>
+            heard even at the farthest limits of space, even in the bottom- <span class="tag lineNumber">420</span><br>
             less abyss. Supreme Judge, from His sentence there will be and <br>
             can be no appeal. He calls the just to His side bidding them <br>
             enter into the kingdom, the eternity of bliss prepared for them. <br>
             The unjust He casts from Him, crying in His offended majesty: <br>
-            <span class="emph">Depart from me, ye cursed, into everlasting fire which was</span> <span class="tag lineNumber">30425</span><br>
+            <span class="emph">Depart from me, ye cursed, into everlasting fire which was</span> <br>
             <span class="emph">prepared for the devil and his angels.</span> O what agony then for <br>
             the miserable sinners! Friend is torn apart from friend, children are torn <br>
             from their parents, husbands from their wives. The poor sinner <br>
             holds out his arms to those who were dear and near to him in <br>
-            this earthly world, to those whose simple piety perhaps he <span class="tag lineNumber">30430</span><br>
+            this earthly world, to those whose simple piety perhaps he <span class="tag lineNumber">430</span><br>
             made a mock of, to those who counselled him and tried to lead <br>
             him on the right path, to a kind brother, to a loving sister, to <br>
             the mother and father who loved him so dearly. But it is too <br>
             late: the just turn away from the wretched damned souls which <br>
-            now appear before the eyes of all in their hideous and evil <span class="tag lineNumber">30435</span><br>
+            now appear before the eyes of all in their hideous and evil <br>
             character. O you hypocrites, O you whited sepulchres, O you <br>
             who present a smooth smiling face to the world while your soul <br>
             within is a foul swamp of sin, how will it fare with you in that <br>
             terrible day?<br> </p>
-            <p class="textParagraph"> And this day will come, shall come, must come: the day of <span class="tag lineNumber">30440</span><br>
+            <p class="textParagraph"> And this day will come, shall come, must come: the day of <span class="tag lineNumber">440</span><br>
             death and the day of judgment. It is appointed unto man to die <br>
             and after death the judgment. Death is certain. The time and <br>
             manner are uncertain,  whether from long disease or from some <br>
             unexpected accident: the Son of God cometh at an hour when <br>
-            you little expect Him. Be therefore ready every moment, seeing <span class="tag lineNumber">30445</span><br>
+            you little expect Him. Be therefore ready every moment, seeing <br>
             that you may die at any moment. Death is the end of us all. <br>
             Death and judgment, brought into the world by the sin of our <br>
             first parents, are the dark portals that close our earthly exist- <br>
             ence, the portals that open into the unknown and the unseen, <br>
-            portals through which every soul must pass, alone, unaided <span class="tag lineNumber">30450</span><br>
+            portals through which every soul must pass, alone, unaided <span class="tag lineNumber">450</span><br>
             save by its good works, without friend or  brother or parents or <br>
             master to help it, alone and trembling. Let that thought be ever <br>
             before our minds and then we cannot sin. Death, a cause of <br>
             terror to the sinner, is a blessed moment for him who has <br>
-            walked in the right path, fulfilling the duties of his station in <span class="tag lineNumber">30455</span><br>
+            walked in the right path, fulfilling the duties of his station in <br>
             life, attending to his morning and evening prayers, approaching <br>
             the holy sacrament frequently and performing good and mer- <br>
             ciful works. For the pious and believing catholic, for the just <br>
             man, death is no cause of terror. Was it not Addison, the great <br>
-            English writer, who, when on his deathbed, sent for the wicked <span class="tag lineNumber">30460</span><br>
+            English writer, who, when on his deathbed, sent for the wicked <span class="tag lineNumber">460</span><br>
             young earl of Warwick to let him see how a christian can meet <br>
             his end? He it is and he alone, the pious and believing christian, <br>
             who can say in his heart:<br> </p>
             <p class="lg">
               O grave, where is thy victory? <br>
-              O death, where is thy sting? <span class="tag lineNumber">30465</span><br>
+              O death, where is thy sting? <br>
             </p>
             <p class="textParagraph"> Every word of it was for him. Against his sin, foul and <br>
             secret, the whole wrath of God was aimed. The preacher's <br>
             knife had probed deeply into his diseased conscience and he felt <br>
             now that his soul was festering in sin. Yes, the preacher was <br>
-            right. God's turn had come. Like a beast in its lair his soul had <span class="tag lineNumber">30470</span><br>
+            right. God's turn had come. Like a beast in its lair his soul had <span class="tag lineNumber">470</span><br>
             lain down in its own filth but the blasts of the angel's trumpet <br>
             had driven him forth from the darkness of sin into the light. <br>
             The words of doom cried by the angel shattered in an instant <br>
             his presumptuous peace. The wind of the last day blew through <br>
-            his mind; his sins, the jeweleyed harlots of his imagination, fled <span class="tag lineNumber">30475</span><br>
+            his mind; his sins, the jeweleyed harlots of his imagination, fled <br>
             before the hurricane, squeaking like mice in their terror and <br>
             huddled under a mane of hair.<br> </p>
             <p class="textParagraph"> As he crossed the square, walking homeward, the light <br>
             laughter of a girl reached his burning ears. The frail gay sound <br>
-            smote his heart more strongly than a trumpetblast, and, not <span class="tag lineNumber">30480</span><br>
+            smote his heart more strongly than a trumpetblast, and, not <span class="tag lineNumber">480</span><br>
             daring to lift his eyes, he turned aside and gazed, as he walked, <br>
             into the shadow of the tangled shrubs. Shame rose from his <br>
             smitten heart and flooded his whole being. The image of Emma <br>
             appeared before him and, under her eyes, the flood of shame <br>
-            rushed forth anew from his heart. If she knew to what his mind <span class="tag lineNumber">30485</span><br>
+            rushed forth anew from his heart. If she knew to what his mind <br>
             had subjected her or how his brutelike lust had torn and <br>
             trampled upon her innocence! Was that boyish love? Was that <br>
             chivalry? Was that poetry? The sordid details of his orgies stank <br>
             under his very nostrils: the sootcoated packet of pictures which <br>
-            he had hidden in the flue of the fireplace and in the presence of <span class="tag lineNumber">30490</span><br>
+            he had hidden in the flue of the fireplace and in the presence of <span class="tag lineNumber">490</span><br>
             whose shameless or bashful  wantonness he lay for hours sin- <br>
             ning in thought and deed: his monstrous dreams, peopled by <br>
             apelike creatures and by harlots with gleaming jewel eyes: the <br>
             foul long letters he had written in the joy of guilty confession <br>
-            and carried secretly for days and days only to throw them <span class="tag lineNumber">30495</span><br>
+            and carried secretly for days and days only to throw them <br>
             under cover of night among the grass in the corner of a field or <br>
             beneath some hingeless door or in some niche in the hedges <br>
             where a girl might come upon them as she walked by and read <br>
             them secretly. Mad! Mad! Was it possible he had done these <br>
-            things? A cold sweat broke out upon his forehead as the foul <span class="tag lineNumber">30500</span><br>
+            things? A cold sweat broke out upon his forehead as the foul <span class="tag lineNumber">500</span><br>
             memories condensed within his brain.<br> </p>
             <p class="textParagraph"> When the agony of shame had passed from him he tried to <br>
             raise his soul from its abject powerlessness. God and the <br>
             Blessed Virgin were too far from him: God was too great and <br>
-            stern and the Blessed Virgin too pure and holy. But he imagined <span class="tag lineNumber">30505</span><br>
+            stern and the Blessed Virgin too pure and holy. But he imagined <br>
             that he stood near Emma in a wide land and,  humbly  and in <br>
             tears, bent and kissed the elbow of her sleeve.<br> </p>
             <p class="textParagraph"> In a wide land under a tender lucid evening sky, a cloud <br>
             drifting westward amid a pale green sea of heaven, they stood <br>
-            together, children that had  erred. Their error had offended <span class="tag lineNumber">30510</span><br>
+            together, children that had  erred. Their error had offended <span class="tag lineNumber">510</span><br>
             deeply God's majesty, though it was the error of two children, <br>
             but it had not offended her whose beauty <span class="emph">is not like earthly</span> <br>
             <span class="emph">beauty, dangerous to look upon, but like the morning star</span> <br>
             <span class="emph">which is its emblem, bright and musical</span>. The eyes were not <br>
-            offended which she turned upon them nor reproachful. She <span class="tag lineNumber">30515</span><br>
+            offended which she turned upon them nor reproachful. She <br>
             placed their hands together, hand in hand, and said, speaking <br>
             to their hearts: <br>
              <p class="dialog"><span class="tag dialog">Virgin Mary</span>―Take hands, Stephen and Emma. It is a beautiful evening <br>
             now in heaven. You have erred but you are always my children. <br>
-            It is one heart that loves another heart. Take hands together, <span class="tag lineNumber">30520</span><br>
+            It is one heart that loves another heart. Take hands together, <span class="tag lineNumber">520</span><br>
             my dear children, and you  will  be happy together and your <br>
             hearts will love each other.<br></p> </p>
             <p class="textParagraph"> The chapel was flooded by the dull scarlet light that filtered <br>
             through the lowered blinds: and through the fissure between <br>
-            the last blind and the sash a shaft of wan light entered like a <span class="tag lineNumber">30525</span><br>
+            the last blind and the sash a shaft of wan light entered like a <br>
             spear and touched the embossed brasses of the candlesticks <br>
             upon the altar that gleamed like the battleworn mail armour of <br>
             angels.<br> </p>
             <p class="textParagraph"> Rain was falling on the chapel, on the garden, on the college. <br>
-            It would rain for ever, noiselessly. The water would rise inch <span class="tag lineNumber">30530</span><br>
+            It would rain for ever, noiselessly. The water would rise inch <span class="tag lineNumber">530</span><br>
             by inch, covering the grass and shrubs, covering the trees and <br>
             houses, covering the monuments and the mountain tops. All <br>
             life would be choked off, noiselessly: birds, men, elephants, <br>
             pigs, children: noiselessly floating corpses amid the litter of the <br>
-            wreckage of the world. Forty days and forty nights the rain <span class="tag lineNumber">30535</span><br>
+            wreckage of the world. Forty days and forty nights the rain <br>
             would fall till the waters covered the face of the earth.<br> </p>
             <p class="textParagraph"> It might be. Why not? <br>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―<span class="emph">Hell has enlarged its soul and opened its mouth without any</span> <br>
             <span class="emph">limits</span> – words taken, my dear little brothers in Christ Jesus, <br>
-            from the book of Isaias, fifth chapter, fourteenth verse. In the <span class="tag lineNumber">30540</span><br>
+            from the book of Isaias, fifth chapter, fourteenth verse. In the <span class="tag lineNumber">540</span><br>
             name of the Father and of the Son and of the Holy Ghost. <br>
             Amen.<br></p> </p>
             <p class="textParagraph"> The preacher took a chainless watch from a pocket within <br>
             his soutane and, having considered its dial for a moment in <br>
-            silence, placed it silently before him on the table.<span class="tag lineNumber">30545</span><br> </p>
+            silence, placed it silently before him on the table.<br> </p>
             <p class="textParagraph"> He began  to speak in a quiet tone. <br>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―Adam and Eve, my dear boys, were, as you know, our first <br>
             parents and you will remember that they were created by God <br>
             in order that the seats in heaven left vacant by the fall of <br>
-            Lucifer and his rebellious angels might be filled again. Lucifer, <span class="tag lineNumber">30550</span><br>
+            Lucifer and his rebellious angels might be filled again. Lucifer, <span class="tag lineNumber">550</span><br>
             we are  told, was a son of the morning, a radiant and mighty <br>
             angel; yet he fell: he fell and there fell with him a third part of <br>
             the host of heaven: he fell and was hurled with his rebellious <br>
             angels into hell. What his sin was we cannot say. Theologians <br>
-            consider that it was the sin of pride, the sinful thought con- <span class="tag lineNumber">30555</span><br>
+            consider that it was the sin of pride, the sinful thought con- <br>
             ceived in an instant: <span class="emph">non serviam: I will not serve</span>. That instant <br>
             was his ruin. He offended the majesty of God by the sinful <br>
             thought of one instant and God cast him out of heaven into hell <br>
             for ever.<br> </p>
-             <p class="dialog"><span class="tag dialog">Father Arnall</span>―Adam and Eve were then created by God and placed in <span class="tag lineNumber">30560</span><br>
+             <p class="dialog"><span class="tag dialog">Father Arnall</span>―Adam and Eve were then created by God and placed in <span class="tag lineNumber">560</span><br>
             Eden, that lovely garden in the plain of Damascus that lovely garden resplendent <br>
             with sunlight and colour, teeming with luxuriant vegetation. <br>
             The fruitful earth gave them her bounty: beasts and birds were <br>
             their willing servants: they knew not the ills our flesh is heir to, <br>
-            disease and poverty and death: all that a great and generous <span class="tag lineNumber">30565</span><br>
+            disease and poverty and death: all that a great and generous <br>
             God could do for them was done. But there was one condition <br>
             imposed on them by God: obedience to His word. They were <br>
             not to eat of the fruit of the forbidden tree.<br> </p>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―Alas, my dear little boys, they too fell. The devil, once a <br>
-            shining angel, a son of the morning, now a foul fiend came to <span class="tag lineNumber">30570</span><br>
+            shining angel, a son of the morning, now a foul fiend came to <span class="tag lineNumber">570</span><br>
             them in the shape of a serpent, the subtlest of all the beasts of <br>
             the field. He envied them. He, the fallen great one, could not <br>
             bear to think that man, a being of clay, should possess the <br>
             inheritance which he by his sin had forfeited for ever. He came <br>
-            to the woman, the weaker vessel, and poured the poison of his <span class="tag lineNumber">30575</span><br>
+            to the woman, the weaker vessel, and poured the poison of his <br>
             eloquence into her ear, promising her  (O, the blasphemy of that <br>
             promise!) that if she and Adam ate of the forbidden fruit they <br>
             would become as gods, nay as God Himself. Eve yielded to the <br>
             wiles of the archtempter. She ate the apple and gave it also to <br>
-            Adam who had not the moral courage to resist her. The poison <span class="tag lineNumber">30580</span><br>
+            Adam who had not the moral courage to resist her. The poison <span class="tag lineNumber">580</span><br>
             tongue of Satan had done its work. They fell.<br> </p>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―And then the voice of God was heard in that garden, calling <br>
             His creature man to account: and Michael, prince of the heav- <br>
             enly host, with a sword of flame in his hand appeared before <br>
-            the guilty pair and drove them forth from Eden into the world, <span class="tag lineNumber">30585</span><br>
+            the guilty pair and drove them forth from Eden into the world, <br>
             the world of sickness and striving, of cruelty and disappoint- <br>
             ment, of labour and hardship, to earn their bread in the sweat <br>
             of their brow. But even then how merciful was God! He took <br>
             pity on our poor degraded first parents and promised that in <br>
-            the fulness of time He would send down from heaven One who <span class="tag lineNumber">30590</span><br>
+            the fulness of time He would send down from heaven One who <span class="tag lineNumber">590</span><br>
             would redeem them, make them once more children of God <br>
             and heirs to the kingdom of heaven: and that One, that <br>
             Redeemer of fallen man, was to be God's onlybegotten  Son, the <br>
             Second Person of the Most Blessed Trinity, the Eternal Word.<br> </p>
-             <p class="dialog"><span class="tag dialog">Father Arnall</span>―He came. He was born of a virgin pure, Mary the virgin <span class="tag lineNumber">30595</span><br>
+             <p class="dialog"><span class="tag dialog">Father Arnall</span>―He came. He was born of a virgin pure, Mary the virgin <br>
             mother. He was born in a poor cowhouse in Judea and lived as <br>
             a humble carpenter for thirty years until the hour of His <br>
             mission had come. And then, filled with love for men, He went <br>
             forth and called to men to hear the new gospel.<br> </p>
-             <p class="dialog"><span class="tag dialog">Father Arnall</span>―Did they listen? Yes, they listened but would not hear. He <span class="tag lineNumber">30600</span><br>
+             <p class="dialog"><span class="tag dialog">Father Arnall</span>―Did they listen? Yes, they listened but would not hear. He <span class="tag lineNumber">600</span><br>
             was seized and bound like a common criminal, mocked at as a <br>
             fool, set aside to give place to a public robber, scourged with <br>
             five thousand lashes, crowned with a crown of thorns, hustled <br>
             through the streets by the jewish rabble and the Roman sol- <br>
-            diery, stripped of His garments and hanged upon a gibbet and <span class="tag lineNumber">30605</span><br>
+            diery, stripped of His garments and hanged upon a gibbet and <br>
             His side was pierced with a lance and from the wounded body <br>
             of Our Lord water and blood issued continually.<br> </p>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―Yet even then, in that hour of supreme agony, Our Merciful <br>
             Redeemer had pity for mankind. Yet even there, on the hill of <br>
-            Calvary, He founded the holy catholic church against which, it <span class="tag lineNumber">30610</span><br>
+            Calvary, He founded the holy catholic church against which, it <span class="tag lineNumber">610</span><br>
             is promised, the gates of hell shall not prevail. He founded it <br>
             upon the rock of ages and endowed it with His grace, with <br>
             sacraments and sacrifice, and promised that if men would obey <br>
             the word of His church they would still enter into eternal life <br>
-            but if, after all that had been done for them, they still persisted <span class="tag lineNumber">30615</span><br>
+            but if, after all that had been done for them, they still persisted <br>
             in their wickedness there  remained for them an eternity of <br>
             torment: hell.<br></p> </p>
             <p class="textParagraph"> The preacher's voice sank. He paused, joined his palms for <br>
             an instant, parted them. Then he resumed: <br>
-             <p class="dialog"><span class="tag dialog">Father Arnall</span>―Now let us try for a moment to realise, as far as we can, the <span class="tag lineNumber">30620</span><br>
+             <p class="dialog"><span class="tag dialog">Father Arnall</span>―Now let us try for a moment to realise, as far as we can, the <span class="tag lineNumber">620</span><br>
             nature of that abode of the damned which the justice of an <br>
             offended God has called into existence for the eternal punish- <br>
             ment of sinners. Hell is a strait and dark and foulsmelling <br>
             prison, an abode of demons and lost souls, filled with fire and <br>
-            smoke. The straitness of this prison house is expressly designed <span class="tag lineNumber">30625</span><br>
+            smoke. The straitness of this prison house is expressly designed <br>
             by God to punish those who refused to be bound by His laws. <br>
             In earthly prisons the poor captive has at least some liberty of <br>
             movement, were it only within the four walls of his cell or in <br>
             the gloomy yard of his prison. Not so in hell. There, by reason <br>
-            of the great number of the damned, the prisoners are heaped <span class="tag lineNumber">30630</span><br>
+            of the great number of the damned, the prisoners are heaped <span class="tag lineNumber">630</span><br>
             together in their awful prison the walls of which are said to be <br>
             four thousand miles thick: and the damned are so utterly <br>
             bound and helpless that, as a blessed saint, saint Anselm, writes <br>
             in his book on similitudes, they are not even able to remove <br>
-            from the eye a worm that gnaws it.<span class="tag lineNumber">30635</span><br> </p>
+            from the eye a worm that gnaws it.<br> </p>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―They lie in exterior darkness. For, remember, the fire of hell <br>
             gives forth no light. As, at the command of God, the fire of the <br>
             Babylonian furnace lost its heat but not its light so, at the <br>
             command of God, the fire of hell, while retaining the intensity <br>
-            of its heat, burns eternally in darkness. It is a neverending <span class="tag lineNumber">30640</span><br>
+            of its heat, burns eternally in darkness. It is a neverending <span class="tag lineNumber">640</span><br>
             storm of darkness, dark flames and dark smoke of burning <br>
             brimstone, amid which the bodies are heaped one upon another <br>
             without even a glimpse of air. Of all the plagues with which the <br>
             land of the Pharaohs was smitten one plague alone, that of <br>
-            darkness, was called horrible. What name, then, shall we give <span class="tag lineNumber">30645</span><br>
+            darkness, was called horrible. What name, then, shall we give <br>
             to the darkness of hell which is to last not for three days alone <br>
             but for all eternity?<br> </p>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―The horror of this strait and dark prison is increased by its <br>
             awful stench. All the filth of the world, all the offal and scum <br>
-            of the world, we are told, shall run there as to a vast reeking <span class="tag lineNumber">30650</span><br>
+            of the world, we are told, shall run there as to a vast reeking <span class="tag lineNumber">650</span><br>
             sewer when the terrible conflagration of the last day has purged <br>
             the world. The brimstone too which burns there in such pro- <br>
             digious quantity fills all hell with its intolerable stench: and the <br>
             bodies of the damned themselves exhale such a pestilential <br>
-            odour that, as saint Bonaventure says, one of them alone would <span class="tag lineNumber">30655</span><br>
+            odour that, as saint Bonaventure says, one of them alone would <br>
             suffice to infect the whole world. The very air of this world, <br>
             that pure element, becomes foul and unbreathable when it has <br>
             been long enclosed. Consider then what must be the foulness of <br>
             the air of hell. Imagine some foul and putrid corpse that has <br>
-            lain rotting and decomposing in the grave, a jellylike mass of <span class="tag lineNumber">30660</span><br>
+            lain rotting and decomposing in the grave, a jellylike mass of <span class="tag lineNumber">660</span><br>
             liquid corruption. Imagine such a corpse a prey to  flames, <br>
             devoured by the fire of burning brimstone and giving off dense <br>
             choking fumes of nauseous loathsome decomposition. And <br>
             then imagine this sickening stench, multiplied a millionfold and <br>
-            a millionfold again from the millions upon millions of fetid <span class="tag lineNumber">30665</span><br>
+            a millionfold again from the millions upon millions of fetid <br>
             carcases massed together in the reeking darkness,  a huge and <br>
             rotting human fungus. Imagine all this and you will have some <br>
             idea of the horror of the stench of hell.<br> </p>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―But this stench is not, horrible though it is, the greatest <br>
-            physical torment to which the damned are subjected. The <span class="tag lineNumber">30670</span><br>
+            physical torment to which the damned are subjected. The <span class="tag lineNumber">670</span><br>
             torment of fire is the greatest torment to which the tyrant has <br>
             ever subjected his fellowcreatures. Place your finger for a mo- <br>
             ment in the flame of a candle and you will feel the pain of fire. <br>
             But our earthly fire was created by God for the benefit of man, <br>
-            to maintain in him the spark of life and to help him in the <span class="tag lineNumber">30675</span><br>
+            to maintain in him the spark of life and to help him in the <br>
             useful arts whereas the fire of hell is of another quality and was <br>
             created by God to torture and punish the unrepentant sinner. <br>
             Our earthly fire also consumes more or less rapidly according <br>
             as the object which it attacks is more or less combustible so <br>
-            that human ingenuity has even succeeded in inventing chemical <span class="tag lineNumber">30680</span><br>
+            that human ingenuity has even succeeded in inventing chemical <span class="tag lineNumber">680</span><br>
             preparations to check or frustrate its action. But the sulphu- <br>
             reous brimstone which burns in hell is a substance which is <br>
             specially designed to burn for ever and for ever with unspeak- <br>
             able fury. Moreover our earthly fire destroys at the same time <br>
-            as it burns so that the more intense it is the shorter is its dur- <span class="tag lineNumber">30685</span><br>
+            as it burns so that the more intense it is the shorter is its dur- <br>
             ation: but the fire of hell has this property that it preserves that <br>
             which it burns and though it rages with incredible intensity it <br>
             rages for ever.<br> </p>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―Our earthly fire again, no matter how fierce or widespread it <br>
-            may be, is always of a limited extent: but the lake of fire in hell <span class="tag lineNumber">30690</span><br>
+            may be, is always of a limited extent: but the lake of fire in hell <span class="tag lineNumber">690</span><br>
             is boundless, shoreless and bottomless. It is on record that the <br>
             devil himself, when asked the question by a certain soldier, was <br>
             obliged to confess that if a whole mountain were thrown into <br>
             the burning ocean of hell it would be burned up in an instant <br>
-            like a piece of wax. And this terrible fire will not afflict the <span class="tag lineNumber">30695</span><br>
+            like a piece of wax. And this terrible fire will not afflict the <br>
             bodies of the damned only from without but each lost soul will <br>
             be a hell unto itself, the boundless fire raging in its very vitals. <br>
             O, how terrible is the lot of those wretched beings! The blood <br>
             seethes and boils in the veins, the brains are boiling in the skull, <br>
-            the heart in the breast glowing and bursting, the bowels a <span class="tag lineNumber">30700</span><br>
+            the heart in the breast glowing and bursting, the bowels a <span class="tag lineNumber">700</span><br>
             redhot mass of burning pulp, the tender eyes flaming like mol- <br>
             ten balls.<br> </p>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―And yet what I have said as to the strength and quality and <br>
             boundlessness of this fire is as nothing when compared to its <br>
-            intensity, an intensity which it has as being the instrument <span class="tag lineNumber">30705</span><br>
+            intensity, an intensity which it has as being the instrument <br>
             chosen by divine design for the punishment of soul and body <br>
             alike. It is a fire which proceeds directly from the ire of God, <br>
             working not of its own activity but as an instrument of divine <br>
             vengeance. As the waters of baptism cleanse the soul with the <br>
-            body so do the fires of punishment torture the spirit with the <span class="tag lineNumber">30710</span><br>
+            body so do the fires of punishment torture the spirit with the <span class="tag lineNumber">710</span><br>
             flesh. Every sense of the flesh is tortured and every faculty of <br>
             the soul therewith: the eyes with impenetrable utter darkness, <br>
             the nose with noisome odours, the ears with yells and howls <br>
             and execrations, the taste with foul matter, leprous corruption, <br>
-            nameless suffocating filth, the touch with redhot goads and <span class="tag lineNumber">30715</span><br>
+            nameless suffocating filth, the touch with redhot goads and <br>
             spikes, with cruel tongues of flame. And through the several <br>
             torments of the senses the immortal soul is tortured eternally in <br>
             its very essence amid the leagues upon leagues of glowing fires <br>
             kindled in the abyss by the offended majesty of the Omnipotent <br>
-            God and fanned into everlasting and ever increasing fury by the <span class="tag lineNumber">30720</span><br>
+            God and fanned into everlasting and ever increasing fury by the <span class="tag lineNumber">720</span><br>
             breath of the anger of the Godhead.<br> </p>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―Consider finally that the torment of this infernal prison is <br>
             increased by the company of the damned themselves. Evil com- <br>
             pany on earth is so noxious that even the plants, as if by <br>
-            instinct, withdraw from the company of whatsoever is deadly <span class="tag lineNumber">30725</span><br>
+            instinct, withdraw from the company of whatsoever is deadly <br>
             or hurtful to them. In hell all laws are overturned: there is no <br>
             thought of family or country, of ties or relationship. The <br>
             damned howl and scream at one another, their torture and rage <br>
             intensified by the presence of beings tortured and raging like <br>
-            themselves. All sense of humanity is forgotten. The yells of the <span class="tag lineNumber">30730</span><br>
+            themselves. All sense of humanity is forgotten. The yells of the <span class="tag lineNumber">730</span><br>
             suffering sinners fill the remotest corners of the vast abyss. The <br>
             mouths of the damned are full of blasphemies against God and <br>
             of hatred for their fellow sufferers and of curses against those <br>
             souls which were their  accomplices in sin. In olden times it was <br>
-            the custom to punish the parricide, the man who had raised his <span class="tag lineNumber">30735</span><br>
+            the custom to punish the parricide, the man who had raised his <br>
             murderous hand against his father, by casting him into the <br>
             depths of the sea in a sack in which were placed a cock, a <br>
             monkey and a serpent. The intention of those lawgivers who <br>
             framed such a law, which seems cruel in our times, was to <br>
-            punish the criminal by the company of hateful and hurtful <span class="tag lineNumber">30740</span><br>
+            punish the criminal by the company of hateful and hurtful <span class="tag lineNumber">740</span><br>
             beasts. But what is the fury of those dumb beasts compared <br>
             with the fury of execration which bursts from the parched lips <br>
             and aching throats of the damned in hell when they behold in <br>
             their companions in misery those who aided and abetted them <br>
-            in sin, those whose words sowed the first seeds of evil thinking <span class="tag lineNumber">30745</span><br>
+            in sin, those whose words sowed the first seeds of evil thinking <br>
             and evil living in their minds, those whose immodest sugges- <br>
             tions led them on to sin, those whose eyes tempted and allured <br>
             them from the path of virtue. They turn upon those accom- <br>
             plices and upbraid them and curse them. But they are helpless <br>
-            and hopeless: it is too late now for repentance.<span class="tag lineNumber">30750</span><br> </p>
+            and hopeless: it is too late now for repentance.<span class="tag lineNumber">750</span><br> </p>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―Last of all consider the frightful torment to those damned <br>
             souls, tempters and tempted alike,  of the company of the devils. <br>
             These devils will afflict the damned in two ways, by their pres- <br>
             ence and by their reproaches. We can have no idea of how <br>
-            horrible these devils are. Saint Catherine of Siena once saw a <span class="tag lineNumber">30755</span><br>
+            horrible these devils are. Saint Catherine of Siena once saw a <br>
             devil and she has written that, rather than look again for one <br>
             single instant on such a frightful monster, she would prefer to <br>
             walk until the end of her life along a track of red coals. These <br>
             devils, who were once beautiful angels, have become as hideous <br>
-            and ugly as they once were beautiful. They mock and  jeer at <span class="tag lineNumber">30760</span><br>
+            and ugly as they once were beautiful. They mock and  jeer at <span class="tag lineNumber">760</span><br>
             the lost souls whom they dragged down to ruin. It is they, the <br>
             foul demons, who are made in hell the voices of conscience. <br>
             Why did you sin? Why did you lend an ear to the temptings of <br>
             fiends? Why did you turn aside from your pious practices and <br>
-            good works? Why did you not shun the occasions of sin? Why <span class="tag lineNumber">30765</span><br>
+            good works? Why did you not shun the occasions of sin? Why <br>
             did you not leave that evil companion? Why did you not give <br>
             up that lewd habit, that impure habit? Why did you not listen <br>
             to the counsels of your confessor? Why did you not, even after <br>
             you had fallen the first or the second or the third or the fourth <br>
-            or the hundredth time, repent of your evil ways and turn to <span class="tag lineNumber">30770</span><br>
+            or the hundredth time, repent of your evil ways and turn to <span class="tag lineNumber">770</span><br>
             God who only waited for your repentance to absolve you of <br>
             your sins? Now the time for repentance has gone by. Time is, <br>
             time was but time shall be no more! Time was to sin in secrecy, <br>
             to indulge in that sloth and pride, to covet the unlawful, to <br>
-            yield to the promptings of your lower nature, to live like the <span class="tag lineNumber">30775</span><br>
+            yield to the promptings of your lower nature, to live like the <br>
             beasts of the field, nay worse than the beasts of the field for <br>
             they, at least, are but brutes and have not reason to guide them: <br>
             time was but time shall be no more. God spoke to you by so <br>
             many voices but you would not hear. You would not crush out <br>
-            that pride and anger in your heart, you would not restore those <span class="tag lineNumber">30780</span><br>
+            that pride and anger in your heart, you would not restore those <span class="tag lineNumber">780</span><br>
             illgotten goods, you would not obey the precepts of your holy <br>
             church nor attend to your religious duties, you would not <br>
             abandon those wicked companions, you would not avoid those <br>
             dangerous temptations. Such is the language of those fiendish <br>
-            tormentors, words of taunting and of reproach, of hatred and <span class="tag lineNumber">30785</span><br>
+            tormentors, words of taunting and of reproach, of hatred and <br>
             of disgust. Of disgust, yes! For even they, the very devils, when <br>
             they sinned sinned by such a sin as alone was compatible with <br>
             such angelical natures, a rebellion of the intellect: and they, <br>
             even they, the foul devils must turn away, revolted and dis- <br>
-            gusted, from the contemplation of those unspeakable sins by <span class="tag lineNumber">30790</span><br>
+            gusted, from the contemplation of those unspeakable sins by <span class="tag lineNumber">790</span><br>
             which degraded man outrages and defiles the temple of the <br>
             Holy Ghost, defiles and pollutes himself.<br> </p>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―O, my dear little brothers in Christ, may it never be our lot <br>
             to hear that language! May it never be our lot, I say! In the last <br>
-            day of terrible reckoning I pray fervently to God that not a <span class="tag lineNumber">30795</span><br>
+            day of terrible reckoning I pray fervently to God that not a <br>
             single soul of those who are in this chapel today may be found <br>
             among those miserable beings whom the Great Judge shall <br>
             command to depart for ever from His sight, that not one of us <br>
             may ever hear ringing in his ears the awful sentence of rejec- <br>
-            tion: <span class="emph">Depart from me, ye cursed, into everlasting fire which</span> <span class="tag lineNumber">30800</span><br>
+            tion: <span class="emph">Depart from me, ye cursed, into everlasting fire which</span> <span class="tag lineNumber">800</span><br>
             <span class="emph">was prepared for the devil and his angels!</span><br></p> </p>
             <p class="textParagraph"> He came down the aisle of the chapel, his legs shaking and <br>
             the scalp of his head trembling as though it had been touched <br>
             by ghostly fingers. He passed up the staircase and into the <br>
-            corridor along the walls of which the overcoats and water- <span class="tag lineNumber">30805</span><br>
+            corridor along the walls of which the overcoats and water- <br>
             proofs hung like gibbeted malefactors, headless and dripping <br>
             and shapeless. And at every step he feared that he had already <br>
             died, that his soul had been wrenched forth of the sheath of his <br>
             body, that he was plunging headlong through space.<br> </p>
-            <p class="textParagraph"> He could not grip the floor with his feet and sat heavily at <span class="tag lineNumber">30810</span><br>
+            <p class="textParagraph"> He could not grip the floor with his feet and sat heavily at <span class="tag lineNumber">810</span><br>
             his desk, opening one of his books at random and poring over <br>
             it. Every word for him! It was true. God was almighty. God <br>
             could call him now, call him as he sat at his desk, before he had <br>
             time to be conscious of the summons. God had called him. Yes? <br>
-            What? Yes? His flesh shrank together as it felt the approach of <span class="tag lineNumber">30815</span><br>
+            What? Yes? His flesh shrank together as it felt the approach of <br>
             the ravenous tongues of flames, dried up as it felt about it the <br>
             swirl of stifling air. He had died. Yes. He was judged. A wave <br>
             of fire swept through his body: the first. Again a wave. His <br>
             brain began to glow. Another. His brain was simmering and <br>
-            bubbling within the cracking tenement of the skull. Flames <span class="tag lineNumber">30820</span><br>
+            bubbling within the cracking tenement of the skull. Flames <span class="tag lineNumber">820</span><br>
             burst forth from his skull like a corolla, shrieking like voices: <br>
              <p class="dialog"><span class="tag dialog">Flames</span>―Hell! Hell! Hell! Hell! Hell!<br></p> </p>
             <p class="textParagraph"> Voices spoke near him: <br>
              <p class="dialog"><span class="tag dialog">a voice</span>―On hell.<br> </p>
-             <p class="dialog"><span class="tag dialog">a voice</span>―I suppose he rubbed it into you well.<span class="tag lineNumber">30825</span><br> </p>
+             <p class="dialog"><span class="tag dialog">a voice</span>―I suppose he rubbed it into you well.<br> </p>
              <p class="dialog"><span class="tag dialog">a voice</span>―You bet he did. He put us all into a blue funk.<br> </p>
              <p class="dialog"><span class="tag dialog">a voice</span>―That's what you fellows want: and plenty of it to make you <br>
             work.<br></p> </p>
             <p class="textParagraph"> He leaned back weakly in his desk. He had not died. God <br>
-            had spared him still. He was still in the familiar world of the <span class="tag lineNumber">30830</span><br>
+            had spared him still. He was still in the familiar world of the <span class="tag lineNumber">830</span><br>
             school. Mr Tate and Vincent Heron stood at the window, <br>
             talking, jesting, gazing out at the bleak rain, moving their }|lb n="30833"/| heads. <br>
             <p class="dialog"><span class="tag dialog">Mr Tate</span>―I wish it would clear up. I had arranged to go for a spin on <br>
-            the bike with some fellows out by <span class="hide">53.450924 -6.150138</span>Malahide. But the roads <span class="tag lineNumber">30835</span><br>
+            the bike with some fellows out by <span class="hide">53.450924 -6.150138</span>Malahide. But the roads <br>
             must be kneedeep.<br> </p>
             <p class="dialog"><span class="tag dialog">Vincent Heron</span>―It might clear up, sir.<br></p> </p>
             <p class="textParagraph">The voices that he knew so well, the common words, the <br>
             quiet of the classroom when the voices paused and the silence <br>
-            was filled by the sound of softly browsing cattle as the other <span class="tag lineNumber">30840</span><br>
+            was filled by the sound of softly browsing cattle as the other <span class="tag lineNumber">840</span><br>
             boys munched their lunches tranquilly, lulled his aching soul.<br> </p>
             <p class="textParagraph"> There was still time. O Mary, refuge of sinners, intercede for <br>
             him! O Virgin Undefiled, save him from the gulf of death!<br> </p>
             <p class="textParagraph"> The English lesson began with the hearing of the history. <br>
-            Royal persons, favourites, intriguers, bishops passed like mute <span class="tag lineNumber">30845</span><br>
+            Royal persons, favourites, intriguers, bishops passed like mute <br>
             phantoms behind their veil of names. All had died: all had been <br>
             judged. What did it profit a man to gain the whole world if he <br>
             lost his soul? At last he had understood: and human life lay <br>
             around him, a plain of peace whereon antlike men laboured in <br>
-            brotherhood, their dead sleeping under quiet mounds. The el- <span class="tag lineNumber">30850</span><br>
+            brotherhood, their dead sleeping under quiet mounds. The el- <span class="tag lineNumber">850</span><br>
             bow of his companion touched him and his heart was touched: <br>
             and when he spoke to answer a question of his master he heard <br>
             his own voice full of the quietude of humility and contrition.<br> </p>
             <p class="textParagraph"> His soul sank back deeper into depths of contrite peace, no <br>
-            longer able to suffer the pain of dread and sending forth, as she <span class="tag lineNumber">30855</span><br>
+            longer able to suffer the pain of dread and sending forth, as she <br>
             sank, a faint prayer. Ah yes, he would still be spared; he would <br>
             repent in his heart and be forgiven: and then those above, those <br>
             in heaven, would see what he would do to make up for the <br>
             past: a whole life, every hour of life. Only wait. <br>
-             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―All, God! All, all!<span class="tag lineNumber">30860</span><br></p> </p>
+             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―All, God! All, all!<span class="tag lineNumber">860</span><br></p> </p>
             <p class="textParagraph"> A messenger came to the door to say that confessions were <br>
             being heard in the chapel. Four boys left the room; and he <br>
             heard others passing down the corridor. A tremulous chill blew <br>
             round his heart, no stronger than a little wind, and yet, listen- <br>
-            ing and suffering silently, he seemed to have laid an ear against <span class="tag lineNumber">30865</span><br>
+            ing and suffering silently, he seemed to have laid an ear against <br>
             the muscle of his own heart, feeling it close and quail, listening <br>
             to the flutter of its ventricles.<br> </p>
             <p class="textParagraph"> No escape. He had to confess, to speak out in words what he <br>
             had done and thought, sin after sin. How? How? <br>
-             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Father, I ...<span class="tag lineNumber">30870</span><br></p> </p>
+             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Father, I ...<span class="tag lineNumber">870</span><br></p> </p>
             <p class="textParagraph">The thought slid like a cold shining rapier into his tender <br>
             flesh: confession. But not there in the chapel of the college. He <br>
             would confess all, every sin of deed and thought, sincerely: but <br>
             not there among his school companions. Far away from there <br>
-            in some dark place he would murmur out his own shame: and <span class="tag lineNumber">30875</span><br>
+            in some dark place he would murmur out his own shame: and <br>
             he besought God humbly not to be offended with him if he did <br>
             not dare to confess in the college chapel: and in utter abjection <br>
             of spirit he craved forgiveness mutely of the boyish hearts <br>
             about him.<br> </p>
-            <p class="textParagraph"> Time passed.<span class="tag lineNumber">30880</span><br> </p>
+            <p class="textParagraph"> Time passed.<span class="tag lineNumber">880</span><br> </p>
             <p class="textParagraph"> He sat again in the front bench of the chapel. The daylight <br>
             without was already failing and, as it fell slowly through the <br>
             dull red blinds, it seemed that the sun of the last day was going <br>
             down and that all souls were being gathered for the judgment. <br>
-             <p class="dialog"><span class="tag dialog">Father Arnall</span>―<span class="emph">I am cast away from the sight of Thine eyes:</span> words taken, <span class="tag lineNumber">30885</span><br>
+             <p class="dialog"><span class="tag dialog">Father Arnall</span>―<span class="emph">I am cast away from the sight of Thine eyes:</span> words taken, <br>
             my dear little brothers in Christ, from the Book of Psalms, <br>
             thirtieth chapter, twentythird verse. In the name of the Father <br>
             and of the Son and of the Holy Ghost. Amen.<br></p> </p>
             <p class="textParagraph"> The preacher began to speak in a quiet friendly tone. His <br>
-            face was kind and he joined gently the fingers of each hand, <span class="tag lineNumber">30890</span><br>
+            face was kind and he joined gently the fingers of each hand, <span class="tag lineNumber">890</span><br>
             forming a frail cage by the union of their tips. <br>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―This morning we endeavoured, in our reflection upon hell, <br>
             to make what our holy founder calls in his book of spiritual <br>
             exercises, the composition of place. We endeavoured, that is, to <br>
-            imagine with the senses of the mind, in our imagination, the <span class="tag lineNumber">30895</span><br>
+            imagine with the senses of the mind, in our imagination, the <br>
             material character of that awful place and of the physical tor- <br>
             ments which all who are in hell endure. This evening we shall <br>
             consider for a few moments the nature of the spiritual torments <br>
             of hell.<br> </p>
-             <p class="dialog"><span class="tag dialog">Father Arnall</span>―Sin, remember, is a twofold enormity. It is a base consent to <span class="tag lineNumber">30900</span><br>
+             <p class="dialog"><span class="tag dialog">Father Arnall</span>―Sin, remember, is a twofold enormity. It is a base consent to <span class="tag lineNumber">900</span><br>
             the promptings of our corrupt nature, to the lower instincts, to <br>
             that which is gross and beastlike; and it is also a turning away <br>
             from the counsel of our higher nature, from all that is pure and <br>
             holy, from the Holy God Himself. For this reason mortal sin is <br>
-            punished in hell by two different forms of punishment, physical <span class="tag lineNumber">30905</span><br>
+            punished in hell by two different forms of punishment, physical <br>
             and spiritual.<br> </p>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―Now of all these spiritual pains by far the greatest is the pain <br>
             of loss, so great, in fact, that in itself it is a torment greater <br>
             than all the others. Saint Thomas, the greatest doctor of the <br>
-            church, the angelic doctor, as he is called, says that the worst <span class="tag lineNumber">30910</span><br>
+            church, the angelic doctor, as he is called, says that the worst <span class="tag lineNumber">910</span><br>
             damnation consists in this that the understanding of man is <br>
             totally deprived of divine light and his affection obstinately <br>
             turned away from the goodness of God. God, remember, is a <br>
             being infinitely good and therefore the loss of such a being <br>
-            must be a loss infinitely painful. In this life we have not a very <span class="tag lineNumber">30915</span><br>
+            must be a loss infinitely painful. In this life we have not a very <br>
             clear idea of what such a loss must be but the damned in hell, <br>
             for their greater torment, have a full understanding of that <br>
             which they have lost and understand  that they have lost it <br>
             through their own sins and have lost it for ever. At the very <br>
-            instant of death the bonds of the flesh are broken asunder and <span class="tag lineNumber">30920</span><br>
+            instant of death the bonds of the flesh are broken asunder and <span class="tag lineNumber">920</span><br>
             the soul at once flies towards God. The soul tends towards <br>
             God as towards the centre of her existence. Remember, my <br>
             dear little boys, our souls long to be with God. We come from <br>
             God, we live by God, we belong to God: we are His, inalien- <br>
-            ably His. God loves with a divine love every human soul and <span class="tag lineNumber">30925</span><br>
+            ably His. God loves with a divine love every human soul and <br>
             every human soul lives in that love. How could it be otherwise? <br>
             Every breath that we draw, every thought of our brain, every <br>
             instant of life proceed from God's inexhaustible goodness. And <br>
             if it be pain for a mother to be parted from her child, for a man <br>
-            to be exiled from hearth and home, for friend to be sundered <span class="tag lineNumber">30930</span><br>
+            to be exiled from hearth and home, for friend to be sundered <span class="tag lineNumber">930</span><br>
             from friend, O think what pain, what anguish it must be for <br>
             the poor soul to be spurned from the presence of the supremely <br>
             good and loving Creator Who has called that soul into exist- <br>
             ence from nothingness and sustained it in life and loved it with <br>
-            an immeasurable love. This, then, to be separated for ever from <span class="tag lineNumber">30935</span><br>
+            an immeasurable love. This, then, to be separated for ever from <br>
             its greatest good, from God, and to feel the anguish of that <br>
             separation, knowing full well that it is unchangeable, this is the <br>
             greatest torment which the created soul is capable of bearing, <br>
             poena damni, the pain of loss.<br> </p>
-             <p class="dialog"><span class="tag dialog">Father Arnall</span>―The second pain which will afflict the souls of the damned in <span class="tag lineNumber">30940</span><br>
+             <p class="dialog"><span class="tag dialog">Father Arnall</span>―The second pain which will afflict the souls of the damned in <span class="tag lineNumber">940</span><br>
             hell is the pain of conscience. Just as in dead bodies worms are <br>
             engendered by putrefaction so in the souls of the lost there <br>
             arises a perpetual remorse from the putrefaction of sin, the <br>
             sting of conscience, the worm, as Pope Innocent the Third calls <br>
-            it, of the triple sting. The first sting inflicted by this cruel worm <span class="tag lineNumber">30945</span><br>
+            it, of the triple sting. The first sting inflicted by this cruel worm <br>
             will be the memory of past pleasures. O what a dreadful mem- <br>
             ory will that be! In the lake of alldevouring flame the proud <br>
             king will remember the pomps of his court, the wise but wicked <br>
             man his libraries and instruments of research, the lover of ar- <br>
-            tistic pleasures his marbles and pictures and other art treasures, <span class="tag lineNumber">30950</span><br>
+            tistic pleasures his marbles and pictures and other art treasures, <span class="tag lineNumber">950</span><br>
             he who delighted in the pleasures of the table his gorgeous <br>
             feasts, his dishes prepared with such delicacy, his choice wines; <br>
             the miser will remember his hoard of gold, the robber his <br>
             illgotten wealth, the angry and revengeful and merciless mur- <br>
-            derers their deeds of blood and violence in which they revelled, <span class="tag lineNumber">30955</span><br>
+            derers their deeds of blood and violence in which they revelled, <br>
             the impure and adulterous the unspeakable and filthy pleasures <br>
             in which they delighted. They will remember all this and loathe <br>
             themselves and their sins. For how miserable will all those <br>
             pleasures seem to the soul condemned to suffer in hellfire for <br>
-            ages and ages. How they will rage and fume to think that they <span class="tag lineNumber">30960</span><br>
+            ages and ages. How they will rage and fume to think that they <span class="tag lineNumber">960</span><br>
             have lost the bliss of heaven for the dross of earth, for a few <br>
             pieces of metal, for vain honours, for bodily comforts, for a <br>
             tingling of the nerves. They will repent indeed: and this is the <br>
             second sting of the worm of conscience, a late and fruitless <br>
-            sorrow for sins committed. Divine justice insists that the under- <span class="tag lineNumber">30965</span><br>
+            sorrow for sins committed. Divine justice insists that the under- <br>
             standing of those miserable wretches be fixed continually on <br>
             the sins of which they were guilty and, moreover, as saint <br>
             Augustine points out, God will impart to them His own <br>
             knowledge of sin so that sin will appear to them in all its <br>
-            hideous malice as it appears to the eyes of God Himself. They <span class="tag lineNumber">30970</span><br>
+            hideous malice as it appears to the eyes of God Himself. They <span class="tag lineNumber">970</span><br>
             will behold their sins in all their foulness and repent but it will <br>
             be too late and then they will bewail the good occasions which <br>
             they neglected. This is the last and deepest and most cruel sting <br>
             of the worm of conscience. The conscience will say: You had <br>
-            time and opportunity to repent and would not. You were <span class="tag lineNumber">30975</span><br>
+            time and opportunity to repent and would not. You were <br>
             brought up religiously by your parents. You had the sacraments <br>
             and graces and indulgences of the church to aid you. You had <br>
             the minister of God to preach to you, to call you back when <br>
             you had strayed, to forgive you your sins, no matter how many, <br>
-            how abominable, if only you had confessed and repented. No. <span class="tag lineNumber">30980</span><br>
+            how abominable, if only you had confessed and repented. No. <span class="tag lineNumber">980</span><br>
             You would not. You flouted the ministers of holy religion, you <br>
             turned your back on the confessional, you wallowed deeper <br>
             and deeper in the mire of sin. God appealed to you, threatened <br>
             you, entreated you to return to Him. O what shame, what <br>
-            misery! The ruler of the universe entreated you, a creature <span class="tag lineNumber">30985</span><br>
+            misery! The ruler of the universe entreated you, a creature <br>
             of clay, to love Him Who  made you and to keep His law. <br>
             No. You would not. And now, though you were to flood all <br>
             hell with your tears if you could still weep, all that sea of <br>
             repentance would not gain for you what a single tear of true <br>
-            repentance shed during your mortal life would have gained for <span class="tag lineNumber">30990</span><br>
+            repentance shed during your mortal life would have gained for <span class="tag lineNumber">990</span><br>
             you. You implore now a moment of earthly life wherein to <br>
             repent: in vain. That time is gone: gone for ever.<br> </p>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―Such is the threefold sting of conscience, the viper which <br>
             gnaws the very heart's core of the wretches in hell so that filled <br>
-            with hellish fury they curse themselves for their folly and curse <span class="tag lineNumber">30995</span><br>
+            with hellish fury they curse themselves for their folly and curse <br>
             the evil companions who have brought them to such ruin and <br>
             curse the devils who tempted them in life and now mock them <br>
             and torture them in eternity and even revile and curse the <br>
             Supreme Being Whose goodness and patience they scorned and <br>
-            slighted but Whose justice and power they cannot evade.<span class="tag lineNumber">31000</span><br> </p>
+            slighted but Whose justice and power they cannot evade.<span class="tag lineNumber">1000</span><br> </p>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―The next spiritual pain to which the damned are subjected is <br>
             the pain of extension. Man, in this earthly life, though he be <br>
             capable of many evils, is not capable of them all at once inas- <br>
             much as one evil corrects and counteracts  another just as one <br>
-            poison frequently corrects another. In hell on the contrary one <span class="tag lineNumber">31005</span><br>
+            poison frequently corrects another. In hell on the contrary one <br>
             torment, instead of counteracting another, lends it still greater <br>
             force: and moreover as the internal faculties are more perfect <br>
             than the external senses so are they more capable of suffering. <br>
             Just as every sense is afflicted with a fitting torment so is every <br>
-            spiritual faculty; the fancy with horrible images, the sensitive <span class="tag lineNumber">31010</span><br>
+            spiritual faculty; the fancy with horrible images, the sensitive <span class="tag lineNumber">1010</span><br>
             faculty with alternate longing and rage, the mind and under- <br>
             standing with an interior darkness more terrible even than the <br>
             exterior darkness which reigns in that dreadful prison. The <br>
             malice, impotent though it be, which possesses these demon <br>
-            souls is an evil of boundless extension, of limitless duration, a <span class="tag lineNumber">31015</span><br>
+            souls is an evil of boundless extension, of limitless duration, a <br>
             frightful state of wickedness which we can scarcely realise <br>
             unless we bear in mind the enormity of sin and the hatred God <br>
             bears to it.<br> </p>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―Opposed to this pain of extension and yet coexistent with it <br>
-            we have the pain of intensity. Hell is the centre of all evils and, <span class="tag lineNumber">31020</span><br>
+            we have the pain of intensity. Hell is the centre of all evils and, <span class="tag lineNumber">1020</span><br>
             as you know, things are more intense at their centres than at <br>
             their remotest points. There are no contraries or admixtures of <br>
             any kind to temper or soften in the least the pains of hell. Nay, <br>
             things which are good in themselves become evil in hell. Com- <br>
-            pany, elsewhere a source of comfort to the afflicted, will be <span class="tag lineNumber">31025</span><br>
+            pany, elsewhere a source of comfort to the afflicted, will be <br>
             there a continual torment: knowledge, so much longed for as <br>
             the chief good of the intellect, will there be hated worse than <br>
             ignorance: light, so much coveted by all creatures from the lord <br>
             of creation down to the humblest plant in the forest, will be <br>
-            loathed intensely. In this life our sorrows are either not very <span class="tag lineNumber">31030</span><br>
+            loathed intensely. In this life our sorrows are either not very <span class="tag lineNumber">1030</span><br>
             long or not very great because nature either overcomes them by <br>
             habits or puts an end to them by sinking under their weight. <br>
             But in hell the torments cannot be overcome by habit for while <br>
             they are of terrible intensity they are at the same time of con- <br>
-            tinual variety, each pain, so to speak, taking fire from another <span class="tag lineNumber">31035</span><br>
+            tinual variety, each pain, so to speak, taking fire from another <br>
             and reendowing that which has enkindled it with a still fiercer <br>
             flame. Nor can nature escape from these intense and various <br>
             tortures by succumbing to them for the soul in hell is sustained <br>
             and maintained in evil so that its suffering may be the greater. <br>
-            Boundless extension of torment, incredible intensity of suffer- <span class="tag lineNumber">31040</span><br>
+            Boundless extension of torment, incredible intensity of suffer- <span class="tag lineNumber">1040</span><br>
             ing, unceasing variety of torture – this is what the divine <br>
             majesty, so outraged by sinners, demands, this is what the <br>
             holiness of heaven, slighted and set aside for the lustful and low <br>
             pleasures of the corrupt flesh, requires, this is what the blood <br>
-            of the innocent Lamb of God, shed for the redemption of <span class="tag lineNumber">31045</span><br>
+            of the innocent Lamb of God, shed for the redemption of <br>
             sinners, trampled upon by the vilest of the vile, insists upon.<br> </p>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―Last and crowning torture of all the tortures of that awful <br>
             place is the eternity of hell. Eternity! O dread and dire word. <br>
             Eternity! What mind of man can understand it? And, remem- <br>
-            ber, it is an eternity of pain. Even though the pains of hell were <span class="tag lineNumber">31050</span><br>
+            ber, it is an eternity of pain. Even though the pains of hell were <span class="tag lineNumber">1050</span><br>
             not so terrible as they are yet they would become infinite as <br>
             they are destined to last for ever. But while they are everlasting <br>
             they are at the same time, as you know, intolerably intense, <br>
             unbearably extensive. To bear even the sting of an insect for  all <br>
-            eternity would be a dreadful torment. What must it be then to <span class="tag lineNumber">31055</span><br>
+            eternity would be a dreadful torment. What must it be then to <br>
             bear the manifold tortures of hell for ever. For ever! For all <br>
             eternity! Not for a year or for an age but for ever. Try to <br>
             imagine the awful meaning of this. You have often seen the <br>
             sand on the seashore. How fine are its tiny grains! And how <br>
-            many of those tiny little grains go to make up the small handful <span class="tag lineNumber">31060</span><br>
+            many of those tiny little grains go to make up the small handful <span class="tag lineNumber">1060</span><br>
             which a child grasps in its play. Now imagine a mountain of <br>
             that sand, a million miles high, reaching from the earth to the <br>
             farthest heavens, and a million miles broad, extending to re- <br>
             motest space, and a million miles in thickness: and imagine <br>
-            such an enormous mass of countless particles of sand multi- <span class="tag lineNumber">31065</span><br>
+            such an enormous mass of countless particles of sand multi- <br>
             plied as often as there are leaves in the forest, drops of water in <br>
             the mighty ocean, feathers on birds, scales on fish, hairs on <br>
             animals, atoms in the vast expanse of the air: and imagine that <br>
             at the end of every million years a little bird came to that <br>
-            mountain and carried away in its beak a tiny grain of that sand. <span class="tag lineNumber">31070</span><br>
+            mountain and carried away in its beak a tiny grain of that sand. <span class="tag lineNumber">1070</span><br>
             How many millions upon millions of centuries would pass be- <br>
             fore that bird had carried away even a square foot of that <br>
             mountain, how many eons upon eons of ages before it had <br>
             carried away all. Yet at the end of that immense stretch of time <br>
-            not even one instant of eternity could be said to have ended. At <span class="tag lineNumber">31075</span><br>
+            not even one instant of eternity could be said to have ended. At <br>
             the end of all those billions and trillions of years eternity would <br>
             have scarcely begun. And if that mountain rose again after it <br>
             had been all carried away and if the bird came again and <br>
             carried it all away again grain by grain: and if it so rose and <br>
-            sank as many times as there are stars in the sky, atoms in the <span class="tag lineNumber">31080</span><br>
+            sank as many times as there are stars in the sky, atoms in the <span class="tag lineNumber">1080</span><br>
             air, drops of water in the sea, leaves on the trees, feathers upon <br>
             birds, scales upon fish, hairs upon animals, at the end of all <br>
             those innumerable risings and sinkings of that immeasurably <br>
             vast mountain not one single instant of eternity could be said to <br>
-            have ended: even then, at the end of such a period, after that <span class="tag lineNumber">31085</span><br>
+            have ended: even then, at the end of such a period, after that <br>
             eon of time the mere thought of which makes our very brain <br>
             reel dizzily, eternity would have scarcely begun.<br> </p>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―A holy saint (one of our own fathers I believe it was) was <br>
             once vouchsafed a vision of hell. It seemed to him that he stood <br>
-            in the midst of a great hall, dark and silent save for the ticking <span class="tag lineNumber">31090</span><br>
+            in the midst of a great hall, dark and silent save for the ticking <span class="tag lineNumber">1090</span><br>
             of a great clock. The ticking went on unceasingly; and it <br>
             seemed to this saint that the sound of the ticking was the <br>
             ceaseless repetition of the words: ever, never; ever, never. Ever <br>
             to be in hell, never to be in heaven; ever to be shut off from the <br>
-            presence of God, never to enjoy the beatific vision; ever to be <span class="tag lineNumber">31095</span><br>
+            presence of God, never to enjoy the beatific vision; ever to be <br>
             eaten with flames, gnawed by vermin, goaded with burning <br>
             spikes, never to be free from those pains; ever to have the <br>
             conscience upbraid one, the memory enrage, the mind filled <br>
             with darkness and despair, never to escape; ever to curse and <br>
-            revile the foul demons who gloat fiendishly over the misery of <span class="tag lineNumber">31100</span><br>
+            revile the foul demons who gloat fiendishly over the misery of <span class="tag lineNumber">1100</span><br>
             their dupes, never to behold the shining raiment of the blessed <br>
             spirits; ever to cry out of the abyss of fire to God for an instant, <br>
             a single instant, of respite from such awful agony, never to <br>
             receive, even for an instant, God's pardon; ever to suffer, never <br>
-            to enjoy; ever to be damned, never to be saved; ever, never; <span class="tag lineNumber">31105</span><br>
+            to enjoy; ever to be damned, never to be saved; ever, never; <br>
             ever, never. O what a dreadful punishment! An eternity of <br>
             endless agony, of endless bodily and spiritual torment, without <br>
             one ray of hope, without one moment of cessation, of agony <br>
             limitless in extent, limitless in intensity, of torment infinitely <br>
-            lasting, infinitely varied, of torture that sustains eternally that <span class="tag lineNumber">31110</span><br>
+            lasting, infinitely varied, of torture that sustains eternally that <span class="tag lineNumber">1110</span><br>
             which it eternally devours, of anguish that everlastingly preys <br>
             upon the spirit while it racks the flesh, an eternity, every instant <br>
             of which is itself an eternity, and that eternity an eternity of <br>
             woe. Such is the terrible punishment decreed for those who die <br>
-            in mortal sin by an almighty and a just God.<span class="tag lineNumber">31115</span><br> </p>
+            in mortal sin by an almighty and a just God.<br> </p>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―Yes, a just God! Men, reasoning always as men, are aston- <br>
             ished that God should mete out an everlasting and infinite pun- <br>
             ishment in the fires of hell for a single grievous sin. They <br>
             reason thus because, blinded by the gross illusion of the flesh <br>
-            and the darkness of human understanding, they are unable to <span class="tag lineNumber">31120</span><br>
+            and the darkness of human understanding, they are unable to <span class="tag lineNumber">1120</span><br>
             comprehend the hideous malice of mortal sin. They reason thus <br>
             because they are unable to comprehend that even venial sin is <br>
             of such a foul and hideous nature that even if the omnipotent <br>
             Creator could end all the evil and misery in the world, the <br>
-            wars, the diseases, the robberies, the crimes, the deaths, the <span class="tag lineNumber">31125</span><br>
+            wars, the diseases, the robberies, the crimes, the deaths, the <br>
             murders, on condition that He allowed a single venial sin to <br>
             pass unpunished, a single venial sin, a lie, an angry look, a <br>
             moment of wilful sloth, He, the great omnipotent God could <br>
             not do so because sin, be it in thought or deed, is a trans- <br>
-            gression of His law and God would not be God if He did not <span class="tag lineNumber">31130</span><br>
+            gression of His law and God would not be God if He did not <span class="tag lineNumber">1130</span><br>
             punish the transgressor.<br> </p>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―A sin, an instant of rebellious pride of the intellect, made <br>
             Lucifer and a third part of the cohorts of angels fall from their <br>
             glory. A sin, an instant of folly and weakness, drove Adam and <br>
-            Eve out of Eden and brought death and suffering into the <span class="tag lineNumber">31135</span><br>
+            Eve out of Eden and brought death and suffering into the <br>
             world. To retrieve the consequences of that sin the onlybegot- <br>
             ten Son of God came down to earth, lived and suffered and <br>
             died a most painful death, hanging for three hours on the cross.<br> </p>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―O, my dear little brethren in Christ Jesus, will we then <br>
-            offend that good Redeemer and provoke His anger? Will we <span class="tag lineNumber">31140</span><br>
+            offend that good Redeemer and provoke His anger? Will we <span class="tag lineNumber">1140</span><br>
             trample again upon that torn and mangled corpse? Will we spit <br>
             upon that face so full of sorrow and love? Will we too, like the <br>
             cruel jews and the brutal soldiers, mock that gentle and com- <br>
             passionate Saviour Who trod alone for our sakes the awful <br>
-            winepress of sorrow? Every word of sin is a wound in His <span class="tag lineNumber">31145</span><br>
+            winepress of sorrow? Every word of sin is a wound in His <br>
             tender side. Every sinful act is a thorn piercing His head. Every <br>
             impure thought, deliberately yielded to, is a keen lance trans- <br>
             fixing that sacred and loving heart. No, no. It is impossible for <br>
             any human being to do that which offends so deeply the divine <br>
-            majesty, that which is punished by an eternity of agony, that <span class="tag lineNumber">31150</span><br>
+            majesty, that which is punished by an eternity of agony, that <span class="tag lineNumber">1150</span><br>
             which crucifies again the Son of God and makes a mockery of <br>
             Him.<br> </p>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―I pray to God that my poor words may have availed today to <br>
             confirm in holiness those who are in a state of grace, to <br>
-            strengthen the wavering, to lead back to the state of grace the <span class="tag lineNumber">31155</span><br>
+            strengthen the wavering, to lead back to the state of grace the <br>
             poor soul that has strayed if any such be among you. I pray to <br>
             God, and do you pray with me, that we may repent of our sins. <br>
             I will ask you now, all of you, to repeat after me the act of <br>
             contrition, kneeling here in this humble chapel in the presence <br>
-            of God. He is there in the tabernacle burning with love for <span class="tag lineNumber">31160</span><br>
+            of God. He is there in the tabernacle burning with love for <span class="tag lineNumber">1160</span><br>
             mankind, ready to comfort the afflicted. Be not afraid. No <br>
             matter how many or how foul the sins if only you repent of <br>
             them they will be forgiven you. Let no worldly shame hold you <br>
             back. God is still the merciful Lord Who wishes not the eternal <br>
-            death of the sinner but rather that he be converted and live.<span class="tag lineNumber">31165</span><br> </p>
+            death of the sinner but rather that he be converted and live.<br> </p>
              <p class="dialog"><span class="tag dialog">Father Arnall</span>―He calls you to Him. You are His. He made you out of <br>
             nothing. He loved you as only a God can love. His arms are <br>
             open to receive you even though you have sinned against Him. <br>
             Come to Him, poor sinner, poor vain and erring sinner. Now is <br>
-            the acceptable time. Now is the hour.<span class="tag lineNumber">31170</span><br></p> </p>
+            the acceptable time. Now is the hour.<span class="tag lineNumber">1170</span><br></p> </p>
             <p class="textParagraph"> The priest rose and turning towards the altar knelt upon the <br>
             step before the tabernacle in the fallen gloom. He waited till all <br>
             in the chapel had knelt and every least noise was still. Then <br>
             raising his head he repeated the act of contrition, phrase by <br>
-            phrase, with fervour. The boys answered him phrase by phrase. <span class="tag lineNumber">31175</span><br>
+            phrase, with fervour. The boys answered him phrase by phrase. <br>
             Stephen, his tongue cleaving to his palate, bowed his head, <br>
             praying with his heart.<br> </p>
             <p class="lg">
               <span class="emph">—O my God!</span>— <br>
               <span class="emph">—O my God!</span>— <br>
-              <span class="emph">—I am heartily sorry</span>— <span class="tag lineNumber">31180</span><br>
+              <span class="emph">—I am heartily sorry</span>— <span class="tag lineNumber">1180</span><br>
               <span class="emph">—I am heartily sorry</span>— <br>
               <span class="emph">—for having offended Thee</span>— <br>
               <span class="emph">—for having offended Thee</span>— <br>
               <span class="emph">—and I detest my sins</span>— <br>
-              <span class="emph">—and I detest my sins</span>— <span class="tag lineNumber">31185</span><br>
+              <span class="emph">—and I detest my sins</span>— <br>
               <span class="emph">—above every other evil</span>— <br>
               <span class="emph">—above every other evil</span>— <br>
               <span class="emph">—because they displease Thee, my God</span>— <br>
               <span class="emph">—because they displease Thee, my God</span>— <br>
-              <span class="emph">—Who art so deserving</span>— <span class="tag lineNumber">31190</span><br>
+              <span class="emph">—Who art so deserving</span>— <span class="tag lineNumber">1190</span><br>
               <span class="emph">—Who art so deserving</span>— <br>
               <span class="emph">—of all my love</span>— <br>
               <span class="emph">—of all my love</span>— <br>
               <span class="emph">—and I firmly purpose</span>— <br>
-              <span class="emph">—and I firmly purpose</span>— <span class="tag lineNumber">31195</span><br>
+              <span class="emph">—and I firmly purpose</span>— <br>
               <span class="emph">—by Thy holy grace</span>— <br>
               <span class="emph">—by Thy holy grace</span>— <br>
               <span class="emph">—never more to offend Thee</span>— <br>
               <span class="emph">—never more to offend Thee</span>— <br>
-              <span class="emph">—and to amend my life</span>— <span class="tag lineNumber">31200</span><br>
+              <span class="emph">—and to amend my life</span>— <span class="tag lineNumber">1200</span><br>
               <span class="emph">—and to amend my life</span>— <br>
             </p>
             <div class="divider">* * *</div>
@@ -4732,382 +4732,382 @@
             <p class="textParagraph"> He  went up to his room after dinner in order to be alone <br>
             with his soul: and at every step his soul seemed  to sigh: at every <br>
             step his soul mounted with his feet, sighing in the ascent, <br>
-            through a region of viscid gloom.<span class="tag lineNumber">31205</span><br> </p>
+            through a region of viscid gloom.<br> </p>
             <p class="textParagraph"> He halted on the landing before the door  and then, grasping <br>
             the porcelain knob, opened the door quickly. He waited in fear, <br>
             his soul pining within him, praying silently that death might <br>
             not touch his brow as he passed over the threshold,  that the <br>
-            fiends that inhabit darkness might not be given power over <span class="tag lineNumber">31210</span><br>
+            fiends that inhabit darkness might not be given power over <span class="tag lineNumber">1210</span><br>
             him. He waited still at the threshold  as at the entrance to some <br>
             dark cave. Faces were there; eyes: they waited and watched. <br>
              <p class="dialog"><span class="tag dialog">murmuring faces</span>―We knew perfectly well of course that though it was bound <br>
             to come to the light he would find considerable difficulty in <br>
-            endeavouring to try to induce himself to try to endeavour to <span class="tag lineNumber">31215</span><br>
+            endeavouring to try to induce himself to try to endeavour to <br>
             ascertain the spiritual plenipotentiary and so we knew of <br>
             course perfectly well—<br></p> </p>
             <p class="textParagraph"> Murmuring faces waited and watched;  murmurous voices <br>
             filled the dark shell of the cave. He feared intensely in spirit <br>
-            and in flesh but, raising his head bravely, he strode into the <span class="tag lineNumber">31220</span><br>
+            and in flesh but, raising his head bravely, he strode into the <span class="tag lineNumber">1220</span><br>
             room firmly. A doorway, a room, the same room, same win- <br>
             dow. He told himself calmly that those words had absolutely <br>
             no sense which had seemed to rise murmurously from the dark. <br>
             He told himself that it was simply his room with the door <br>
-            open.<span class="tag lineNumber">31225</span><br> </p>
+            open.<br> </p>
             <p class="textParagraph"> He closed the door and, walking swiftly to the bed, knelt <br>
             beside it and covered his face with his hands. His hands were <br>
             cold and damp and his limbs ached with chill. Bodily unrest <br>
             and chill and weariness beset him, routing his thoughts. Why <br>
-            was he kneeling there like a child saying his evening prayers? <span class="tag lineNumber">31230</span><br>
+            was he kneeling there like a child saying his evening prayers? <span class="tag lineNumber">1230</span><br>
             To be alone with his soul, to examine his conscience, to meet <br>
             his sins face to face, to recall their times and manners and <br>
             circumstances, to weep over them. He could not weep. He <br>
             could not summon them to his memory. He felt only an ache of <br>
-            soul and body, his whole being, memory, will, understanding, <span class="tag lineNumber">31235</span><br>
+            soul and body, his whole being, memory, will, understanding, <br>
             flesh, benumbed and weary.<br> </p>
             <p class="textParagraph"> That was the work of devils, to scatter his thoughts and <br>
             overcloud his conscience, assailing him at the gates of the cow- <br>
             ardly and sincorrupted flesh: and, praying God timidly to <br>
-            forgive him his weakness, he crawled up on to the bed and, <span class="tag lineNumber">31240</span><br>
+            forgive him his weakness, he crawled up on to the bed and, <span class="tag lineNumber">1240</span><br>
             wrapping the blankets closely about him, covered his face again <br>
             with his hands. He had  sinned. He had sinned so deeply against <br>
             heaven and before God that he was not worthy to be called <br>
             God's child.<br> </p>
-            <p class="textParagraph"> Could it be that he, Stephen Dedalus, had done those things? <span class="tag lineNumber">31245</span><br>
+            <p class="textParagraph"> Could it be that he, Stephen Dedalus, had done those things? <br>
             His conscience sighed in answer. Yes, he had done them, se- <br>
             cretly, filthily, time after time, and, hardened in sinful impeni- <br>
             tence, he had dared to wear the mask of holiness before the <br>
             tabernacle itself while his soul within was a living mass of <br>
-            corruption. How came it that God had not struck him dead? <span class="tag lineNumber">31250</span><br>
+            corruption. How came it that God had not struck him dead? <span class="tag lineNumber">1250</span><br>
             The leprous company of his sins closed about him, breathing <br>
             upon him, bending over him from all sides. He strove to forget <br>
             them in an act of prayer, huddling his limbs closer  together and <br>
             binding down his eyelids: but the senses of the soul would not <br>
-            be bound and, though his eyes were shut fast, he saw the places <span class="tag lineNumber">31255</span><br>
+            be bound and, though his eyes were shut fast, he saw the places <br>
             where he had sinned and, though his ears were tightly covered, <br>
             he heard. He desired with all his will not to hear or see. He <br>
             desired till his frame shook under the strain of his desire and <br>
             until the senses of his soul closed. They closed for an instant <br>
-            and then opened. He saw.<span class="tag lineNumber">31260</span><br> </p>
+            and then opened. He saw.<span class="tag lineNumber">1260</span><br> </p>
             <p class="textParagraph"> A field of stiff weeds and thistles and tufted nettlebunches. <br>
             Thick among the tufts of rank stiff growth lay battered canis- <br>
             ters and clots and coils of solid excrement. A faint marshlight <br>
             struggled upwards from all the ordure through the bristling <br>
-            greygreen weeds. An evil smell, faint and foul as the light, <span class="tag lineNumber">31265</span><br>
+            greygreen weeds. An evil smell, faint and foul as the light, <br>
             curled upwards sluggishly out of the canisters and from the <br>
             stale crusted dung.<br> </p>
             <p class="textParagraph"> Creatures were in the field; one, three, six: creatures were <br>
             moving in the field, hither and thither. Goatish creatures with <br>
-            human faces, hornybrowed, lightly bearded and grey as india- <span class="tag lineNumber">31270</span><br>
+            human faces, hornybrowed, lightly bearded and grey as india- <span class="tag lineNumber">1270</span><br>
             rubber. The malice of evil glittered in their hard eyes, as they <br>
             moved hither and thither, trailing their long tails behind them. <br>
             A rictus of cruel malignity lit up greyly their old bony faces. <br>
             One was clasping about his ribs a torn flannel waistcoat, an- <br>
-            other complained monotonously as his beard stuck in the <span class="tag lineNumber">31275</span><br>
+            other complained monotonously as his beard stuck in the <br>
             tufted weeds. Soft language issued from their spittleless lips as <br>
             they swished in slow circles round and round the field, winding <br>
             hither and thither through the weeds, dragging their long tails <br>
             amid the rattling canisters. They moved in slow circles, circling <br>
-            closer and closer, to enclose, to  enclose, soft language issuing <span class="tag lineNumber">31280</span><br>
+            closer and closer, to enclose, to  enclose, soft language issuing <span class="tag lineNumber">1280</span><br>
             from their lips, their long swishing tails  besmeared with stale <br>
             shite, thrusting upwards their terrific faces .....<br> </p>
             <p class="textParagraph"> Help!<br> </p>
             <p class="textParagraph"> He flung the blankets from him madly to free his face and <br>
-            neck. That was his hell. God had allowed him to see the hell <span class="tag lineNumber">31285</span><br>
+            neck. That was his hell. God had allowed him to see the hell <br>
             reserved for his sins: stinking, bestial, malignant, a hell of lech- <br>
             erous goatish fiends. For him! For him!<br> </p>
             <p class="textParagraph"> He sprang from the bed, the reeking odour pouring down <br>
             his throat, clogging and revolting his entrails. Air! The air of <br>
-            heaven! He stumbled towards the window, groaning and al- <span class="tag lineNumber">31290</span><br>
+            heaven! He stumbled towards the window, groaning and al- <span class="tag lineNumber">1290</span><br>
             most fainting with sickness. At the washstand a convulsion <br>
             seized him within: and, clasping his cold forehead wildly, he <br>
             vomited profusely in agony.<br> </p>
             <p class="textParagraph"> When the fit had spent itself he walked weakly to the win- <br>
-            dow and, lifting the sash, sat in a corner of the embrasure and <span class="tag lineNumber">31295</span><br>
+            dow and, lifting the sash, sat in a corner of the embrasure and <br>
             leaned his elbow upon the sill. The rain had drawn off; and <br>
             amid the moving vapours from point to point of light the city <br>
             was spinning about herself a soft cocoon of yellowish haze. <br>
             Heaven was still and faintly luminous and the air sweet to <br>
-            breathe, as in a thicket drenched with showers: and amid peace <span class="tag lineNumber">31300</span><br>
+            breathe, as in a thicket drenched with showers: and amid peace <span class="tag lineNumber">1300</span><br>
             and shimmering lights and quiet fragrances he made a covenant <br>
             with his heart.<br> </p>
             <p class="textParagraph"> He prayed: <br>
              <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―<span class="emph">He once had meant to come on earth in heavenly glory but <br>
-            we sinned: and then He could not safely visit us but with a <span class="tag lineNumber">31305</span><br>
+            we sinned: and then He could not safely visit us but with a <br>
             shrouded majesty and a bedimmed radiance for He was God. <br>
             So He came Himself in weakness not in power and He sent <br>
             thee, a creature in His stead, with a creature's comeliness and <br>
             lustre suited to our state. And now thy very face and form, dear <br>
-            mother, speak to us of the Eternal; not like earthly beauty, <span class="tag lineNumber">31310</span><br>
+            mother, speak to us of the Eternal; not like earthly beauty, <span class="tag lineNumber">1310</span><br>
             dangerous to look upon, but like the morning star which is thy <br>
             emblem, bright and musical, breathing purity, telling of heaven <br>
             and infusing peace. O harbinger of day! O light of the pilgrim! <br>
             Lead us still as thou hast led. In the dark night, across the bleak <br>
-            wilderness guide us on to our Lord Jesus, guide us home.</span><span class="tag lineNumber">31315</span><br></p> </p>
+            wilderness guide us on to our Lord Jesus, guide us home.</span><br></p> </p>
             <p class="textParagraph">His eyes were dimmed with tears and, looking humbly up to <br>
             heaven, he wept for the innocence he had lost.<br> </p>
             <p class="textParagraph"> When evening had fallen he left the house and the first touch <br>
             of the damp dark air and the noise of the door as it closed <br>
-            behind him made ache again his conscience, lulled by prayer <span class="tag lineNumber">31320</span><br>
+            behind him made ache again his conscience, lulled by prayer <span class="tag lineNumber">1320</span><br>
             and tears. Confess! Confess! It was not enough to lull the con- <br>
             science with a tear and a prayer. He had to kneel before the <br>
             minister of the Holy Ghost and tell over his hidden sins truly <br>
             and repentantly. Before he heard again the footboard of the <br>
-            housedoor trail over the threshold  as it opened to let him in, <span class="tag lineNumber">31325</span><br>
+            housedoor trail over the threshold  as it opened to let him in, <br>
             before he saw again the table in the kitchen set for supper he <br>
             would have knelt and confessed. It was quite simple.<br> </p>
             <p class="textParagraph"> The ache of conscience ceased and he walked onward swiftly <br>
             through the dark streets. There were so many flagstones on the <br>
-            footpath of that street and so many streets in that city and so <span class="tag lineNumber">31330</span><br>
+            footpath of that street and so many streets in that city and so <span class="tag lineNumber">1330</span><br>
             many cities in the world. Yet eternity had no end. He was in <br>
             mortal sin. Even once was a mortal sin. It could happen in an <br>
             instant. But how so quickly? By seeing or by thinking of seeing. <br>
             The eyes see the thing, without having wished first to see. Then <br>
-            in an instant it happens. But does that part of the body under- <span class="tag lineNumber">31335</span><br>
+            in an instant it happens. But does that part of the body under- <br>
             stand or what? The serpent, the most subtle beast of the field. <br>
             It must understand when it desires in one instant and then <br>
             prolongs its own desire instant after instant, sinfully. It feels <br>
             and understands and desires. What a horrible thing! Who made <br>
-            it to be like that, a bestial part of the body able to understand <span class="tag lineNumber">31340</span><br>
+            it to be like that, a bestial part of the body able to understand <span class="tag lineNumber">1340</span><br>
             bestially and desire bestially? Was that then he or an inhuman <br>
             thing moved by a lower soul than his soul? His soul sickened at <br>
             the thought of a torpid snaky life feeding itself out of the tender <br>
             marrow of his life and fattening upon the slime of lust. O why <br>
-            was that so? O why?<span class="tag lineNumber">31345</span><br> </p>
+            was that so? O why?<br> </p>
             <p class="textParagraph"> He cowered in the shadow of the thought, abasing himself in <br>
             the awe of God  Who had made all things and all men. Mad- <br>
             ness. Who could think such a thought? And, cowering in <br>
             darkness and abject, he prayed mutely to his angel guardian to <br>
-            drive away with his sword the demon that was whispering to <span class="tag lineNumber">31350</span><br>
+            drive away with his sword the demon that was whispering to <span class="tag lineNumber">1350</span><br>
             his brain.<br> </p>
             <p class="textParagraph"> The whisper ceased and he knew then clearly that his own <br>
             soul had sinned in thought and word and deed wilfully through <br>
             his own body. Confess! He had to confess every sin. How could <br>
-            he utter in words to the priest what he had done? Must, must. <span class="tag lineNumber">31355</span><br>
+            he utter in words to the priest what he had done? Must, must. <br>
             Or how could he explain without dying of shame? Or how <br>
             could he have done such things without shame? A madman, a <br>
             loathsome madman! Confess! O he would indeed to be free and <br>
             sinless again! Perhaps the priest would know. O dear God!<br> </p>
-            <p class="textParagraph"> He walked on and on through illlit  streets, fearing to stand <span class="tag lineNumber">31360</span><br>
+            <p class="textParagraph"> He walked on and on through illlit  streets, fearing to stand <span class="tag lineNumber">1360</span><br>
             still for a moment lest it might seem that he held back from <br>
             what awaited him, fearing to arrive at that towards which he <br>
             still turned with longing. How beautiful must be a soul in the <br>
             state of grace when God looked upon it with love!<br> </p>
-            <p class="textParagraph"> Frowsy girls sat along the curbstones before their baskets. <span class="tag lineNumber">31365</span><br>
+            <p class="textParagraph"> Frowsy girls sat along the curbstones before their baskets. <br>
             Their dank hair hung trailed  over their brows. They were not <br>
             beautiful to see as they crouched in the mire. But their souls <br>
             were seen by God; and if their souls were in a state of grace <br>
             they were radiant to see: and God loved them, seeing them.<br> </p>
-            <p class="textParagraph"> A wasting breath of humiliation blew bleakly over his soul <span class="tag lineNumber">31370</span><br>
+            <p class="textParagraph"> A wasting breath of humiliation blew bleakly over his soul <span class="tag lineNumber">1370</span><br>
             to think of how he had fallen, to feel that those souls were <br>
             dearer to God than his. The wind blew over him and passed on <br>
             to the myriads and myriads of other souls on whom God's <br>
             favour shone now  more and now less, stars now brighter and <br>
-            now dimmer, sustained  and failing. And the glimmering souls <span class="tag lineNumber">31375</span><br>
+            now dimmer, sustained  and failing. And the glimmering souls <br>
             passed away, sustained and failing, merged in a moving breath. <br>
             One soul was lost; a tiny soul: his. It flickered once and went <br>
             out, forgotten, lost. The end: black cold void waste.<br> </p>
             <p class="textParagraph"> Consciousness of place came ebbing back to him slowly over <br>
-            a vast tract of time unlit, unfelt, unlived. The squalid scene <span class="tag lineNumber">31380</span><br>
+            a vast tract of time unlit, unfelt, unlived. The squalid scene <span class="tag lineNumber">1380</span><br>
             composed itself around him; the common accents, the burning <br>
             gasjets in the shops, odours of fish and spirits and wet sawdust, <br>
             moving men and women. An old woman was about to cross <br>
             the street, an oilcan in her hand. He bent down and asked her <br>
-            was there a chapel near. <span class="tag lineNumber">31385</span><br>
+            was there a chapel near. <br>
             <p class="dialog"><span class="tag dialog">an old woman</span>―A chapel, sir? Yes, sir. Church Street chapel.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Church?<br></p> </p>
             <p class="textParagraph"> She shifted the can to her other hand and directed him: and, <br>
             as she held out her reeking withered right hand under its fringe <br>
-            of shawl, he bent lower towards her, saddened and soothed by <span class="tag lineNumber">31390</span><br>
+            of shawl, he bent lower towards her, saddened and soothed by <span class="tag lineNumber">1390</span><br>
             her voice. <br>
              <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Thank you.<br> </p>
             <p class="dialog"><span class="tag dialog">an old woman</span>―You are quite  welcome, sir.<br></p> </p>
             <p class="textParagraph"> The candles on the high altar had been extinguished but the <br>
-            fragrance of incense still floated down the dim nave. Bearded <span class="tag lineNumber">31395</span><br>
+            fragrance of incense still floated down the dim nave. Bearded <br>
             workmen with pious faces were guiding a canopy out through <br>
             a sidedoor, the sacristan aiding them with quiet gestures and <br>
             words. A few of the faithful still lingered, praying before one of <br>
             the sidealtars or kneeling in the benches near the confessionals. <br>
-            He approached timidly and knelt at the last bench in the body, <span class="tag lineNumber">31400</span><br>
+            He approached timidly and knelt at the last bench in the body, <span class="tag lineNumber">1400</span><br>
             thankful for the peace and silence and fragrant shadow of the <br>
             church. The board on which he knelt was narrow and worn <br>
             and those who knelt near him were humble followers of Jesus. <br>
             Jesus too had been born in poverty and had worked in the shop <br>
-            of a carpenter, cutting boards and planing them, and had first <span class="tag lineNumber">31405</span><br>
+            of a carpenter, cutting boards and planing them, and had first <br>
             spoken of the kingdom of God to poor fishermen, teaching all <br>
             men to be meek and humble of heart.<br> </p>
             <p class="textParagraph"> He bowed his head upon his hands, bidding his heart be <br>
             meek and humble that he might be like those who knelt beside <br>
-            him and his prayer as acceptable as theirs. He prayed beside <span class="tag lineNumber">31410</span><br>
+            him and his prayer as acceptable as theirs. He prayed beside <span class="tag lineNumber">1410</span><br>
             them but it was hard. His soul was foul with sin and he dared <br>
             not ask forgiveness with the simple trust of those whom Jesus, <br>
             in the mysterious ways of God, had called first to His side, the <br>
             carpenters, the fishermen, poor and simple people  following a <br>
-            lowly trade, handling and shaping the wood of trees, mending <span class="tag lineNumber">31415</span><br>
+            lowly trade, handling and shaping the wood of trees, mending <br>
             their nets with patience.<br> </p>
             <p class="textParagraph"> A tall figure came down the aisle and the penitents stirred: <br>
             and, at the last moment glancing up swiftly, he saw a long grey <br>
             beard and the brown habit of a capuchin. The priest entered <br>
-            the box and was hidden. Two penitents rose and entered the <span class="tag lineNumber">31420</span><br>
+            the box and was hidden. Two penitents rose and entered the <span class="tag lineNumber">1420</span><br>
             confessional at either side. The wooden slide was drawn back <br>
             and the faint murmur of a voice troubled the silence.<br> </p>
             <p class="textParagraph"> His blood began to murmur in his veins, murmuring like a <br>
             sinful city summoned from its sleep to hear its doom. Little <br>
-            flakes of fire fell and powdery ashes fell softly, alighting on the <span class="tag lineNumber">31425</span><br>
+            flakes of fire fell and powdery ashes fell softly, alighting on the <br>
             houses of men. They stirred, waking from sleep, troubled by <br>
             the heated air.<br> </p>
             <p class="textParagraph"> The slide was shot back. The penitent emerged from the side <br>
             of the box. The farther slide was drawn. A woman entered <br>
-            quietly and deftly where the first penitent had knelt. The faint <span class="tag lineNumber">31430</span><br>
+            quietly and deftly where the first penitent had knelt. The faint <span class="tag lineNumber">1430</span><br>
             murmur began again.<br> </p>
             <p class="textParagraph"> He could still leave the chapel. He could stand up, put one <br>
             foot before the other and walk out softly and then run, run, run <br>
             swiftly through the dark streets. He could still escape from the <br>
-            shame. O what shame! His face was burning with shame. Had <span class="tag lineNumber">31435</span><br>
+            shame. O what shame! His face was burning with shame. Had <br>
             it been any terrible crime but that one sin! Had it been murder! <br>
             Little fiery flakes fell and touched him at all points, shameful <br>
             thoughts, shameful words, shameful acts. Shame covered him <br>
             wholly like fine glowing ashes falling continually. To say it in <br>
-            words! His soul, stifling and helpless, would cease to be.<span class="tag lineNumber">31440</span><br> </p>
+            words! His soul, stifling and helpless, would cease to be.<span class="tag lineNumber">1440</span><br> </p>
             <p class="textParagraph"> The slide was shot back. A penitent emerged from the far- <br>
             ther side of the box. The near slide was drawn. A penitent <br>
             entered where the other penitent had come out. A soft whisper- <br>
             ing noise floated in vaporous cloudlets out of the box. It was <br>
-            the woman: soft whispering cloudlets, soft whispering vapour, <span class="tag lineNumber">31445</span><br>
+            the woman: soft whispering cloudlets, soft whispering vapour, <br>
             whispering and vanishing.<br> </p>
             <p class="textParagraph"> He beat his breast with his fist humbly, secretly under cover <br>
             of the wooden armrest. He would be at one with others and <br>
             with God. He would love his neighbour. He would love God <br>
-            Who had made and loved him. He would kneel and pray with <span class="tag lineNumber">31450</span><br>
+            Who had made and loved him. He would kneel and pray with <span class="tag lineNumber">1450</span><br>
             others and be happy. God would look down on him and on <br>
             them and would love them all.<br> </p>
             <p class="textParagraph"> It was easy to be good. God's yoke was sweet and light. It <br>
             was better never to have sinned, to have remained always a <br>
-            child, for God loved little children and suffered them to come <span class="tag lineNumber">31455</span><br>
+            child, for God loved little children and suffered them to come <br>
             to Him. It was a terrible and a sad thing to sin. But God was <br>
             merciful to poor sinners who were truly sorry. How true that <br>
             was! That was indeed goodness.<br> </p>
             <p class="textParagraph"> The slide was shot to suddenly. The penitent came out. He <br>
-            was next. He stood up in terror and walked blindly into the <span class="tag lineNumber">31460</span><br>
+            was next. He stood up in terror and walked blindly into the <span class="tag lineNumber">1460</span><br>
             box.<br> </p>
             <p class="textParagraph"> At last it had come. He knelt in the silent gloom and raised <br>
             his eyes to the white crucifix suspended above him. God could <br>
             see that he was sorry. He would tell all his sins. His confession <br>
-            would be long, long. Everybody in the chapel would know then <span class="tag lineNumber">31465</span><br>
+            would be long, long. Everybody in the chapel would know then <br>
             what a sinner he had been. Let them know. It was true. But <br>
             God had promised to forgive him if he was sorry. He was <br>
             sorry. He clasped his hands and raised them towards the white <br>
             form, praying with his darkened eyes, praying with all his <br>
-            trembling body, swaying his head to and fro like a lost crea- <span class="tag lineNumber">31470</span><br>
+            trembling body, swaying his head to and fro like a lost crea- <span class="tag lineNumber">1470</span><br>
             ture, praying with whimpering lips. <br>
              <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Sorry! Sorry! O sorry!<br></p> </p>
             <p class="textParagraph"> The slide clicked back and his heart bounded in his breast. <br>
             The face of an old priest was at the grating, averted from him, <br>
-            leaning upon a hand. He made the sign of the cross and prayed <span class="tag lineNumber">31475</span><br>
+            leaning upon a hand. He made the sign of the cross and prayed <br>
             of the priest to bless him for he had sinned. Then, bowing his <br>
             head, he repeated the Confiteor in fright. At the words <span class="emph">my</span> <br>
             <span class="emph">most grievous fault</span> he ceased, breathless. <br>
             <p class="dialog"><span class="tag dialog">Priest</span>―How long is it since your last confession, my child?<br> </p>
-            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―A long time, father.<span class="tag lineNumber">31480</span><br> </p>
+            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―A long time, father.<span class="tag lineNumber">1480</span><br> </p>
             <p class="dialog"><span class="tag dialog">Priest</span>―A month, my child?<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>Longer, father.<br> </p>
             <p class="dialog"><span class="tag dialog">Priest</span>Three months, my child?<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Longer, father.<br> </p>
-            <p class="dialog"><span class="tag dialog">Priest</span>―Six months?<span class="tag lineNumber">31485</span><br> </p>
+            <p class="dialog"><span class="tag dialog">Priest</span>―Six months?<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Eight months, father.<br></p> </p>
             <p class="textParagraph"> He had begun. The priest asked: <br>
             <p class="dialog"><span class="tag dialog">Priest</span>―And what do you remember since that time?<br></p> </p>
             <p class="textParagraph"> He began to confess his sins: masses missed, prayers not <br>
-            said, lies. <span class="tag lineNumber">31490</span><br>
+            said, lies. <span class="tag lineNumber">1490</span><br>
             <p class="dialog"><span class="tag dialog">Priest</span>―Anything else, my child?<br></p> </p>
             <p class="textParagraph"> Sins of anger, envy of  others, gluttony, vanity, disobedience. <br>
             <p class="dialog"><span class="tag dialog">Priest</span>―Anything else, my child?<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Sloth.<br> </p>
-            <p class="dialog"><span class="tag dialog">Priest</span>―Anything else, my child?<span class="tag lineNumber">31495</span><br></p> </p>
+            <p class="dialog"><span class="tag dialog">Priest</span>―Anything else, my child?<br></p> </p>
             <p class="textParagraph"> There was no help. He murmured: <br>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I .... committed sins of impurity, father.<br></p> </p>
             <p class="textParagraph"> The priest did not turn his head. <br>
             <p class="dialog"><span class="tag dialog">Priest</span>―With yourself, my child?<br> </p>
-            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―And ... with others.<span class="tag lineNumber">31500</span><br> </p>
+            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―And ... with others.<span class="tag lineNumber">1500</span><br> </p>
             <p class="dialog"><span class="tag dialog">Priest</span>―With women, my child?<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Yes, father.<br> </p>
             <p class="dialog"><span class="tag dialog">Priest</span>Were they married women, my child?<br></p> </p>
             <p class="textParagraph">He did not know. His sins trickled from his lips, one by one, <br>
-            trickled in shameful drops from his soul festering and oozing <span class="tag lineNumber">31505</span><br>
+            trickled in shameful drops from his soul festering and oozing <br>
             like a sore, a squalid stream of vice. The last sins oozed forth, <br>
             sluggish, filthy. There was no more to tell. He bowed his head, <br>
             overcome.<br> </p>
             <p class="textParagraph"> The priest was silent. Then he asked: <br>
-            <p class="dialog"><span class="tag dialog">Priest</span>―How old are you, my child?<span class="tag lineNumber">31510</span><br> </p>
+            <p class="dialog"><span class="tag dialog">Priest</span>―How old are you, my child?<span class="tag lineNumber">1510</span><br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Sixteen, father.<br></p> </p>
             The priest passed his hand several times over his face. Then, <br>
             resting his forehead against his hand, he leaned towards the <br>
             grating and, with eyes still averted, spoke slowly. His voice was <br>
-            weary and old. <span class="tag lineNumber">31515</span><br>
+            weary and old. <br>
             <p class="dialog"><span class="tag dialog">Priest</span>―You are very young, my child,</p> he said, <p class="dialog"><span class="tag dialog">Priest</span>and let me implore of <br>
             you to give up that sin. It is a terrible sin. It kills the body and <br>
             it kills the soul. It is the cause of many crimes and misfortunes. <br>
             Give it up, my child, for God' sake. It is dishonourable and <br>
-            unmanly. You cannot know where that wretched habit will <span class="tag lineNumber">31520</span><br>
+            unmanly. You cannot know where that wretched habit will <span class="tag lineNumber">1520</span><br>
             lead you or where it will come against you. As long as you <br>
             commit that sin, my poor child, you will never be worth one <br>
             farthing to God. Pray to our mother Mary to help you. She will <br>
             help you, my child. Pray to Our Blessed Lady when that sin <br>
-            comes into  your mind. I am sure you will do that, will you not? <span class="tag lineNumber">31525</span><br>
+            comes into  your mind. I am sure you will do that, will you not? <br>
             You repent of all those sins. I am sure you do. And you will <br>
             promise God now that by His holy grace you will never offend <br>
             Him any more by that wicked sin. You will make that solemn <br>
             promise to God, will you not?<br> </p>
-            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Yes, father.<span class="tag lineNumber">31530</span><br> </p>
+            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Yes, father.<span class="tag lineNumber">1530</span><br> </p>
             <p class="textParagraph">The old and weary voice fell like sweet rain upon his quak- <br>
             ing parching heart. How sweet and sad! <br>
             <p class="dialog"><span class="tag dialog">Priest</span>―Do so, my poor child. The devil has led you astray. Drive <br>
             him back to hell when he tempts you to dishonour your body <br>
-            in that way - the foul spirit who hates Our Lord. Promise God <span class="tag lineNumber">31535</span><br>
+            in that way - the foul spirit who hates Our Lord. Promise God <br>
             now that you will give up that sin, that wretched wretched sin.<br></p> </p>
             <p class="textParagraph">Blinded by his tears and by the light of God's mercifulness <br>
             he bent his head and heard the grave words of absolution <br>
             spoken and saw the priest's hand raised above him in token of <br>
-            forgiveness. <span class="tag lineNumber">31540</span><br>
+            forgiveness. <span class="tag lineNumber">1540</span><br>
             <p class="dialog"><span class="tag dialog">Priest</span>―God bless you, my child. Pray for me.<br></p> </p>
             <p class="textParagraph">He knelt to say his penance, praying in a corner of the dark <br>
             nave: and his prayers ascended to heaven from his purified <br>
             heart like perfume streaming upwards from a heart of white <br>
-            rose.<span class="tag lineNumber">31545</span><br> </p>
+            rose.<br> </p>
             <p class="textParagraph"> The  muddy streets were gay. He strode homeward, con- <br>
             scious of an  invisible grace pervading and making light his <br>
             limbs. In spite of all he had done it. He had confessed and God <br>
             had pardoned him. His soul was made fair and holy once more, <br>
-            holy and happy.<span class="tag lineNumber">31550</span><br> </p>
+            holy and happy.<span class="tag lineNumber">1550</span><br> </p>
             <p class="textParagraph"> It would be beautiful to die if God so willed. It was beautiful <br>
             to live if God so willed, to live in grace a life of peace and <br>
             virtue and forbearance with others.<br> </p>
             <p class="textParagraph"> He sat by the fire in the kitchen, not daring to speak for <br>
-            happiness. Till that moment he had not known how beautiful <span class="tag lineNumber">31555</span><br>
+            happiness. Till that moment he had not known how beautiful <br>
             and peaceful life could be. The green square of paper pinned <br>
             round the lamp cast down a tender shade. On the dresser was a <br>
             plate of sausages and white pudding and on the shelf there were <br>
             eggs. They would be for the breakfast in the morning after the <br>
-            communion in the college chapel. White pudding and eggs and <span class="tag lineNumber">31560</span><br>
+            communion in the college chapel. White pudding and eggs and <span class="tag lineNumber">1560</span><br>
             sausages and cups of tea. How simple and beautiful was life <br>
             after all! And life lay all before him.<br> </p>
             <p class="textParagraph"> In a dream he fell asleep. In a dream he rose and saw that it <br>
             was morning. In a waking dream he went through the quiet <br>
-            morning towards the college.<span class="tag lineNumber">31565</span><br> </p>
+            morning towards the college.<br> </p>
             <p class="textParagraph"> The boys were all there, kneeling in their places. He knelt <br>
             among them, happy and shy. The altar was heaped with fra- <br>
             grant masses of white flowers: and in the morning light the pale <br>
             flames of the candles among the white flowers were clear and <br>
-            silent as his own soul.<span class="tag lineNumber">31570</span><br> </p>
+            silent as his own soul.<span class="tag lineNumber">1570</span><br> </p>
             <p class="textParagraph"> He knelt before the altar with his classmates, holding the <br>
             altar cloth with them over a living rail of hands. His hands <br>
             were trembling: and his soul trembled as he heard the priest <br>
             pass with the ciborium from communicant to communicant. <br>
-            <p class="dialog"><span class="tag dialog">Priest</span>―Corpus Domini nostri.<span class="tag lineNumber">31575</span><br></p> </p>
+            <p class="dialog"><span class="tag dialog">Priest</span>―Corpus Domini nostri.<br></p> </p>
             <p class="textParagraph"> Could it be? He knelt there sinless and timid: and he would <br>
             hold upon his tongue the host and God would enter his purified <br>
             body. <br>
             <p class="dialog"><span class="tag dialog">Priest</span>―In vitam eternam. Amen.<br></p> </p>
-            <p class="textParagraph"> Another life! A life of grace and virtue and happiness! It was <span class="tag lineNumber">31580</span><br>
+            <p class="textParagraph"> Another life! A life of grace and virtue and happiness! It was <span class="tag lineNumber">1580</span><br>
             true. It was not a dream from which he would wake.  The past <br>
             was past. <br>
             <p class="dialog"><span class="tag dialog">Priest</span>―Corpus Domini nostri.<br></p> </p>
@@ -5122,237 +5122,237 @@
             Monday to the Holy Ghost, Tuesday to the Guardian Angels, <br>
             Wednesday to Saint Joseph, Thursday to the Most Blessed Sac- <br>
             rament of the Altar, Friday to the Suffering Jesus, Saturday to <br>
-            the Blessed Virgin Mary.<span class="tag lineNumber">40005</span><br> </p>
+            the Blessed Virgin Mary.<br> </p>
             <p class="textParagraph"> Every morning he hallowed himself anew in the presence of <br>
             some holy image or mystery. His day began with an heroic <br>
             offering of its every moment of thought or action for the intentions <br>
             tions of the sovereign pontiff and with an early mass. The raw <br>
-            morning air whetted his resolute piety; and often as he knelt <span class="tag lineNumber">40010</span><br>
+            morning air whetted his resolute piety; and often as he knelt <span class="tag lineNumber">10</span><br>
             among the few worshippers at the sidealtar, following with his <br>
             interleaved prayerbook the murmur of the priest, he glanced up <br>
             for an instant towards the vested figure standing in the gloom <br>
             between the two candles which were the old and the new <br>
-            testaments and imagined that he was kneeling at mass in the <span class="tag lineNumber">40015</span><br>
+            testaments and imagined that he was kneeling at mass in the <br>
             catacombs.<br> </p>
             <p class="textParagraph"> His daily life was laid out in devotional areas. By means of <br>
             ejaculations and prayers he stored up ungrudgingly for the <br>
             souls in purgatory centuries of days and quarantines and years; <br>
-            yet the spiritual triumph which he felt in achieving with ease so <span class="tag lineNumber">40020</span><br>
+            yet the spiritual triumph which he felt in achieving with ease so <span class="tag lineNumber">20</span><br>
             many fabulous ages of canonical penances did not wholly re- <br>
             ward his zeal of prayer since he could never know how much <br>
             temporal punishment he had remitted by way of suffrage for <br>
             the agonising souls: and, fearful lest in the midst of the purga- <br>
-            torial fire, which differed from the infernal only in that it was <span class="tag lineNumber">40025</span><br>
+            torial fire, which differed from the infernal only in that it was <br>
             not everlasting, his penance might avail no more than a drop of <br>
             moisture, he drove his soul daily through an increasing circle of <br>
             works of supererogation.<br> </p>
             <p class="textParagraph"> Every part of his day, divided by what he regarded now as <br>
-            the duties of his station in life, circled about its own centre of <span class="tag lineNumber">40030</span><br>
+            the duties of his station in life, circled about its own centre of <span class="tag lineNumber">30</span><br>
             spiritual energy. His life seemed to have drawn near to eternity; <br>
             every thought, word and deed, every instance of consciousness <br>
             could be made to revibrate radiantly in heaven: and at times his <br>
             sense of such immediate repercussion was so lively that he <br>
-            seemed to feel his soul in devotion pressing like fingers the <span class="tag lineNumber">40035</span><br>
+            seemed to feel his soul in devotion pressing like fingers the <br>
             keyboard of a great cash register and to see the amount of his <br>
             purchase start forth immediately in heaven, not as a number but <br>
             as a frail column of incense or as a slender flower.<br> </p>
             <p class="textParagraph"> The rosaries too which he said constantly - for he carried his <br>
-            beads loose in his trousers' pockets that he might tell them as <span class="tag lineNumber">40040</span><br>
+            beads loose in his trousers' pockets that he might tell them as <span class="tag lineNumber">40</span><br>
             he walked the streets - transformed themselves into coronals of <br>
             flowers of such vague unearthly texture that they seemed to <br>
             him as hueless and odourless as they were nameless. He offered <br>
             up each of his three daily chaplets that his soul might grow <br>
-            strong in each of the three theological virtues, in faith in the <span class="tag lineNumber">40045</span><br>
+            strong in each of the three theological virtues, in faith in the <br>
             Father Who had created him, in hope in the Son Who had <br>
             redeemed him, and in love of the Holy Ghost Who had sanc- <br>
             tified him, and this thrice triple prayer he offered to the Three <br>
             Persons through Mary in the name of her joyful and sorrowful <br>
-            and glorious  mysteries.<span class="tag lineNumber">40050</span><br> </p>
+            and glorious  mysteries.<span class="tag lineNumber">50</span><br> </p>
             <p class="textParagraph"> On each of the seven days of the week he further prayed that <br>
             one of the seven gifts of the Holy Ghost might descend upon <br>
             his soul and drive out of it day by day the seven deadly sins <br>
             which had defiled it in the past; and he prayed for each gift on <br>
-            its appointed day, confident that it would descend upon him, <span class="tag lineNumber">40055</span><br>
+            its appointed day, confident that it would descend upon him, <br>
             though it seemed strange to him at times that wisdom and <br>
             understanding and knowledge were so distinct in their nature <br>
             that each should be prayed for apart from the others. Yet he <br>
             believed that at some future stage of his spiritual progress this <br>
-            difficulty would be removed when his sinful soul had been <span class="tag lineNumber">40060</span><br>
+            difficulty would be removed when his sinful soul had been <span class="tag lineNumber">60</span><br>
             raised up from its weakness and enlightened by the Third Person <br>
             son of the Most Blessed Trinity. He believed this all the more, <br>
             and with trepidation, because of the divine gloom and silence <br>
             wherein dwelt the unseen Paraclete, Whose symbols were a <br>
-            dove and a mighty wind, to sin against Whom was a sin be- <span class="tag lineNumber">40065</span><br>
+            dove and a mighty wind, to sin against Whom was a sin be- <br>
             yond forgiveness, the eternal, mysterious secret Being to <br>
             Whom, as God, the priests offered up mass once a year, robed <br>
             in the scarlet of the tongues of fire.<br> </p>
             <p class="textParagraph"> The imagery through which the nature and kinship of the <br>
-            Three Persons of the Trinity were darkly shadowed forth in the <span class="tag lineNumber">40070</span><br>
+            Three Persons of the Trinity were darkly shadowed forth in the <span class="tag lineNumber">70</span><br>
             books of devotion which he read - the Father contemplating <br>
             from all eternity as in a mirror His Divine Perfections and <br>
             thereby begetting eternally the Eternal Son and the Holy Spirit <br>
             proceeding out of Father and Son from all eternity - were easier <br>
-            of acceptance by his mind by reason of their august incompre- <span class="tag lineNumber">40075</span><br>
+            of acceptance by his mind by reason of their august incompre- <br>
             hensibility than was the simple fact that God had loved his soul <br>
             from all eternity, for ages before he had been born into the <br>
             world, for ages before the world itself had existed. He had <br>
             heard the names of the passions of love and hate pronounced <br>
-            solemnly on the stage and in the pulpit, had found them set <span class="tag lineNumber">40080</span><br>
+            solemnly on the stage and in the pulpit, had found them set <span class="tag lineNumber">80</span><br>
             forth solemnly in books, and had wondered why his soul was <br>
             unable to harbour them for any time or to force his lips to utter <br>
             their names with conviction. A brief anger had often invested <br>
             him but he had never been able to make it an abiding passion <br>
-            and had always felt himself passing out of it as if his very body <span class="tag lineNumber">40085</span><br>
+            and had always felt himself passing out of it as if his very body <br>
             were being divested with ease of some outer skin or peel. He <br>
             had felt a subtle, dark and murmurous presence penetrate his <br>
             being and fire him with a brief iniquitous lust: it too had <br>
             slipped beyond his grasp leaving his mind lucid and indifferent. <br>
-            This, it seemed, was the only love and that the only hate his <span class="tag lineNumber">40090</span><br>
+            This, it seemed, was the only love and that the only hate his <span class="tag lineNumber">90</span><br>
             soul would harbour.<br> </p>
             <p class="textParagraph"> But he could no longer disbelieve in the reality of love since <br>
             God Himself had loved his individual soul with divine love <br>
             from all eternity. Gradually, as his soul was enriched with <br>
-            spiritual knowledge, he saw the whole world forming one vast <span class="tag lineNumber">40095</span><br>
+            spiritual knowledge, he saw the whole world forming one vast <br>
             symmetrical expression of God's power and love. Life became a <br>
             divine gift for every moment and sensation of which, were it <br>
             even the sight of a single leaf hanging on the twig of a tree, his <br>
             soul should praise and thank the Giver. The world for all its <br>
-            solid substance and complexity no longer existed for his soul <span class="tag lineNumber">40100</span><br>
+            solid substance and complexity no longer existed for his soul <span class="tag lineNumber">100</span><br>
             save as a theorem of divine power and love and universality. So <br>
             entire and unquestionable was this sense of the divine meaning <br>
             in all nature granted to his soul that he could scarcely understand <br>
             stand why it was in any way necessary that he should continue <br>
-            to live. Yet that was part of the divine purpose and he <span class="tag lineNumber">40105</span><br>
+            to live. Yet that was part of the divine purpose and he <br>
             dared not question its use, he above all others who had sinned <br>
             so deeply and so foully against the divine purpose. Meek and <br>
             abased by this consciousness of the one eternal omnipresent <br>
             perfect reality his soul took up again her burden of pieties, <br>
-            masses and prayers and sacraments and mortifications, and <span class="tag lineNumber">40110</span><br>
+            masses and prayers and sacraments and mortifications, and <span class="tag lineNumber">110</span><br>
             only then for the first time since he had brooded on the great <br>
             mystery of love did he feel within him a warm movement like <br>
             that of some newly born life or virtue of the soul itself. The <br>
             attitude of rapture in sacred art, the raised and parted hands, <br>
-            the parted lips and eyes as of one about to swoon, became for <span class="tag lineNumber">40115</span><br>
+            the parted lips and eyes as of one about to swoon, became for <br>
             him an image of the soul in prayer, humiliated and faint before <br>
             her Creator.<br> </p>
             <p class="textParagraph"> But he had been forewarned of the dangers of spiritual exal- <br>
             tation and did not allow himself to desist from even the least or <br>
-            lowliest devotion,  striving also by constant mortification to <span class="tag lineNumber">40120</span><br>
+            lowliest devotion,  striving also by constant mortification to <span class="tag lineNumber">120</span><br>
             undo the sinful past rather than to achieve a saintliness fraught <br>
             with peril. Each of his senses was brought under a rigorous <br>
             discipline. In order to mortify the sense of sight he made it his <br>
             rule to walk in the street with downcast eyes, glancing neither <br>
-            to right nor left and never behind him. His eyes shunned every <span class="tag lineNumber">40125</span><br>
+            to right nor left and never behind him. His eyes shunned every <br>
             encounter with the eyes of women. From time to time also he <br>
             balked them by a sudden effort of the will, as by lifting them <br>
             suddenly in the middle of an unfinished sentence and closing <br>
             the book. To mortify his hearing he exerted no control over his <br>
-            voice which was then breaking, neither sang nor whistled and <span class="tag lineNumber">40130</span><br>
+            voice which was then breaking, neither sang nor whistled and <span class="tag lineNumber">130</span><br>
             made no attempt to flee from noises which caused him painful <br>
             nervous irritation such as the sharpening of knives on the <br>
             knifeboard, the gathering of cinders on the fireshovel and the <br>
             twigging of the carpet. To mortify his smell was more difficult <br>
-            as he found in himself no instinctive repugnance to bad odours, <span class="tag lineNumber">40135</span><br>
+            as he found in himself no instinctive repugnance to bad odours, <br>
             whether they were the odours of the outdoor world such as <br>
             those of dung and tar or the odours of his own person among <br>
             which he had made many curious comparisons and experiments. <br>
             ments. He found in the end that the only odour against which <br>
-            his sense of smell revolted was a certain stale fishy stink like <span class="tag lineNumber">40140</span><br>
+            his sense of smell revolted was a certain stale fishy stink like <span class="tag lineNumber">140</span><br>
             that of longstanding urine: and whenever it was possible he <br>
             subjected himself to this unpleasant odour. To mortify the taste <br>
             he practised strict habits at table, observed to the letter all the <br>
             fasts of the church and sought by distraction to divert his mind <br>
-            from the savours of different foods. But it was to the mortification <span class="tag lineNumber">40145</span><br>
+            from the savours of different foods. But it was to the mortification <br>
             cation of touch that he brought the most assiduous ingenuity of <br>
             inventiveness. He never consciously changed his position in <br>
             bed, sat in the most uncomfortable positions, suffered patiently <br>
             every itch and pain, kept away from the fire, remained on his <br>
-            knees all through the mass except at the gospels, left parts of <span class="tag lineNumber">40150</span><br>
+            knees all through the mass except at the gospels, left parts of <span class="tag lineNumber">150</span><br>
             his neck and face undried so that air might sting them and, <br>
             whenever he was not saying his beads, carried his arms stiffly <br>
             at his sides like a runner and never in his pockets or clasped <br>
             behind him.<br> </p>
-            <p class="textParagraph"> He had no temptations to sin mortally. It surprised him <span class="tag lineNumber">40155</span><br>
+            <p class="textParagraph"> He had no temptations to sin mortally. It surprised him <br>
             however to find that at the end of his course of intricate piety <br>
             and selfrestraint he was so easily at the mercy of childish and <br>
             unworthy imperfections. His prayers and fasts availed him little <br>
             for the suppression of anger at hearing his mother sneeze or at <br>
-            being disturbed in his devotions. It needed an immense effort of <span class="tag lineNumber">40160</span><br>
+            being disturbed in his devotions. It needed an immense effort of <span class="tag lineNumber">160</span><br>
             his will to master the impulse which urged him to give outlet to <br>
             such irritation. Images of the outbursts of trivial anger which <br>
             he had often noted among his masters, their twitching mouths, <br>
             closeshut lips and flushed cheeks, recurred to his memory, dis- <br>
-            couraging him, for all his practice of humility, by the comparison. <span class="tag lineNumber">40165</span><br>
+            couraging him, for all his practice of humility, by the comparison. <br>
             son. To merge his life in the common tide of other lives was <br>
             harder for him than any fasting or prayer, and it was his <br>
             constant failure to do this to his own satisfaction which caused <br>
             in his soul at last a sensation of spiritual dryness together with <br>
-            a growth of doubts and  scruples. His soul traversed a period of <span class="tag lineNumber">40170</span><br>
+            a growth of doubts and  scruples. His soul traversed a period of <span class="tag lineNumber">170</span><br>
             desolation in which the sacraments themselves seemed to have <br>
             turned into dried up sources. His confession became a channel <br>
             for the escape of scrupulous and unrepented imperfections. His <br>
             actual reception of the eucharist did not bring him the same <br>
-            dissolving moments of virginal selfsurrender as did those spiritual <span class="tag lineNumber">40175</span><br>
+            dissolving moments of virginal selfsurrender as did those spiritual <br>
             tual communions made by him sometimes at the close of some <br>
             visit to the Blessed Sacrament. The book which he used for <br>
             these visits was an old neglected book written by saint Alphonsus <br>
             sus Liguori, with fading characters and sere foxpapered leaves. <br>
-            A faded world of fervent love and virginal responses seemed to <span class="tag lineNumber">40180</span><br>
+            A faded world of fervent love and virginal responses seemed to <span class="tag lineNumber">180</span><br>
             be evoked for his soul by the reading of its pages in which the <br>
             imagery of the canticles was interwoven with the communicant's <br>
             cant's prayers. An inaudible voice seemed to caress the soul, <br>
             telling her names and glories, bidding her arise as for espousal <br>
-            and come away, bidding her look forth, a spouse, from Amana <span class="tag lineNumber">40185</span><br>
+            and come away, bidding her look forth, a spouse, from Amana <br>
             and from the mountains of the leopards; and the soul seemed to <br>
             answer with the same inaudible voice, surrendering herself:<br> </p>
             <p class="textParagraph"> Inter ubera mea commorabitur.<br> </p>
             <p class="textParagraph"> This idea of surrender had a perilous attraction for his mind <br>
-            now that he felt his soul beset once again by the insistent voices <span class="tag lineNumber">40190</span><br>
+            now that he felt his soul beset once again by the insistent voices <span class="tag lineNumber">190</span><br>
             of the flesh which began to murmur to him again during his <br>
             prayers and meditations. It gave him an intense sense of power <br>
             to know that he  could by a single act of consent, in a moment <br>
             of thought, undo all that he had done. He seemed to feel a <br>
-            flood slowly advancing towards his naked feet and to be waiting <span class="tag lineNumber">40195</span><br>
+            flood slowly advancing towards his naked feet and to be waiting <br>
             ing for the first faint timid noiseless wavelet to touch his <br>
             fevered skin. Then, almost at the instant of that touch, almost <br>
             at the verge of sinful consent, he found himself standing far <br>
             away from the flood upon a dry shore, saved by a sudden act of <br>
-            the will or a sudden ejaculation: and, seeing the silver line of <span class="tag lineNumber">40200</span><br>
+            the will or a sudden ejaculation: and, seeing the silver line of <span class="tag lineNumber">200</span><br>
             the flood far away and beginning again its slow advance to- <br>
             wards his feet, a new thrill of power and satisfaction shook his <br>
             soul to know that he had not yielded nor undone all.<br> </p>
             <p class="textParagraph"> When he had eluded the flood of temptation many times in <br>
-            this way he grew troubled and wondered whether the grace <span class="tag lineNumber">40205</span><br>
+            this way he grew troubled and wondered whether the grace <br>
             which he had refused to lose was not being filched from him <br>
             little by little. The clear certitude of his own immunity grew <br>
             dim and to it succeeded a vague fear that his soul had really <br>
             fallen unawares. It was with difficulty that he won back his old <br>
-            consciousness of his state of grace by telling himself that he had <span class="tag lineNumber">40210</span><br>
+            consciousness of his state of grace by telling himself that he had <span class="tag lineNumber">210</span><br>
             prayed to God at every temptation and that the grace which he <br>
             had prayed for must have been given to him inasmuch as God <br>
             was obliged to give it. The very frequency and violence of <br>
             temptations showed him at last the truth of what he had heard <br>
-            about the trials of the saints. Frequent and violent temptations <span class="tag lineNumber">40215</span><br>
+            about the trials of the saints. Frequent and violent temptations <br>
             were a proof that the citadel of the soul had not fallen and that <br>
             the devil raged to make it fall.<br> </p>
             <p class="textParagraph"> Often when he had confessed his doubts and scruples, some <br>
             momentary inattention at prayer, a movement of trivial anger <br>
-            in his soul or a subtle wilfulness in speech or act, he was bidden <span class="tag lineNumber">40220</span><br>
+            in his soul or a subtle wilfulness in speech or act, he was bidden <span class="tag lineNumber">220</span><br>
             by his confessor to name some sin of his past life before absolution <br>
             ution was given him. He named it with humility and shame and <br>
             repented of it once more. It humiliated and shamed him to <br>
             think that he would never be freed from it wholly, however <br>
-            holily he might live or whatever virtues or perfections he might <span class="tag lineNumber">40225</span><br>
+            holily he might live or whatever virtues or perfections he might <br>
             attain. A restless feeling of guilt would always be present with <br>
             him: he would confess and repent and be absolved, confess and <br>
             repent again and be absolved again, fruitlessly. Perhaps that <br>
             first hasty confession wrung from him by the fear of hell had <br>
-            not been good? Perhaps, concerned only for his imminent <span class="tag lineNumber">40230</span><br>
+            not been good? Perhaps, concerned only for his imminent <span class="tag lineNumber">230</span><br>
             doom, he had not had sincere sorrow for his sin? But the surest <br>
             sign that his confession had been good and that he had had <br>
             sincere sorrow for his sin was, he knew, the amendment of his <br>
             life. <br>
-            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I have amended  my life, have I not? he asked himself.<span class="tag lineNumber">40235</span><br></p> </p>
+            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I have amended  my life, have I not? he asked himself.<br></p> </p>
             <div class="divider">* * *</div>
          
 
@@ -5361,373 +5361,373 @@
             to the light, leaning an elbow on the brown crossblind and, as <br>
             he spoke and smiled, slowly dangling and looping the cord of <br>
             the other blind. Stephen stood before him, following for a mo- <br>
-            ment with his eyes the waning of the long summer daylight <span class="tag lineNumber">40240</span><br>
+            ment with his eyes the waning of the long summer daylight <span class="tag lineNumber">240</span><br>
             above the roofs or the slow deft movements of the priestly <br>
             fingers. The priest's face was in total shadow but the waning <br>
             daylight from behind him touched the deeply grooved temples <br>
             and the curves of the skull. Stephen followed also with his ears <br>
-            the accents and intervals of the priest's voice as he spoke <span class="tag lineNumber">40245</span><br>
+            the accents and intervals of the priest's voice as he spoke <br>
             gravely and cordially of indifferent themes, the vacation which <br>
             had just ended, the colleges of the order abroad, the transference <br>
             ence of masters. The grave and cordial voice went on easily <br>
             with its tale, and in the pauses Stephen felt bound to set it on <br>
-            again with respectful questions. He knew that the tale was a <span class="tag lineNumber">40250</span><br>
+            again with respectful questions. He knew that the tale was a <span class="tag lineNumber">250</span><br>
             prelude and his mind waited for the sequel. Ever since the <br>
             message of summons had come for him from the director his <br>
             mind had struggled to find the meaning of the message; and <br>
             during the long restless time he had sat in the college parlour <br>
-            waiting for the director to come in his eyes had wandered from <span class="tag lineNumber">40255</span><br>
+            waiting for the director to come in his eyes had wandered from <br>
             one sober picture to another around the walls and his mind had <br>
             wandered from one guess to another until the meaning of the <br>
             summons had almost become clear. Then, just as he was wishing <br>
             ing that some unforeseen cause might prevent the director from <br>
-            coming he had heard the handle of the door turning and the <span class="tag lineNumber">40260</span><br>
+            coming he had heard the handle of the door turning and the <span class="tag lineNumber">260</span><br>
             swish of a soutane.<br> </p>
             <p class="textParagraph"> The director had begun to speak of the dominican and fran- <br>
             ciscan orders and of the friendship between saint Thomas and <br>
             saint Bonaventure. The capuchin dress, he thought, was rather <br>
-            too .......<span class="tag lineNumber">40265</span><br> </p>
+            too .......<br> </p>
             <p class="textParagraph"> Stephen's face gave back the priest's indulgent smile and, not <br>
             being anxious to give an opinion, he made a slight dubitative <br>
             movement with his lips. <br>
             <p class="dialog"><span class="tag dialog">the director</span>―I believe, continued the director, that there is some talk now <br>
-            among the capuchins themselves of doing away with it and <span class="tag lineNumber">40270</span><br>
+            among the capuchins themselves of doing away with it and <span class="tag lineNumber">270</span><br>
             following the example of the other franciscans.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I suppose they would retain it in the cloister, said Stephen.<br> </p>
             <p class="dialog"><span class="tag dialog">the director</span>―O certainly, said the director. For the cloister it is all right <br>
             but for the street I really think it would be better to do away <br>
-            with it, don't you?<span class="tag lineNumber">40275</span><br> </p>
+            with it, don't you?<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―It must be troublesome, I imagine.<br> </p>
             <p class="dialog"><span class="tag dialog">Priest</span>―Of course it is, of course. Just imagine when I was in Bel- <br>
             gium I used to see them out cycling in all kinds of weather with <br>
             this thing up about their knees! It was really ridiculous. Les <br>
-            jupes, they call them in Belgium.<span class="tag lineNumber">40280</span><br></p> </p>
+            jupes, they call them in Belgium.<span class="tag lineNumber">280</span><br></p> </p>
             <p class="textParagraph"> The vowel was so modified as to be indistinct. <br>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―What do they call them?<br> </p>
             <p class="dialog"><span class="tag dialog">Priest</span>―Les jupes.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>O.<br></p> </p>
-            <p class="textParagraph"> Stephen smiled again in answer to the smile which he could <span class="tag lineNumber">40285</span><br>
+            <p class="textParagraph"> Stephen smiled again in answer to the smile which he could <br>
             not see on the priest's shadowed face, its image or spectre only <br>
             passing rapidly across his mind as the low discreet accent fell <br>
             upon his ear. He gazed calmly before him at the waning sky, <br>
             glad of the cool of the evening and the faint yellow glow <br>
-            which hid the tiny flame kindling upon his cheek.<span class="tag lineNumber">40290</span><br> </p>
+            which hid the tiny flame kindling upon his cheek.<span class="tag lineNumber">290</span><br> </p>
             <p class="textParagraph"> The names of articles of dress worn by women or of certain <br>
             soft and delicate stuffs used in their making brought always to <br>
             his mind a delicate and sinful perfume. As a boy he had imagined <br>
             ined the reins by which horses are driven as slender silken <br>
-            bands and it shocked him to feel at <span class="hide">53.293003 -6.168866</span>Stradbrook the greasy <span class="tag lineNumber">40295</span><br>
+            bands and it shocked him to feel at <span class="hide">53.293003 -6.168866</span>Stradbrook the greasy <br>
             leather of harness. It had shocked him too when he had felt for <br>
             the first time beneath his tremulous fingers the brittle texture of <br>
             a woman's stocking for, retaining nothing of all he read save <br>
             that which seemed to him an echo or a prophecy of his own <br>
-            state, it was only amid softworded phrases or within rosesoft <span class="tag lineNumber">40300</span><br>
+            state, it was only amid softworded phrases or within rosesoft <span class="tag lineNumber">300</span><br>
             stuffs that he dared to conceive of the soul or body of a woman <br>
             moving with tender life.<br> </p>
             <p class="textParagraph"> But the phrase on the priest's lips was disingenuous for he <br>
             knew that a priest should not speak lightly on that theme. The <br>
-            phrase had been spoken lightly with design and he felt that his <span class="tag lineNumber">40305</span><br>
+            phrase had been spoken lightly with design and he felt that his <br>
             face was being searched by the eyes in the shadow. Whatever <br>
             he had heard or read of the craft of jesuits he had put aside <br>
             frankly as not borne out by his own experience. His masters, <br>
             even when they had not attracted him, had seemed to him <br>
-            always intelligent and serious priests, athletic and highspirited <span class="tag lineNumber">40310</span><br>
+            always intelligent and serious priests, athletic and highspirited <span class="tag lineNumber">310</span><br>
             prefects. He thought of them as men who washed their bodies <br>
             briskly with cold water and wore clean cold linen. During all <br>
             the years he had lived among them in <span class="hide">53.310601 -6.695541</span>Clongowes <br>
             and in <span class="hide">52.207800 -8.211070</span>Bel-
             vedere he had received only two pandies and, though these had <br>
-            been dealt him in the wrong, he knew that he had often escaped <span class="tag lineNumber">40315</span><br>
+            been dealt him in the wrong, he knew that he had often escaped <br>
             punishment. During all those years he had never heard from <br>
             any of his masters a flippant word: it was they who had taught <br>
             him christian doctrine and urged him to live a good life and, <br>
             when he had fallen into grievous sin, it was they who had led <br>
-            him back to grace. Their presence had made him diffident of <span class="tag lineNumber">40320</span><br>
+            him back to grace. Their presence had made him diffident of <span class="tag lineNumber">320</span><br>
             himself when he was a muff in Clongowes and it had made him <br>
             diffident of himself also while he had held his equivocal <br>
             position in Belvedere. A constant sense of this had remained <br>
             with him up to the last year of his school life. He had never <br>
-            once disobeyed or allowed turbulent companions to seduce him <span class="tag lineNumber">40325</span><br>
+            once disobeyed or allowed turbulent companions to seduce him <br>
             from his habit of quiet obedience: and, even when he doubted <br>
             some statement of a master, he had never presumed to doubt <br>
             openly. Lately some of their judgments had sounded a little <br>
             childish in his ears and had made him feel a regret and pity as <br>
-            though he were slowly passing out of an accustomed world and <span class="tag lineNumber">40330</span><br>
+            though he were slowly passing out of an accustomed world and <span class="tag lineNumber">330</span><br>
             were hearing its language for the last time. One day when some <br>
             boys had gathered round a priest under the shed near the <br>
             chapel he had heard the priest say:<br> </p>
             <p class="textParagraph"> ―I believe that Lord Macaulay was a man who probably never <br>
-            committed a mortal sin in his life, that is to say, a deliberate <span class="tag lineNumber">40335</span><br>
+            committed a mortal sin in his life, that is to say, a deliberate <br>
             mortal sin.<br> </p>
             <p class="textParagraph"> Some of the boys had then asked the priest if Victor Hugo <br>
             were not the greatest French writer. The priest had answered <br>
             that Victor Hugo had never written half so well when he had <br>
-            turned against the church as he had written when he was a <span class="tag lineNumber">40340</span><br>
+            turned against the church as he had written when he was a <span class="tag lineNumber">340</span><br>
             catholic. <br>
             <p class="dialog"><span class="tag dialog">Priest</span>―But there are many eminent French critics, said the priest, <br>
             who consider that even Victor Hugo, great as he certainly was, <br>
             had not so pure a French style as Louis Veuillot.<br></p> </p>
-            <p class="textParagraph"> The tiny flame which the priest's allusion had kindled upon <span class="tag lineNumber">40345</span><br>
+            <p class="textParagraph"> The tiny flame which the priest's allusion had kindled upon <br>
             Stephen's cheek had sunk down again and his eyes were still <br>
             fixed calmly on the colorless sky. But an unresting doubt flew <br>
             hither and thither before his mind. Masked memories passed <br>
             quickly before him: he recognised scenes and persons yet he <br>
-            was conscious that he had failed to perceive some vital circumstance <span class="tag lineNumber">40350</span><br>
+            was conscious that he had failed to perceive some vital circumstance <span class="tag lineNumber">350</span><br>
             stance in them. He saw himself walking about the grounds <br>
             watching the sports in <span class="hide">53.348746 -6.275034</span>Clongowes and eating slim jim out of his <br>
             cricketcap. Some jesuits were walking round the cycletrack in <br>
             the company of ladies. The echoes of certain expressions used <br>
-            in <span class="hide">53.348746 -6.275034</span>Clongowes sounded in remote caves of his mind.<span class="tag lineNumber">40355</span><br> </p>
+            in <span class="hide">53.348746 -6.275034</span>Clongowes sounded in remote caves of his mind.<br> </p>
             <p class="textParagraph"> His ears were listening to these distant echoes amid the si- <br>
             lence of the parlour when he became aware that the priest was <br>
             addressing him in a different voice.<br> </p>
             <p class="textParagraph"> ―I sent for you today, Stephen, because I wished to speak to <br>
-            you on a very important subject.<span class="tag lineNumber">40360</span><br> </p>
+            you on a very important subject.<span class="tag lineNumber">360</span><br> </p>
             <p class="textParagraph"> ―Yes, sir.<br> </p>
             <p class="textParagraph"> ―Have you ever felt that you had a vocation?<br> </p>
             <p class="textParagraph"> Stephen parted his lips to answer yes and then withheld the <br>
             word suddenly. The priest waited for the answer and added:<br> </p>
-            <p class="textParagraph"> ―I mean have you ever felt within yourself, in your soul, a <span class="tag lineNumber">40365</span><br>
+            <p class="textParagraph"> ―I mean have you ever felt within yourself, in your soul, a <br>
             desire to join the order. Think.<br> </p>
             <p class="textParagraph"> ―I have sometimes thought of it, said Stephen.<br> </p>
             <p class="textParagraph"> The priest let the blindcord fall to one side and, uniting his <br>
             hands, leaned his chin gravely upon them, communing with <br>
-            himself. <span class="tag lineNumber">40370</span><br>
+            himself. <span class="tag lineNumber">370</span><br>
             <p class="dialog"><span class="tag dialog">Priest</span>―In a college like this,</p> he said at length, <p class="dialog"><span class="tag dialog">Priest</span>there is one boy or <br>
             perhaps two or three boys whom God calls to the religious life. <br>
             Such a boy is marked off from his companions by his piety, by <br>
             the good example he shows to others. He is looked up to by <br>
-            them; he is chosen perhaps as prefect by his fellow sodalists. <span class="tag lineNumber">40375</span><br>
+            them; he is chosen perhaps as prefect by his fellow sodalists. <br>
             And you, Stephen, have been such a boy in this college, prefect <br>
             of Our Blessed Lady's sodality. Perhaps you are the boy in this <br>
             college whom God designs to call to Himself.<br></p> </p>
             <p class="textParagraph"> A strong note of pride reinforcing the gravity of the priest's <br>
-            voice made Stephen's heart quicken in response.<span class="tag lineNumber">40380</span><br> </p>
+            voice made Stephen's heart quicken in response.<span class="tag lineNumber">380</span><br> </p>
             <p class="textParagraph"> ―To receive that call, Stephen, said the priest, is the greatest <br>
             honour that the Almighty God can bestow upon a man. No <br>
             king or emperor on this earth has the power of the priest <br>
             of God. No angel or archangel in heaven, no saint, not even <br>
-            the Blessed Virgin herself has the power of a priest of God: the <span class="tag lineNumber">40385</span><br>
+            the Blessed Virgin herself has the power of a priest of God: the <br>
             power of the keys, the power to bind and to loose from sin, the <br>
             power of exorcism, the power to cast out from the creatures of <br>
             God the evil spirits that have power over them, the power, the <br>
             authority, to make the great God of Heaven come down upon <br>
-            the altar and take the form of bread and wine. What an awful <span class="tag lineNumber">40390</span><br>
+            the altar and take the form of bread and wine. What an awful <span class="tag lineNumber">390</span><br>
             power, Stephen!<br> </p>
             <p class="textParagraph"> A flame began to flutter again on Stephen's cheek as he <br>
             heard in this proud address an echo of his own proud musings. <br>
             How often had he seen himself as a priest wielding calmly and <br>
-            humbly the awful power of which angels and saints stood in <span class="tag lineNumber">40395</span><br>
+            humbly the awful power of which angels and saints stood in <br>
             reverence! His soul had loved to muse in secret on this desire. <br>
             He had seen himself, a young and silentmannered priest, en- <br>
             tering a confessional swiftly, ascending the altarsteps, in- <br>
             censing, genuflecting, accomplishing the vague acts of the <br>
-            priesthood which pleased him by reason of their semblance of <span class="tag lineNumber">40400</span><br>
+            priesthood which pleased him by reason of their semblance of <span class="tag lineNumber">400</span><br>
             reality and of their distance from it. In that dim life which he <br>
             had lived through in his musings he had assumed the voices and <br>
             gestures which he had noted with various priests. He had bent <br>
             his knee sideways like such a one, he had shaken the thurible <br>
-            only slightly like such a one, his chasuble had swung open like <span class="tag lineNumber">40405</span><br>
+            only slightly like such a one, his chasuble had swung open like <br>
             that of such another as he had turned to the altar again after <br>
             having blessed the people. And above all it had pleased him to <br>
             fill the second place in those dim scenes of his imagining. He <br>
             shrank from the dignity of celebrant because it displeased him <br>
-            to imagine that all the vague pomp should end in his own <span class="tag lineNumber">40410</span><br>
+            to imagine that all the vague pomp should end in his own <span class="tag lineNumber">410</span><br>
             person or that the ritual should assign to him so clear and final <br>
             an office. He longed for the minor sacred offices, to be vested <br>
             with the tunicle of subdeacon at high mass, to stand aloof from <br>
             the altar, forgotten by the people, his shoulders covered with a <br>
-            humeral veil, holding the paten within its folds, or, when the <span class="tag lineNumber">40415</span><br>
+            humeral veil, holding the paten within its folds, or, when the <br>
             sacrifice had  been accomplished, to stand as deacon in a dal- <br>
             matic of cloth of gold on the step below the celebrant, his <br>
             hands joined and his face towards the people, and sing the <br>
             chant Ite, missa est. If ever he had seen himself celebrant it was <br>
-            as in the pictures of the mass in his child's massbook, in a <span class="tag lineNumber">40420</span><br>
+            as in the pictures of the mass in his child's massbook, in a <span class="tag lineNumber">420</span><br>
             church without worshippers, save for the angel of the sacrifice, <br>
             at a bare altar and served by an acolyte scarcely more boyish <br>
             than himself. In vague sacrificial or sacramental acts alone his <br>
             will seemed drawn to go forth to encounter reality: and it was <br>
-            partly the absence of an appointed rite which had always con- <span class="tag lineNumber">40425</span><br>
+            partly the absence of an appointed rite which had always con- <br>
             strained him to inaction whether he had allowed silence to <br>
             cover his anger or pride or had suffered only an embrace he <br>
             longed to give.<br> </p>
             <p class="textParagraph"> He listened in reverent silence now to the priest's appeal and <br>
-            through the words he heard even more distinctly a voice bid- <span class="tag lineNumber">40430</span><br>
+            through the words he heard even more distinctly a voice bid- <span class="tag lineNumber">430</span><br>
             ding him approach, offering him secret knowledge and secret <br>
             power. He would know then what was the sin  of Simon Magus <br>
             and what the sin against the Holy Ghost for which there was <br>
             no forgiveness. He would know obscure things, hidden from <br>
-            others, from those who  were conceived and born children of <span class="tag lineNumber">40435</span><br>
+            others, from those who  were conceived and born children of <br>
             wrath. He would know the sins, the sinful longings and sinful <br>
             thoughts and sinful acts, of others, hearing them murmured <br>
             into his ears in the confessional under the shame of a darkened <br>
             chapel by the lips of women and of girls: but rendered immune <br>
-            mysteriously at his ordination by the imposition of hands his <span class="tag lineNumber">40440</span><br>
+            mysteriously at his ordination by the imposition of hands his <span class="tag lineNumber">440</span><br>
             soul would pass again uncontaminated to the white peace of <br>
             the altar. No touch of sin would linger upon the hands with <br>
             which he would elevate and break the host; no touch of sin <br>
             would linger on his lips in prayer to make him eat and drink <br>
-            damnation to himself, not discerning the body of the Lord. He <span class="tag lineNumber">40445</span><br>
+            damnation to himself, not discerning the body of the Lord. He <br>
             would hold his secret knowledge and secret power, being as <br>
             sinless as the innocent: and he would be a priest for ever <br>
             according to the order of Melchisedec.<br> </p>
             <p class="textParagraph"> ―I will offer up my mass tomorrow morning, said the director, <br>
-            tor, that Almighty God may reveal to you His holy will. And <span class="tag lineNumber">40450</span><br>
+            tor, that Almighty God may reveal to you His holy will. And <span class="tag lineNumber">450</span><br>
             let you, Stephen, make a novena to your holy patron saint, the first <br>
             martyr, who is very powerful with God, that God may en- <br>
             lighten your mind. But you must be quite sure, Stephen, that <br>
             you have a vocation because it would be terrible if you found <br>
-            afterwards that you had none. Once a priest always a priest, <span class="tag lineNumber">40455</span><br>
+            afterwards that you had none. Once a priest always a priest, <br>
             remember. Your catechism tells you that the sacrament of Holy <br>
             Orders is one of those which can be received only once because <br>
             it imprints on the soul an indelible spiritual mark which can <br>
             never be effaced. It is before you must weigh well, not after. It <br>
-            is a solemn question, Stephen, because on it may depend the <span class="tag lineNumber">40460</span><br>
+            is a solemn question, Stephen, because on it may depend the <span class="tag lineNumber">460</span><br>
             salvation of your eternal soul. But we will pray to God to- <br>
             gether.<br> </p>
             <p class="textParagraph"> He held open the heavy hall door and gave his hand as if <br>
             already to a companion in the spiritual life. Stephen passed out <br>
-            on to  the wide platform above the steps and was conscious of <span class="tag lineNumber">40465</span><br>
+            on to  the wide platform above the steps and was conscious of <br>
             the caress of mild evening air. Towards <span class="hide">53.354445 -6.263812</span>Findlater's church a <br>
             quartet of young men were striding along with linked arms, <br>
             swaying their heads and stepping to the agile melody of their <br>
             leader's concertina. The music passed in an instant, as the first <br>
-            bars of sudden music always did, over the fantastic fabrics of <span class="tag lineNumber">40470</span><br>
+            bars of sudden music always did, over the fantastic fabrics of <span class="tag lineNumber">470</span><br>
             his mind, dissolving them painlessly and noiselessly as a sudden <br>
             wave dissolves the sandbuilt turrets of children. Smiling at the <br>
             trivial air he raised his eyes to the priest's face and, seeing in it <br>
             a mirthless reflection of the sunken day, detached his hand <br>
-            slowly which had acquiesced  faintly in that companionship.<span class="tag lineNumber">40475</span><br> </p>
+            slowly which had acquiesced  faintly in that companionship.<br> </p>
             <p class="textParagraph"> As he descended the steps the impression which effaced his <br>
             troubled selfcommunion was that of a mirthless mask reflecting <br>
             a sunken day from the threshold of the college. The shadow, <br>
             then, of the life of the college passed gravely over his consciousness. <br>
-            ness. It was a grave and ordered and passionless life that <span class="tag lineNumber">40480</span><br>
+            ness. It was a grave and ordered and passionless life that <span class="tag lineNumber">480</span><br>
             awaited him, a life without material cares. He wondered how <br>
             he would pass the first night in the novitiate and with what <br>
             dismay he would wake the first morning in the dormitory. The <br>
             troubling odour of the long corridors of <span class="hide">53.348746 -6.275034</span>Clongowes came back <br>
-            to him and he heard the discreet murmur of the burning <span class="tag lineNumber">40485</span><br>
+            to him and he heard the discreet murmur of the burning <br>
             gasflames. At once from every part of his being unrest began to <br>
             irradiate. A feverish quickening of his pulses followed and a din <br>
             of meaningless words drove his reasoned thoughts hither and <br>
             thither confusedly. His lungs dilated and sank as if he were <br>
-            inhaling a warm moist unsustaining air and he smelt again the <span class="tag lineNumber">40490</span><br>
+            inhaling a warm moist unsustaining air and he smelt again the <span class="tag lineNumber">490</span><br>
             warm moist air which hung in the bath in <span class="hide">53.348746 -6.275034</span>Clongowes above the <br>
             sluggish turfcoloured water.<br> </p>
             <p class="textParagraph"> Some instinct, waking at these memories, stronger than edu- <br>
             cation or piety, quickened within him at every near approach <br>
-            to that life, an instinct subtle and hostile, and armed him <span class="tag lineNumber">40495</span><br>
+            to that life, an instinct subtle and hostile, and armed him <br>
             against acquiescence. The chill and order of the life repelled <br>
             him. He saw himself rising in the cold of the morning and filing <br>
             down with the others to early mass and trying vainly to <br>
             struggle with his prayers against the fainting sickness of his <br>
-            stomach. He saw himself sitting at dinner with the community <span class="tag lineNumber">40500</span><br>
+            stomach. He saw himself sitting at dinner with the community <span class="tag lineNumber">500</span><br>
             of a college. What, then, had become of that deeprooted shyness of <br>
             his which had made him loth to eat or drink under a strange <br>
             roof? What had come of the pride of his spirit which had <br>
             always made him conceive himself as a being apart in every <br>
-            order?<span class="tag lineNumber">40505</span><br> </p>
+            order?<br> </p>
             <p class="textParagraph"> The Reverend Stephen Dedalus, S.J.<br> </p>
             <p class="textParagraph"> His name in that new life leaped into characters before his <br>
             eyes and to it there followed a mental sensation of an unde- <br>
             fined face or colour of a face. The colour faded and became <br>
-            strong like a changing glow of pallid brick red. Was it the raw <span class="tag lineNumber">40510</span><br>
+            strong like a changing glow of pallid brick red. Was it the raw <span class="tag lineNumber">510</span><br>
             reddish glow he had so often seen on wintry mornings on the <br>
             shaven gills of the priests? The face was eyeless and sourfavoured <br>
             voured and devout, shot with pink tinges of suffocated anger. <br>
             Was it not a mental spectre of the face of one of the jesuits <br>
-            whom some of the boys called Lantern Jaws and others Foxy <span class="tag lineNumber">40515</span><br>
+            whom some of the boys called Lantern Jaws and others Foxy <br>
             Campbell?<br> </p>
             <p class="textParagraph"> He was passing at that moment before the <span class="hide">53.358000 -6.259655</span>jesuit house in <br>
             Gardiner Street, and wondered vaguely which window would <br>
             be his if he ever joined the order. Then he wondered at the <br>
-            vagueness of his wonder, at the remoteness of his soul <span class="tag lineNumber">40520</span><br>
+            vagueness of his wonder, at the remoteness of his soul <span class="tag lineNumber">520</span><br>
             from what he had hitherto imagined her sanctuary, at the frail <br>
             hold which so many years of order and obedience had of him <br>
             when once a definite and irrevocable act of his threatened to <br>
             end for ever, in time and in eternity, his freedom. The voice of <br>
-            the director urging upon him the proud claims of the church <span class="tag lineNumber">40525</span><br>
+            the director urging upon him the proud claims of the church <br>
             and the mystery and power of the priestly office repeated itself <br>
             idly in his memory. His soul was not there to hear and greet it <br>
             and he knew now that the exhortation he had listened to had <br>
             already fallen into an idle formal tale. He would never swing <br>
-            the thurible  before the tabernacle as priest. His destiny was to <span class="tag lineNumber">40530</span><br>
+            the thurible  before the tabernacle as priest. His destiny was to <span class="tag lineNumber">530</span><br>
             be elusive of social or religious orders. The wisdom of the <br>
             priest's appeal did not touch him to the quick. He was destined <br>
             to learn his own wisdom apart from others or to learn the <br>
             wisdom of others himself wandering among the snares of the <br>
-            world.<span class="tag lineNumber">40535</span><br> </p>
+            world.<br> </p>
             <p class="textParagraph"> The snares of the world were its ways of sin. He would fall. <br>
             He had not yet fallen but he would fall silently, in an instant. <br>
             Not to fall was too hard, too hard: and he felt the silent lapse <br>
             of his soul, as it would be at some instant to come, falling, <br>
-            falling but not yet fallen, still unfallen but about to fall.<span class="tag lineNumber">40540</span><br> </p>
+            falling but not yet fallen, still unfallen but about to fall.<span class="tag lineNumber">540</span><br> </p>
             <p class="textParagraph"> He crossed the bridge over the stream of the <span class="hide"> 53.361845 -6.242480</span>Tolka and <br>
             turned his eyes coldly for an instant towards the faded blue <br>
             shrine of the Blessed Virgin which stood fowlwise on a pole in <br>
             the middle of a hamshaped encampment of poor cottages. <br>
-            Then, bending to the left, he followed the lane which led up to <span class="tag lineNumber">40545</span><br>
+            Then, bending to the left, he followed the lane which led up to <br>
             his house. The faint sour stink of rotted cabbages came to- <br>
             wards him from the kitchengardens on the rising ground above <br>
             the river. He smiled to think that it was this disorder, the <br>
             misrule and confusion of his father's house and the stagnation <br>
-            of vegetable life, which was to win the day in his soul. Then a <span class="tag lineNumber">40550</span><br>
+            of vegetable life, which was to win the day in his soul. Then a <span class="tag lineNumber">550</span><br>
             short laugh broke from his lips as he thought of that solitary <br>
             farmhand in the kitchengardens behind their house whom they <br>
             had nicknamed the man with the hat. A second laugh, taking <br>
             rise from the first after a pause, broke from him involuntarily <br>
-            as he thought of how the man with the hat worked, considering <span class="tag lineNumber">40555</span><br>
+            as he thought of how the man with the hat worked, considering <br>
             in turn the four points of the sky and then regretfully plunging <br>
             his spade in the earth.<br> </p>
             <p class="textParagraph"> He pushed open the latchless door of the porch and passed <br>
             through the naked hallway into the kitchen. A group of his <br>
-            brothers and sisters was sitting round the table. Tea was nearly <span class="tag lineNumber">40560</span><br>
+            brothers and sisters was sitting round the table. Tea was nearly <span class="tag lineNumber">560</span><br>
             over and only the last of the second watered tea remained in <br>
             the bottoms of the small glassjars and jampots which did ser- <br>
             vice for teacups. Discarded crusts and lumps of sugared bread, <br>
             turned brown by the tea which had been poured over them, lay <br>
-            scattered on the table. Little wells of tea lay here and there on <span class="tag lineNumber">40565</span><br>
+            scattered on the table. Little wells of tea lay here and there on <br>
             the board and a knife with a broken ivory handle was stuck <br>
             through the pith of a ravaged turnover.<br> </p>
             <p class="textParagraph"> The sad quiet greyblue glow of the dying day came through <br>
             the window and the open door, covering over and allaying <br>
-            quietly a sudden instinct of remorse in Stephen's heart. All that <span class="tag lineNumber">40570</span><br>
+            quietly a sudden instinct of remorse in Stephen's heart. All that <span class="tag lineNumber">570</span><br>
             had been denied them had been freely given to him, the eldest: <br>
             but the quiet glow of evening showed him in their faces no sign <br>
             of rancour.<br> </p>
             <p class="textParagraph"> He sat near them at the table and asked where his father and <br>
-            mother were. One answered:<span class="tag lineNumber">40575</span><br> </p>
+            mother were. One answered:<br> </p>
             <p class="textParagraph"> ―Goneboro toboro lookboro atboro aboro houseboro.<br> </p>
             <p class="textParagraph"> Still another removal! A boy named Fallon in Belvedere had <br>
             often asked him with a silly laugh why they moved so often. A <br>
             frown of scorn darkened quickly his forehead as he heard again <br>
-            the silly laugh of the questioner.<span class="tag lineNumber">40580</span><br> </p>
+            the silly laugh of the questioner.<span class="tag lineNumber">580</span><br> </p>
             <p class="textParagraph"> He asked:<br> </p>
             <p class="textParagraph"> ―Why are we on the move again, if it's a fair question?<br> </p>
             <p class="textParagraph"> The same sister answered:<br> </p>
             <p class="textParagraph"> ―Becauseboro theboro landboro lordboro willboro putboro <br>
-            usboro outboro.<span class="tag lineNumber">40585</span><br> </p>
+            usboro outboro.<br> </p>
             <p class="textParagraph"> The voice of his youngest brother from the farther side of <br>
             the fireplace began to sing the air <span class="emph">Oft in the Stilly Night</span>. One <br>
             by one the others took up the air until a full choir of voices was <br>
             singing. They would sing so for hours, melody after melody, <br>
-            glee after glee, till the last pale light died down on the horizon, <span class="tag lineNumber">40590</span><br>
+            glee after glee, till the last pale light died down on the horizon, <span class="tag lineNumber">590</span><br>
             till the first dark nightclouds came forth and night fell.<br> </p>
             <p class="textParagraph"> He waited for some moments, listening, before he too took <br>
             up the air with them. He was listening with pain of spirit to the <br>
             overtone of weariness behind their frail fresh innocent voices. <br>
-            Even before they set out on life's journey they seemed weary <span class="tag lineNumber">40595</span><br>
+            Even before they set out on life's journey they seemed weary <br>
             already of the way.<br> </p>
             <p class="textParagraph"> He heard the choir of voices in the kitchen echoed and mul- <br>
             tiplied through an endless reverberation of the choirs of endless <br>
             generations of children: and heard in all the echoes an echo also <br>
-            of the recurring note of weariness and pain. All seemed weary <span class="tag lineNumber">40600</span><br>
+            of the recurring note of weariness and pain. All seemed weary <span class="tag lineNumber">600</span><br>
             of life even before entering upon it. And he remembered that <br>
             Newman had heard this note also in the broken lines of Virgil <br>
             <span class="emph">giving utterance, like the voice of Nature herself, to that pain <br>
             and weariness yet hope of better things which has been the <br>
-            experience of her children in every time.</span><span class="tag lineNumber">40605</span><br> </p>
+            experience of her children in every time.</span><br> </p>
         <div class="divider">* * *</div> 
          
         
@@ -5735,317 +5735,317 @@
             <p class="textParagraph"> From the door of Byron's publichouse to the gate of Clontarf <br>
             tarf Chapel, from the gate of <span class="hide">53.364179 -6.201478</span>Clontarf Chapel to the door of <br>
             Byron's publichouse and then back again to the chapel and <br>
-            then back again to the publichouse he had paced slowly at first, <span class="tag lineNumber">40610</span><br>
+            then back again to the publichouse he had paced slowly at first, <span class="tag lineNumber">610</span><br>
             planting his steps scrupulously in the spaces of the patchwork <br>
             of the footpath, then timing their fall to the fall of verses. A full <br>
             hour had passed since his father had gone in with Dan Crosby, <br>
             the tutor, to find out for him something about the <span class="hide">53.310485 -6.225058</span>university. <br>
-            For a full hour he had paced up and down, waiting: but he <span class="tag lineNumber">40615</span><br>
+            For a full hour he had paced up and down, waiting: but he <br>
             could wait no longer.<br> </p>
             <p class="textParagraph"> He set off abruptly for <span class="hide">53.359381 -6.179831</span>the Bull, walking rapidly lest his <br>
             father's shrill whistle might call him back; and in a few mo- <br>
             ments he had rounded the curve at the police barrack and was <br>
-            safe.<span class="tag lineNumber">40620</span><br> </p>
+            safe.<span class="tag lineNumber">620</span><br> </p>
             <p class="textParagraph"> Yes, his mother was hostile to the idea, as he  had read from <br>
             her listless silence. Yet her mistrust pricked him more keenly <br>
             than his father's pride and he thought coldly how he had <br>
             watched the faith which was fading down in his soul aging and <br>
-            strengthening in her eyes. A dim antagonism gathered force <span class="tag lineNumber">40625</span><br>
+            strengthening in her eyes. A dim antagonism gathered force <br>
             within him and darkened his mind as a cloud against her dis- <br>
             loyalty: and when it  passed, cloudlike, leaving his mind serene <br>
             and dutiful towards her again, he was made aware dimly and <br>
             without regret of a first noiseless sundering of their lives.<br> </p>
-            <p class="textParagraph"> The university! So he had passed beyond the challenge of the <span class="tag lineNumber">40630</span><br>
+            <p class="textParagraph"> The university! So he had passed beyond the challenge of the <span class="tag lineNumber">630</span><br>
             sentries who had stood as guardians of his boyhood and had <br>
             sought to keep him among them that he might be subject to <br>
             them and serve their ends. Pride after satisfaction uplifted him <br>
             like long slow waves. The end he had been born to serve yet <br>
-            did not see had led him to escape by an unseen path: and now it <span class="tag lineNumber">40635</span><br>
+            did not see had led him to escape by an unseen path: and now it <br>
             beckoned to him once more and a new adventure was about to <br>
             be opened to him. It seemed to him that he heard notes of fitful <br>
             music leaping upwards a tone and downwards a diminished <br>
             fourth, upwards a tone and downwards a major third, like <br>
-            triplebranching flames leaping fitfully, flame after flame, out of <span class="tag lineNumber">40640</span><br>
+            triplebranching flames leaping fitfully, flame after flame, out of <span class="tag lineNumber">640</span><br>
             a midnight wood. It was an elfin prelude, endless and formless; <br>
             and, as it grew wilder and faster, the flames leaping out of <br>
             time, he seemed to hear from under the boughs and grasses <br>
             wild creatures racing, their feet pattering like rain upon the <br>
-            leaves. Their feet passed in pattering tumult over his mind, the <span class="tag lineNumber">40645</span><br>
+            leaves. Their feet passed in pattering tumult over his mind, the <br>
             feet of hares and rabbits, the feet of harts and hinds and ante- <br>
             lopes, until he heard them no more and remembered only a <br>
             proud cadence from Newman: <span class="emph">Whose feet are as the feet of <br>
             harts and underneath the everlasting arms.</span><br> </p>
-            <p class="textParagraph"> The pride of that dim image brought back to his mind the <span class="tag lineNumber">40650</span><br>
+            <p class="textParagraph"> The pride of that dim image brought back to his mind the <span class="tag lineNumber">650</span><br>
             dignity of the office he had refused. All through his boyhood he <br>
             had mused upon that which he had so often thought to be his <br>
             destiny and when the moment had come for him to obey the <br>
             call he had turned aside, obeying a wayward instinct. Now <br>
-            time lay between: the oils of ordination would never anoint his <span class="tag lineNumber">40655</span><br>
+            time lay between: the oils of ordination would never anoint his <br>
             body. He had refused. Why?<br> </p>
             <p class="textParagraph"> He turned seaward  from the road at <span class="hide">53.365979 -6.174239</span>Dollymount and as he <br>
             passed on to the thin wooden bridge he felt the planks shaking <br>
             with the tramp of heavily shod feet. A squad of christian <br>
-            brothers was on its way back from the <span class="hide">53.369769 -6.147334</span>Bull and had begun to <span class="tag lineNumber">40660</span><br>
+            brothers was on its way back from the <span class="hide">53.369769 -6.147334</span>Bull and had begun to <span class="tag lineNumber">660</span><br>
             pass, two by two, across the bridge. Soon the whole bridge was <br>
             trembling and resounding. The uncouth faces passed him two <br>
             by two, stained yellow or red or livid by the sea, and as he <br>
             strove to look at them with ease and indifference, a faint stain <br>
-            of personal shame and commiseration rose to his own face. <span class="tag lineNumber">40665</span><br>
+            of personal shame and commiseration rose to his own face. <br>
             Angry with himself he tried to hide his face from their eyes by <br>
             gazing down sideways into the shallow swirling water under <br>
             the bridge but he still saw a reflection therein of their topheavy <br>
             silk hats, and humble tapelike collars and loosely hanging cleri- <br>
-            cal clothes. <span class="tag lineNumber">40670</span><br>
+            cal clothes. <span class="tag lineNumber">670</span><br>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Brother Hickey. <br>
             Brother Quaid. <br>
             Brother MacArdle. <br>
             Brother Keogh.<br></p> </p>
-            <p class="textParagraph"> Their piety would be like their names, like their faces, like <span class="tag lineNumber">40675</span><br>
+            <p class="textParagraph"> Their piety would be like their names, like their faces, like <br>
             their clothes, and it was idle for him to tell himself that their <br>
             humble and contrite hearts, it might be, paid a far richer tribute <br>
             of devotion than his had ever been, a gift tenfold more acceptable <br>
             able than his elaborate adoration. It was idle for him to move <br>
-            himself to be generous towards them, to tell himself that if he <span class="tag lineNumber">40680</span><br>
+            himself to be generous towards them, to tell himself that if he <span class="tag lineNumber">680</span><br>
             ever came to their gates, stripped of his pride, beaten and in <br>
             beggar's weeds, that they would be generous towards him, <br>
             loving him as themselves. Idle and embittering, finally,  to ar- <br>
             gue, against his own dispassionate certitude, that the com- <br>
-            mandment of love bade us not to love our neighbour  as <span class="tag lineNumber">40685</span><br>
+            mandment of love bade us not to love our neighbour  as <br>
             ourselves with the same amount and intensity of love but to <br>
             love him as ourselves with the same kind of love.<br> </p>
             <p class="textParagraph"> He drew forth a phrase from his treasure and spoke it softly <br>
             to himself:<br> </p>
-            <p class="textParagraph"> ―A day of dappled seaborne clouds.<span class="tag lineNumber">40690</span><br> </p>
+            <p class="textParagraph"> ―A day of dappled seaborne clouds.<span class="tag lineNumber">690</span><br> </p>
             <p class="textParagraph"> The phrase and the day and the scene harmonised in a <br>
             chord. Words. Was it their colours? He allowed them to glow <br>
             and fade, hue after hue: sunrise gold, the russet and green of <br>
             apple orchards, azure of waves, the greyfringed fleece of <br>
-            clouds. No, it was not their colours: it was the poise and <span class="tag lineNumber">40695</span><br>
+            clouds. No, it was not their colours: it was the poise and <br>
             balance of the period itself. Did he then love the rhythmic rise <br>
             and fall of words better than their associations of legend and <br>
             colour? Or was it that, being as weak of sight as he was shy of <br>
             mind, he drew less pleasure from the reflection of the glowing <br>
-            sensible world through the prism of a language manycoloured <span class="tag lineNumber">40700</span><br>
+            sensible world through the prism of a language manycoloured <span class="tag lineNumber">700</span><br>
             and richly storied than from the contemplation of an inner <br>
             world of individual emotions mirrored perfectly in a lucid <br>
             supple periodic prose?<br> </p>
             <p class="textParagraph"> He passed from the trembling bridge on to firm land again. <br>
-            At that instant, as it seemed to him, the air was chilled and <span class="tag lineNumber">40705</span><br>
+            At that instant, as it seemed to him, the air was chilled and <br>
             looking askance towards the water he saw a flying squall dark- <br>
             ening and crisping suddenly the tide. A faint click at his heart, a <br>
             faint throb in his throat told him once more of how his flesh <br>
             dreaded the cold infrahuman odour of the sea: yet he did not <br>
-            strike across the downs on his left but held straight on along <span class="tag lineNumber">40710</span><br>
+            strike across the downs on his left but held straight on along <span class="tag lineNumber">710</span><br>
             the spine of rocks that pointed against the river's mouth.<br> </p>
             <p class="textParagraph"> A veiled sunlight lit up faintly the grey sheet of water where <br>
             the river was embayed. In the distance along the course of the <br>
             slowflowing Liffey slender masts flecked the sky and, more <br>
-            distant still, the dim fabric of the city lay prone in haze. Like a <span class="tag lineNumber">40715</span><br>
+            distant still, the dim fabric of the city lay prone in haze. Like a <br>
             scene on some vague arras, old as man's weariness, the image <br>
             of the seventh city of christendom was visible to him across the <br>
             timeless air, no older nor more weary nor less patient of subjection <br>
             tion than in the days of the thingmote.<br> </p>
-            <p class="textParagraph"> Disheartened, he raised his eyes towards the slowdrifting <span class="tag lineNumber">40720</span><br>
+            <p class="textParagraph"> Disheartened, he raised his eyes towards the slowdrifting <span class="tag lineNumber">720</span><br>
             clouds, dappled and seaborne. They were voyaging across the <br>
             deserts of the sky, a host of nomads on the march, voyaging <br>
             high over Ireland, westward bound. The Europe they had come <br>
             from lay out there beyond the <span class="hide">53.13 -5.32</span>Irish Sea, Europe of strange <br>
-            tongues and valleyed and woodbegirt and citadelled and of <span class="tag lineNumber">40725</span><br>
+            tongues and valleyed and woodbegirt and citadelled and of <br>
             entrenched and marshalled races. He heard a confused music <br>
             within him as of memories and names which he was almost <br>
             conscious of but could not capture even for an instant; then the <br>
             music seemed to recede, to  recede, to recede: and from each <br>
-            receding trail of nebulous music there fell always one long- <span class="tag lineNumber">40730</span><br>
+            receding trail of nebulous music there fell always one long- <span class="tag lineNumber">730</span><br>
             drawn calling note, piercing like a star the dusk of silence. <br>
             Again! Again! Again! Again! A voice from beyond the world <br>
             was calling. <br>
             <p class="dialog"><span class="tag dialog">a voice</span>―Hello, Stephanos!<br> </p>
-            <p class="dialog"><span class="tag dialog">a voice</span>―Here comes The Dedalus!<span class="tag lineNumber">40735</span><br> </p>
+            <p class="dialog"><span class="tag dialog">a voice</span>―Here comes The Dedalus!<br> </p>
             <p class="dialog"><span class="tag dialog">a voice</span>―Ao! ... Eh, give it over, Dwyer, I'm telling you or I'll give you <br>
             a stuff in the kisser for yourself .... Ao!<br> </p>
             <p class="dialog"><span class="tag dialog">a voice</span>―Good man, Towser! Duck him!<br> </p>
             <p class="dialog"><span class="tag dialog">a voice</span>―Come along, Dedalus! Bous Stephanoumenos! Bous Steph- <br>
-            aneforos!<span class="tag lineNumber">40740</span><br> </p>
+            aneforos!<span class="tag lineNumber">740</span><br> </p>
             <p class="dialog"><span class="tag dialog">a voice</span>―Duck him! Guzzle him now, Towser!<br> </p>
             <p class="dialog"><span class="tag dialog">a voice</span>―Help! Help! ... Ao!<br></p> </p>
             <p class="textParagraph"> He recognised their speech collectively before he distin- <br>
             guished their faces. The mere sight of that medley of wet <br>
-            nakedness chilled him to the bone. Their bodies, corpsewhite <span class="tag lineNumber">40745</span><br>
+            nakedness chilled him to the bone. Their bodies, corpsewhite <br>
             or suffused with a pallid golden light or rawly tanned by the <br>
             sun, gleamed with the wet of the sea. Their divingstone, poised <br>
             on its rude supports and rocking under their plunges, and the <br>
             roughhewn stones of the sloping breakwater over which they <br>
-            scrambled in their horseplay, gleamed with cold wet lustre. The <span class="tag lineNumber">40750</span><br>
+            scrambled in their horseplay, gleamed with cold wet lustre. The <span class="tag lineNumber">750</span><br>
             towels with which they smacked their bodies were heavy with <br>
             cold seawater: and drenched with cold brine was their matted <br>
             hair.<br> </p>
             <p class="textParagraph"> He stood still in deference to their calls and parried their <br>
-            banter with easy words. How characterless they looked: Shuley <span class="tag lineNumber">40755</span><br>
+            banter with easy words. How characterless they looked: Shuley <br>
             without his deep unbuttoned collar, Ennis without his scarlet <br>
             belt with the snaky clasp, and Connolly  without his <span class="hide">52.613969 0.886402</span>Norfolk <br>
             coat with the flapless sidepockets!  It was a pain to see them and <br>
             a swordlike pain to see the signs of adolescence that made <br>
-            repellent their pitiable nakedness. Perhaps they had taken refuge <span class="tag lineNumber">40760</span><br>
+            repellent their pitiable nakedness. Perhaps they had taken refuge <span class="tag lineNumber">760</span><br>
             uge in number and noise from the secret dread in their souls. <br>
             But he, apart from them and in silence, remembered in what <br>
             dread he stood of the mystery of his own body.<br> </p>
             <p class="textParagraph"> ―Stephanos Dedalos! Bous Stephanoumenos! Bous Stephane- <br>
-            foros!<span class="tag lineNumber">40765</span><br> </p>
+            foros!<br> </p>
             <p class="textParagraph"> Their banter was not new to him and now it <br>
             flattered his mild proud sovereignty. Now, as never before, his <br>
             strange name seemed to him a prophecy. So timeless seemed <br>
             the grey warm air, so fluid and impersonal his own mood, that <br>
-            all ages were as one to him. A moment before the ghost of <span class="tag lineNumber">40770</span><br>
+            all ages were as one to him. A moment before the ghost of <span class="tag lineNumber">770</span><br>
             the ancient kingdom of the Danes had looked forth through the <br>
             vesture of the hazewrapped city. Now, at the name of the <br>
             fabulous artificer, he seemed to hear the noise of dim waves <br>
             and to see a winged form flying above the waves and slowly <br>
-            climbing the air. What did it mean? Was it a quaint device <span class="tag lineNumber">40775</span><br>
+            climbing the air. What did it mean? Was it a quaint device <br>
             opening a page of some medieval book of prophecies and sym- <br>
             bols, a hawklike man flying sunward above the sea, a prophecy <br>
             of the end he had been born to serve and had been following <br>
             through the mists of childhood and boyhood, a symbol of the <br>
-            artist forging anew in his workshop out of the sluggish matter <span class="tag lineNumber">40780</span><br>
+            artist forging anew in his workshop out of the sluggish matter <span class="tag lineNumber">780</span><br>
             of the earth a new soaring impalpable imperishable being?<br> </p>
             <p class="textParagraph"> His heart trembled;  his breath came faster and a wild spirit <br>
             passed over his limbs as though he were soaring sunward. His <br>
             heart trembled in an ecstasy of fear and his soul was in flight. <br>
-            His soul was soaring in an air beyond the world and the body <span class="tag lineNumber">40785</span><br>
+            His soul was soaring in an air beyond the world and the body <br>
             he knew was purified in a breath and delivered of incertitude <br>
             and made radiant and commingled with the element of the <br>
             spirit. An ecstasy of flight made radiant his eyes and wild his <br>
             breath and tremulous and wild and radiant his windswept <br>
-            limbs. <span class="tag lineNumber">40790</span><br>
-            <p class="dialog"><span class="tag dialog">a voice</span>―One! Two! ... Look out!<span class="tag lineNumber">40790</span><br> </p>
+            limbs. <span class="tag lineNumber">790</span><br>
+            <p class="dialog"><span class="tag dialog">a voice</span>―One! Two! ... Look out!<span class="tag lineNumber">790</span><br> </p>
             <p class="dialog"><span class="tag dialog">a voice</span>―O, cripes, I'm drownded!<br> </p>
             <p class="dialog"><span class="tag dialog">a voice</span>―One! Two! Three and away!<br> </p>
             <p class="dialog"><span class="tag dialog">a voice</span>―Me next! Me next!<br> </p>
-            <p class="dialog"><span class="tag dialog">a voice</span>―One! ... Uk!<span class="tag lineNumber">40795</span><br> </p>
+            <p class="dialog"><span class="tag dialog">a voice</span>―One! ... Uk!<br> </p>
             <p class="dialog"><span class="tag dialog">a voice</span>―Stephaneforos!<br></p> </p>
             <p class="textParagraph"> His throat ached with a desire to cry aloud, the cry of a <br>
             hawk or eagle on high, to cry piercingly of his deliverance to <br>
             the winds. This was the call of life to his soul not the dull gross <br>
-            voice of the world of duties and despair, not the inhuman voice <span class="tag lineNumber">40800</span><br>
+            voice of the world of duties and despair, not the inhuman voice <span class="tag lineNumber">800</span><br>
             that had called him to the pale service of the altar. An instant <br>
             of wild flight had delivered him and the cry of triumph which <br>
             his lips withheld cleft his brain. <br>
             <p class="dialog"><span class="tag dialog">a voice</span>―Stephaneforos!<br></p> </p>
-            <p class="textParagraph"> What were they now but cerements shaken from the body of <span class="tag lineNumber">40805</span><br>
+            <p class="textParagraph"> What were they now but cerements shaken from the body of <br>
             death death - the fear he had walked in night and day, the incertitude <br>
             that had ringed him round, the shame that had abased him <br>
             within and without - cerements, the linens of the grave?<br> </p>
             <p class="textParagraph"> His soul had arisen from the grave of boyhood, spurning her <br>
-            graveclothes. Yes! Yes! Yes! He would create proudly out of the <span class="tag lineNumber">40810</span><br>
+            graveclothes. Yes! Yes! Yes! He would create proudly out of the <span class="tag lineNumber">810</span><br>
             freedom and power of his soul, as the great artificer whose <br>
             name he bore, a living thing, new and soaring and beautiful, <br>
             impalpable, imperishable.<br> </p>
             <p class="textParagraph"> He started up nervously from the stoneblock for he could no <br>
-            longer quench the flame in his blood. He felt his cheeks aflame <span class="tag lineNumber">40815</span><br>
+            longer quench the flame in his blood. He felt his cheeks aflame <br>
             and his throat throbbing with song. There was a lust of wan- <br>
             dering in his feet that burned to set out for the ends of the <br>
             earth. On! On! his heart seemed to cry. Evening would deepen <br>
             above the sea, night fall upon the plains, dawn glimmer before <br>
-            the wanderer and show him strange fields and hills and faces. <span class="tag lineNumber">40820</span><br>
+            the wanderer and show him strange fields and hills and faces. <span class="tag lineNumber">820</span><br>
             Where?<br> </p>
             <p class="textParagraph"> He looked northward towards <span class="hide">53.378569 -6.057013</span>Howth. The sea had fallen <br>
             below the line of seawrack on the shallow side of the breakwater <br>
             water and already the tide was running out fast along the <br>
-            foreshore. Already one long oval bank of sand lay warm and <span class="tag lineNumber">40825</span><br>
+            foreshore. Already one long oval bank of sand lay warm and <br>
             dry amid the wavelets. Here and there warm isles of sand <br>
             gleamed above the shallow tide, and about the isles and around <br>
             the long bank and amid the shallow currents of the beach were <br>
             lightclad gayclad figures, wading and delving.<br> </p>
-            <p class="textParagraph"> In a few moments he was barefoot, his stockings folded in <span class="tag lineNumber">40830</span><br>
+            <p class="textParagraph"> In a few moments he was barefoot, his stockings folded in <span class="tag lineNumber">830</span><br>
             his pockets and his canvas shoes dangling by their knotted laces <br>
             over his shoulders: and, picking a pointed salteaten stick out of <br>
             the jetsam among the rocks, he clambered down the slope of <br>
             the breakwater.<br> </p>
-            <p class="textParagraph"> There was a long rivulet in the <span class="hide">53.366498 -6.147804</span>strand: and, as he waded <span class="tag lineNumber">40835</span><br>
+            <p class="textParagraph"> There was a long rivulet in the <span class="hide">53.366498 -6.147804</span>strand: and, as he waded <br>
             slowly up its course, he wondered at the endless drift of sea- <br>
             weed. Emerald and black and russet and olive, it moved <br>
             beneath the current, swaying and turning. The water of the <br>
             rivulet was dark with endless drift and mirrored the highdrifting <br>
-            ing clouds. The clouds were drifting above him silently and <span class="tag lineNumber">40840</span><br>
+            ing clouds. The clouds were drifting above him silently and <span class="tag lineNumber">840</span><br>
             silently the seatangle was drifting below him; and the grey <br>
             warm air was still: and a new wild life was singing in his veins.<br> </p>
             <p class="textParagraph"> Where was his boyhood now? Where was the soul that had <br>
             hung back from her destiny, to brood alone upon the shame of <br>
-            her wounds and in her house of squalor and subterfuge to <span class="tag lineNumber">40845</span><br>
+            her wounds and in her house of squalor and subterfuge to <br>
             queen it in faded cerements and in wreaths that withered at the <br>
             touch? Or where was he?<br> </p>
             <p class="textParagraph"> He was alone. He was unheeded, happy and near to the wild <br>
             heart of life. He was alone and young and wilful and wild- <br>
-            hearted, alone amid a waste of wild air and brackish waters <span class="tag lineNumber">40850</span><br>
+            hearted, alone amid a waste of wild air and brackish waters <span class="tag lineNumber">850</span><br>
             and the seaharvest of shells and tangle and veiled grey sunlight <br>
             and gayclad lightclad figures, of children and girls and voices <br>
             childish and girlish in the air.<br> </p>
             <p class="textParagraph"> A girl stood before him in midstream, alone and still, gazing <br>
-            out to sea. She seemed like one whom magic had changed into <span class="tag lineNumber">40855</span><br>
+            out to sea. She seemed like one whom magic had changed into <br>
             the likeness of a strange and beautiful seabird. Her long slender <br>
             bare legs were delicate as a crane's and pure save where an <br>
             emerald trail of seaweed had fashioned itself as a sign upon the <br>
             flesh. Her thighs, fuller and softhued as ivory, were bared al- <br>
-            most to the hips where the white fringes of her drawers were <span class="tag lineNumber">40860</span><br>
+            most to the hips where the white fringes of her drawers were <span class="tag lineNumber">860</span><br>
             like featherings of soft white down. Her slateblue skirts were <br>
             kilted boldly about her waist and dovetailed behind her. Her <br>
             bosom was as  a bird's soft and slight, slight and soft as the <br>
             breast of some darkplumaged dove. But her long fair hair was <br>
-            girlish; and girlish, and touched with the wonder of mortal <span class="tag lineNumber">40865</span><br>
+            girlish; and girlish, and touched with the wonder of mortal <br>
             beauty, her face.<br> </p>
             <p class="textParagraph"> She was alone and still, gazing out to sea; and when she felt <br>
             his presence and the worship of his eyes her eyes turned to him <br>
             in quiet sufferance of his gaze, without shame or wantonness. <br>
-            Long, long she suffered his gaze and then quietly withdrew her <span class="tag lineNumber">40870</span><br>
+            Long, long she suffered his gaze and then quietly withdrew her <span class="tag lineNumber">870</span><br>
             eyes from his and bent them towards the stream, gently stirring <br>
             the water with her foot hither and thither. The first faint noise <br>
             of gently moving water broke the silence, low and faint and <br>
             whispering, faint as the bells of sleep; hither and thither, hither <br>
-            and thither: and a faint flame trembled on her cheek.<span class="tag lineNumber">40875</span><br> </p>
+            and thither: and a faint flame trembled on her cheek.<br> </p>
             <p class="textParagraph"> ―Heavenly God! cried Stephen's soul, in an outburst of pro- <br>
             fane joy.<br> </p>
             <p class="textParagraph"> He turned away from her suddenly and set off across the <span class="hide">53.366498 -6.147804</span> <br>
             strand. His cheeks  were aflame; his body was aglow; his limbs <br>
-            were trembling. On and on and on and on he strode, far out <span class="tag lineNumber">40880</span><br>
+            were trembling. On and on and on and on he strode, far out <span class="tag lineNumber">880</span><br>
             over the sands, singing wildly to the sea, crying to greet the <br>
             advent of the life that had cried to him.<br> </p>
             <p class="textParagraph"> Her image had passed into his soul for ever and no word had <br>
             broken the holy silence of his ecstasy. Her eyes had called him <br>
-            and his soul had leaped at the call. To live, to err, to fall, to <span class="tag lineNumber">40885</span><br>
+            and his soul had leaped at the call. To live, to err, to fall, to <br>
             triumph, to recreate life out of life! A wild angel had appeared <br>
             to him, the angel of mortal youth and beauty, an envoy from <br>
             the fair courts of life, to throw open before him in an instant of <br>
             ecstasy the gates of all the ways of error and glory. On and on <br>
-            and on and on!<span class="tag lineNumber">40890</span><br> </p>
+            and on and on!<span class="tag lineNumber">890</span><br> </p>
             <p class="textParagraph"> He halted suddenly and heard his heart in the silence. How <br>
             far had he walked? What hour was it?<br> </p>
             <p class="textParagraph"> There was no human figure near him nor any sound borne <br>
             to him over the air. But the tide was near the turn and already <br>
-            the day was on the wane. He turned landward and ran towards <span class="tag lineNumber">40895</span><br>
+            the day was on the wane. He turned landward and ran towards <br>
             the shore and, running up the sloping beach, reckless of the <br>
             sharp shingle, found a sandy nook amid a ring of tufted sand- <br>
             knolls and lay down there that the peace and silence of the <br>
             evening might still the riot of his blood.<br> </p>
-            <p class="textParagraph"> He  felt above him the vast indifferent dome and the calm <span class="tag lineNumber">40900</span><br>
+            <p class="textParagraph"> He  felt above him the vast indifferent dome and the calm <span class="tag lineNumber">900</span><br>
             processes of the heavenly bodies; and the earth beneath him, <br>
             the earth that had borne him, had taken him to her breast.<br> </p>
             <p class="textParagraph"> He closed his eyes in the languor of sleep. His eyelids <br>
             trembled as if they felt the vast cyclic movement of the earth <br>
-            and her watchers, trembled as if they felt the strange light of <span class="tag lineNumber">40905</span><br>
+            and her watchers, trembled as if they felt the strange light of <br>
             some new world. His soul was swooning into some new world, <br>
             fantastic, dim, uncertain as under sea, traversed by cloudy <br>
             shapes and beings. A world, a glimmer, or a flower? Glimmering <br>
             ing and trembling, trembling and unfolding, a breaking light, <br>
-            an opening flower, it spread in endless succession to itself, <span class="tag lineNumber">40910</span><br>
+            an opening flower, it spread in endless succession to itself, <span class="tag lineNumber">910</span><br>
             breaking in full crimson and unfolding and fading to palest <br>
             rose, leaf by leaf and wave of light by wave of light, flooding all <br>
             the heavens with its soft flushes, every flush deeper than other.<br> </p>
             <p class="textParagraph"> Evening had fallen when he woke and the sand and arid <br>
-            grasses of his bed glowed no longer. He rose slowly and, re- <span class="tag lineNumber">40915</span><br>
+            grasses of his bed glowed no longer. He rose slowly and, re- <br>
             calling the rapture of his sleep, sighed at its joy.<br> </p>
             <p class="textParagraph"> He climbed to the crest of the sandhill and gazed about him. <br>
             Evening had fallen. A rim of the young moon cleft the pale <br>
             waste of sky like the rim of a silver hoop embedded in grey <br>
-            sand: and the tide was flowing in fast to the land with a low <span class="tag lineNumber">40920</span><br>
+            sand: and the tide was flowing in fast to the land with a low <span class="tag lineNumber">920</span><br>
             whisper of her waves, islanding a few last figures in distant <br>
             pools.<br> </p>
         
@@ -6058,1532 +6058,1532 @@
             chewing the crusts of fried bread that were scattered near him, <br>
             staring into the dark pool of the jar. The yellow dripping had <br>
             been scooped out like a boghole and the pool under it brought <br>
-            back to his memory the dark turfcoloured water of the bath in <span class="hide">53.310601 -6.695541</span> <span class="tag lineNumber">50005</span><br>
+            back to his memory the dark turfcoloured water of the bath in <span class="hide">53.310601 -6.695541</span> <br>
             Clongowes. The box of pawntickets at his elbow had just been <br>
             rifled and he took up idly one after another in his greasy fingers <br>
             the blue and white dockets, scrawled and sanded and creased <br>
             and bearing the name of the pledger as Daly or MacEvoy. <br>
-            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>1 Pair Buskins <span class="tag lineNumber">50010</span><br>
+            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>1 Pair Buskins <span class="tag lineNumber">10</span><br>
             1 D. Coat <br>
             3 Articles and White <br>
             1 Man's Pants<br></p> </p>
             <p class="textParagraph"> Then he put them aside and gazed thoughtfully at the lid of <br>
-            the box, speckled with lousemarks, and asked vaguely: <span class="tag lineNumber">50015</span><br>
+            the box, speckled with lousemarks, and asked vaguely: <br>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―How much is the clock fast now? <br></p> </p>
             <p class="textParagraph"> His mother straightened the battered alarmclock that was <br>
             lying on its side in the middle of the kitchen mantelpiece until <br>
             its dial showed a quarter to twelve and then laid it once more <br>
-            on its side. <span class="tag lineNumber">50020</span><br>
+            on its side. <span class="tag lineNumber">20</span><br>
               <p class="dialog"><span class="tag dialog">Mary Dedalus</span>―An hour and twentyfive minutes,</p> she said. <p class="dialog"><span class="tag dialog">Mary Dedalus</span>The right time <br>
             now is  twenty past ten. The dear knows you might try to be in <br>
             time for your lectures. <br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Fill out the place for me to wash,</p> said Stephen. <br>
-            <p class="dialog"><span class="tag dialog">Mary Dedalus</span>―Katey, fill out the place for Stephen to wash. <span class="tag lineNumber">50025</span><br> </p>
+            <p class="dialog"><span class="tag dialog">Mary Dedalus</span>―Katey, fill out the place for Stephen to wash. <br> </p>
             <p class="dialog"><span class="tag dialog">Katey</span>―Boody, fill out the place for Stephen to wash. <br> </p>
             <p class="dialog"><span class="tag dialog">Boody</span>―I can't. I'm going for blue. Fill it out, you, Maggie. <br></p> </p>
             <p class="textParagraph"> When the enamelled basin had  been fitted into the well of <br>
             the sink and the old washingglove flung on the side of it he <br>
-            allowed his mother to scrub his neck and root into the folds of <span class="tag lineNumber">50030</span><br>
+            allowed his mother to scrub his neck and root into the folds of <span class="tag lineNumber">30</span><br>
             his ears and into the interstices at the wings of his nose. <br>
               <p class="dialog"><span class="tag dialog">Mary Dedalus</span>―Well, it's a poor case,</p> she said, <p class="dialog"><span class="tag dialog">Mary Dedalus</span>when a university student is <br>
             so dirty that his mother has to wash him. <br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―But it gives you pleasure,</p> said Stephen calmly. <br> </p>
-            <p class="textParagraph"> An earsplitting whistle was heard from upstairs and his <span class="tag lineNumber">50035</span><br>
+            <p class="textParagraph"> An earsplitting whistle was heard from upstairs and his <br>
             mother thrust  a damp overall into his hands, saying: <br>
             <p class="dialog"><span class="tag dialog">Mary Dedalus</span>―Dry yourself and hurry out for the love of goodness. <br></p> </p>
             <p class="textParagraph"> A second shrill whistle, prolonged angrily, brought one of <br>
             the girls to the foot of the staircase. <br>
-            <p class="dialog"><span class="tag dialog">one of the girls</span>―Yes, father?<span class="tag lineNumber">50040</span><br> </p>
+            <p class="dialog"><span class="tag dialog">one of the girls</span>―Yes, father?<span class="tag lineNumber">40</span><br> </p>
             <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Is your lazy bitch of a brother gone out yet? <br> </p>
             <p class="dialog"><span class="tag dialog">one of the girls</span>―Yes, father.<br> </p>
             <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Sure? <br> </p>
             <p class="dialog"><span class="tag dialog">one of the girls</span>―Yes, father.<br> </p>
-            <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Hm!<span class="tag lineNumber">50045</span><br></p> </p>
+            <p class="dialog"><span class="tag dialog">Simon Dedalus</span>―Hm!<br></p> </p>
             <p class="textParagraph"> The girl came back making signs to him to be quick and go <br>
             out quietly by the back. Stephen laughed and said: <br>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―He has  a curious idea of genders if he thinks a bitch is <br>
             masculine. <br> </p>
-            <p class="dialog"><span class="tag dialog">Mary Dedalus</span>―Ah, it's a scandalous shame for you, Stephen,</p> said his <span class="tag lineNumber">50050</span><br>
+            <p class="dialog"><span class="tag dialog">Mary Dedalus</span>―Ah, it's a scandalous shame for you, Stephen,</p> said his <span class="tag lineNumber">50</span><br>
             mother, <p class="dialog"><span class="tag dialog">Mary Dedalus</span>and you'll live to rue the day you set your foot in that <br>
             place. I know how it has changed you. <br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Good morning, everybody,</p> said Stephen smiling and kissing <br>
             the tips of his fingers in adieu. <br></p>
-            <p class="textParagraph"> The lane  behind the terrace was waterlogged and as he went <span class="tag lineNumber">50055</span><br>
+            <p class="textParagraph"> The lane  behind the terrace was waterlogged and as he went <br>
             down it slowly, choosing his steps amid heaps of wet rubbish, <br>
             he heard a mad nun screeching in the <span class="hide">53.364283 -6.244879</span>nuns' madhouse beyond <br>
             the wall: <br>
             <p class="dialog"><span class="tag dialog">???</span>―Jesus! O Jesus! Jesus!<br></p> </p>
-            <p class="textParagraph"> He shook the sound out of his ears by an angry toss of his <span class="tag lineNumber">50060</span><br>
+            <p class="textParagraph"> He shook the sound out of his ears by an angry toss of his <span class="tag lineNumber">60</span><br>
             head and hurried on, stumbling through the mouldering offal, <br>
             his heart already bitten by an ache of loathing and bitterness. <br>
             His father's whistle, his mother's mutterings, the screech of an <br>
             unseen maniac were to him now so many voices offending and <br>
-            threatening to humble the pride of his youth. He drove their <span class="tag lineNumber">50065</span><br>
+            threatening to humble the pride of his youth. He drove their <br>
             echoes even out of his heart with an execration: but as he <br>
             walked down the avenue and felt the grey morning light falling <br>
             about him through the dripping trees and smelt the strange <br>
             wild smell of the wet leaves and bark his soul was loosed of her <br>
-            miseries.<span class="tag lineNumber">50070</span><br> </p>
+            miseries.<span class="tag lineNumber">70</span><br> </p>
             <p class="textParagraph"> The rainladen trees of the avenue evoked in him, as always, <br>
             memories of the girls and women in the plays of Gerhart <br>
             Hauptmann: and the memory of their pale sorrows and the <br>
             fragrance falling from the wet branches mingled in a mood of <br>
-            quiet joy. His morning walk across <span class="hide">53.363150 -6.270676</span>the city had begun: and he <span class="tag lineNumber">50075</span><br>
+            quiet joy. His morning walk across <span class="hide">53.363150 -6.270676</span>the city had begun: and he <br>
             foreknew that as he passed the sloblands of Fairview he would <br>
             think of the cloistral silverveined prose of Newman, that as he <br>
             walked along <span class="hide">53.357548 -6.242725</span>the North Strand Road, glancing idly at the win- <br>
             dows of the provision shops, he would recall the dark humour <br>
-            of Guido Cavalcanti and smile, that as he went by Baird's <span class="tag lineNumber">50080</span><br>
+            of Guido Cavalcanti and smile, that as he went by Baird's <span class="tag lineNumber">80</span><br>
             stonecutting works in <span class="hide">53.350416 -6.251694</span>Talbot Place the spirit of Ibsen would <br>
             blow through him like a keen wind, a spirit of wayward boyish <br>
             beauty, and that passing a grimy marine dealer's shop beyond <br>
             the Liffey he would repeat the song by Ben Jonson which <br>
-            begins:<span class="tag lineNumber">50085</span><br> </p>
+            begins:<br> </p>
             <p class="lg"> <span class="emph">I was not wearier where I lay.</span></p> <br>
             <p class="textParagraph"> His mind when wearied of its search for the essence of <br>
             beauty amid the spectral words of Aristotle or Aquinas turned <br>
             often for its pleasure to the dainty songs of the Elizabethans. <br>
-            His mind, in the vesture of a doubting monk, stood often in <span class="tag lineNumber">50090</span><br>
+            His mind, in the vesture of a doubting monk, stood often in <span class="tag lineNumber">90</span><br>
             shadow under the windows of that age, to hear the grave and <br>
             mocking music of the lutenists or the frank laughter of waist- <br>
             coateers until a laugh too low, a phrase, tarnished by time, of <br>
             chambering and false honour stung his monkish pride and <br>
-            drove him on from his lurkingplace.<span class="tag lineNumber">50095</span><br> </p>
+            drove him on from his lurkingplace.<br> </p>
             <p class="textParagraph"> The lore which he was believed to pass his days brooding <br>
             upon so that it had rapt him from the companionships of youth <br>
             was only a garner of slender sentences from Aristotle's poetics <br>
             and psychology and a Synopsis Philosophiae Scholasticae ad <br>
-            mentem divi Thomae. His thinking was a dusk of doubt and <span class="tag lineNumber">50100</span><br>
+            mentem divi Thomae. His thinking was a dusk of doubt and <span class="tag lineNumber">100</span><br>
             selfmistrust lit up at moments by the lightnings of intuition, but <br>
             lightnings of so clear a splendour that in those moments the <br>
             world perished about his feet as if it had been fireconsumed: <br>
             and thereafter his tongue grew heavy and he met the eyes of <br>
-            others with unanswering eyes for he felt that the spirit of <span class="tag lineNumber">50105</span><br>
+            others with unanswering eyes for he felt that the spirit of <br>
             beauty had folded him round like a mantle and that in revery at <br>
             least he had been acquainted with nobility. But when this brief <br>
             pride of silence upheld him no longer he was glad to find him- <br>
             self still in the midst of common lives, passing on his way amid <br>
-            the squalor and noise and sloth of the city fearlessly and with a <span class="tag lineNumber">50110</span><br>
+            the squalor and noise and sloth of the city fearlessly and with a <span class="tag lineNumber">110</span><br>
             light heart.<br> </p>
             <p class="textParagraph"> Near the hoardings on the canal he met the consumptive <br>
             man with the doll's face and the brimless hat coming towards <br>
             him down the slope of the bridge with little steps, tightly but- <br>
-            toned into his chocolate overcoat and holding his furled um- <span class="tag lineNumber">50115</span><br>
+            toned into his chocolate overcoat and holding his furled um- <br>
             brella a span or two from him like a diviningrod. It must be <br>
             eleven, he thought, and peered into a dairy to see the time. The <br>
             clock in the dairy told him that it was five minutes to five but, <br>
             as he turned away, he heard a clock somewhere near him but <br>
-            unseen beating eleven strokes in swift precision. He laughed as <span class="tag lineNumber">50120</span><br>
+            unseen beating eleven strokes in swift precision. He laughed as <span class="tag lineNumber">120</span><br>
             he heard it for it made him think of MacCann and he saw him <br>
             a squat figure in a shooting jacket and breeches and with a fair <br>
             goatee standing in the wind at <span class="hide">53.351242 -6.260779</span>Hopkins' corner, and heard him <br>
             say: <br>
-            <p class="dialog"><span class="tag dialog">MacCann</span>―Dedalus, you're an antisocial being, wrapped up in yourself. <span class="tag lineNumber">50125</span><br>
+            <p class="dialog"><span class="tag dialog">MacCann</span>―Dedalus, you're an antisocial being, wrapped up in yourself. <br>
             I'm not. I'm a democrat: and I'll work and act for social liberty <br>
             and equality among all classes and sexes in the United States of <br>
             the Europe of the future. <br></p> </p>
             <p class="textParagraph"> Eleven! Then he was late for that lecture too. What day of <br>
-            the week was it? He stopped at a newsagent's to read the <span class="tag lineNumber">50130</span><br>
+            the week was it? He stopped at a newsagent's to read the <span class="tag lineNumber">130</span><br>
             headline of a placard. Thursday.  Ten to eleven; English: eleven <br>
             to twelve; French: twelve to one; physics. He fancied to himself <br>
             the English lecture and felt, even at that distance, restless and <br>
             helpless. He saw the heads of his classmates meekly bent as <br>
-            they wrote in their notebooks the points they were bidden to <span class="tag lineNumber">50135</span><br>
+            they wrote in their notebooks the points they were bidden to <br>
             note, nominal definitions, essential definitions and examples or <br>
             dates of birth and death, chief works, a favourable and an <br>
             unfavourable criticism side by side. His own head was unbent <br>
             for his thoughts wandered abroad and whether he looked <br>
-            around the little class of students or out of the window across <span class="tag lineNumber">50140</span><br>
+            around the little class of students or out of the window across <span class="tag lineNumber">140</span><br>
             the desolate gardens of the green an odour assailed him of <br>
             cheerless cellardamp and decay. Another head than his, right <br>
             before him in the first benches, was poised squarely above its <br>
             bending fellows like the head of a priest appealing without <br>
-            humility to the tabernacle for the humble worshippers about <span class="tag lineNumber">50145</span><br>
+            humility to the tabernacle for the humble worshippers about <br>
             him. Why was it that when he thought of Cranly he could <br>
             never raise before his mind the entire image of his body but <br>
             only the image of the head and face? Even now against the grey <br>
             curtain of the morning he saw it before him like the phantom <br>
-            of a dream, the face of a severed head or deathmask, crowned <span class="tag lineNumber">50150</span><br>
+            of a dream, the face of a severed head or deathmask, crowned <span class="tag lineNumber">150</span><br>
             on the brows by its stiff black upright hair as by an iron crown. <br>
             It was a priestlike face, priestlike in its pallor, in the wide- <br>
             winged nose, in the shadowings below the eyes and along the <br>
             jaws, priestlike in the lips that were long and bloodless and <br>
-            faintly smiling: and Stephen, remembering swiftly how he had <span class="tag lineNumber">50155</span><br>
+            faintly smiling: and Stephen, remembering swiftly how he had <br>
             told Cranly of all the tumults and unrest and longings in his <br>
             soul, day after day and night by night only to be answered by <br>
             his friend's listening silence, would have told himself that it <br>
             was the face of a guilty priest who heard confessions of those <br>
-            whom he had not power to absolve but that he felt again in <span class="tag lineNumber">50160</span><br>
+            whom he had not power to absolve but that he felt again in <span class="tag lineNumber">160</span><br>
             memory the gaze of its dark womanish eyes.<br> </p>
             <p class="textParagraph"> Through this image he had a glimpse of a strange dark <br>
             cavern of speculation but at once turned away from it feeling <br>
             that it was not yet the hour  to enter it. But the nightshade of his <br>
-            friend's listlessness seemed to be diffusing in the air around him <span class="tag lineNumber">50165</span><br>
+            friend's listlessness seemed to be diffusing in the air around him <br>
             a tenuous and deadly exhalation: and he found himself <br>
             glancing from one casual word to another on his right or left in <br>
             stolid wonder that they had been so silently emptied of instan- <br>
             taneous sense until every mean shop legend bound his mind <br>
-            like the words of a spell and his soul shrivelled up sighing with <span class="tag lineNumber">50170</span><br>
+            like the words of a spell and his soul shrivelled up sighing with <span class="tag lineNumber">170</span><br>
             age as he walked on in a lane among heaps of dead language. <br>
             His own consciousness of language was ebbing from his brain <br>
             and trickling into the very words themselves which set to band <br>
             and disband themselves in wayward rhythms:<br> </p>
             <p class="lg">
-              The ivy whines upon the wall <span class="tag lineNumber">50175</span><br>
+              The ivy whines upon the wall <br>
               And whines and twines upon the wall <br>
               The ivy whines upon the wall <br>
               The yellow ivy on the wall <br>
               Ivy, ivy up the wall. <br>
             </p>
-            <p class="textParagraph"> Did any one ever hear such drivel? Lord Almighty! Who ever <span class="tag lineNumber">50180</span><br>
+            <p class="textParagraph"> Did any one ever hear such drivel? Lord Almighty! Who ever <span class="tag lineNumber">180</span><br>
             heard of ivy whining on a wall? Yellow ivy: that was all right. <br>
             Yellow ivory also. And what about ivory ivy?<br> </p>
             <p class="textParagraph"> The word now shone in his brain, clearer and brighter than <br>
             any ivory sawn from the mottled tusks of elephants. <span class="emph">Ivory, <br>
-            <span class="emph">ivoire</span>, avorio, ebur.</span> One of the first examples that he had <span class="tag lineNumber">50185</span><br>
+            <span class="emph">ivoire</span>, avorio, ebur.</span> One of the first examples that he had <br>
             learnt in Latin had run: India mittit ebur; and he recalled the <br>
             shrewd northern face of the rector who had taught him to <br>
             construe the Metamorphoses of Ovid in a courtly English, <br>
             made whimsical by the mention of porkers and potsherds and <br>
-            chines of bacon. He had learnt what little he knew of the laws <span class="tag lineNumber">50190</span><br>
+            chines of bacon. He had learnt what little he knew of the laws <span class="tag lineNumber">190</span><br>
             of Latin verse from a ragged book written by a Portuguese <br>
             priest:<br> </p>
             <p class="textParagraph"><p class="lg">Contrahit orator, variant in carmine vates.</p><br> </p>
             <p class="textParagraph"> The crises and victories and secessions in Roman history <br>
-            were handed on to him in the trite words in tanto discrimine <span class="tag lineNumber">50195</span><br>
+            were handed on to him in the trite words in tanto discrimine <br>
             and he had tried to peer into the social life of the city of cities <br>
             through the words implere ollam denariorum which the rector <br>
             had rendered sonorously as the filling of a pot with denaries. <br>
             The pages of his timeworn Horace never felt cold to the touch <br>
-            even when his own fingers were cold:  they were human pages: <span class="tag lineNumber">50200</span><br>
+            even when his own fingers were cold:  they were human pages: <span class="tag lineNumber">200</span><br>
             and fifty years before they had been turned by the human <br>
             fingers of John Duncan Inverarity and by his brother William <br>
             Malcolm Inverarity. Yes, those were noble names on the dusky <br>
             flyleaf and, even for so poor a Latinist as he, the dusky verses <br>
-            were as fragrant as though they had lain all those years in <span class="tag lineNumber">50205</span><br>
+            were as fragrant as though they had lain all those years in <br>
             myrtle and lavender and vervain: but yet it wounded him to <br>
             think that he would never be but a shy guest at the feast of the <br>
             world's culture and that the monkish learning, in terms of <br>
             which he was striving to forge out an esthetic philosophy, was <br>
-            held no higher by the age he lived in than the subtle and <span class="tag lineNumber">50210</span><br>
+            held no higher by the age he lived in than the subtle and <span class="tag lineNumber">210</span><br>
             curious jargons of heraldry and falconry.<br> </p>
             <p class="textParagraph"> The grey block <span class="hide">53.345478 -6.257690</span>of Trinity on his left, set heavily in the city's <br>
             ignorance like a great dull stone set in a cumbrous ring, pulled <br>
             his mind downward: and while he was striving this way and <br>
-            that to free his feet from the fetters of the reformed conscience <span class="tag lineNumber">50215</span><br>
+            that to free his feet from the fetters of the reformed conscience <br>
             he came upon the droll statue of the national poet of Ireland.<br> </p>
             <p class="textParagraph"> He looked at it without anger: for, though sloth of the body <br>
             and of  the soul crept over it like unseen vermin, over the <br>
             shuffling feet and up the folds of the cloak and around the <br>
-            servile head, it seemed humbly conscious of its indignity. It <span class="tag lineNumber">50220</span><br>
+            servile head, it seemed humbly conscious of its indignity. It <span class="tag lineNumber">220</span><br>
             was a Firbolg in the borrowed cloak of a Milesian; and he <br>
             thought of his friend Davin, the peasant student. It was a <br>
             jesting name between them but the young peasant bore with it <br>
             lightly, saying: <br>
-            <p class="dialog"><span class="tag dialog">Davin</span>―Go on, Stevie. I have a hard head, you tell me. Call me what <span class="tag lineNumber">50225</span><br>
+            <p class="dialog"><span class="tag dialog">Davin</span>―Go on, Stevie. I have a hard head, you tell me. Call me what <br>
             you will. <br></p> </p>
             <p class="textParagraph"> The homely version of his christian name on the lips of his <br>
             friend had touched Stephen pleasantly when first heard for he <br>
             was as formal in speech with others as they were with him. <br>
-            Often, as he sat in Davin's rooms in <span class="hide">53.334106 -6.266592</span>Grantham Street, wonder- <span class="tag lineNumber">50230</span><br>
+            Often, as he sat in Davin's rooms in <span class="hide">53.334106 -6.266592</span>Grantham Street, wonder- <span class="tag lineNumber">230</span><br>
             ing at his friend's wellmade boots that flanked the wall pair by <br>
             pair and repeating for his friend's simple ear the verses and <br>
             cadences of others which were the veils of his own longing and <br>
             dejection, the rude Firbolg mind of his listener had drawn his <br>
-            mind towards it and flung it back again, drawing it by a quiet <span class="tag lineNumber">50235</span><br>
+            mind towards it and flung it back again, drawing it by a quiet <br>
             inbred courtesy of attention or by a quaint turn of old English <br>
             speech or by the force of its delight in rude bodily skill - (for <br>
             Davin had sat at the feet of Michael Cusack, the Gael), <br>
             repelling swiftly and suddenly by a grossness of intelligence or <br>
-            by a bluntness of feeling or by a dull stare of terror in the eyes <span class="tag lineNumber">50240</span><br>
+            by a bluntness of feeling or by a dull stare of terror in the eyes <span class="tag lineNumber">240</span><br>
             the terror of soul of a starving Irish village in which the curfew <br>
             was still a nightly fear.<br> </p>
             <p class="textParagraph"> Side by side with his memory of the deeds of prowess of his <br>
             uncle Mat Davin, the athlete, the young peasant worshipped <br>
-            the sorrowful legend of Ireland. The gossip of his fellowstu- <span class="tag lineNumber">50245</span><br>
+            the sorrowful legend of Ireland. The gossip of his fellowstu- <br>
             dents which strove to render the flat life of the college signifi- <br>
             cant at any cost loved to think of him as a young fenian. His <br>
             nurse had taught him Irish and shaped the rude imagination by <br>
             the broken lights of Irish myth. He stood towards this myth <br>
-            upon which no individual mind had ever drawn out a line of <span class="tag lineNumber">50250</span><br>
+            upon which no individual mind had ever drawn out a line of <span class="tag lineNumber">250</span><br>
             beauty and to its unwieldy  tales that divided against themselves <br>
             as they moved down the cycles in the same attitude as towards <br>
             the Roman catholic religion, the attitude of a dullwitted loyal <br>
             serf. Whatsoever of thought or of feeling came to him from <br>
-            England or by way of English culture his mind stood armed <span class="tag lineNumber">50255</span><br>
+            England or by way of English culture his mind stood armed <br>
             against in obedience to a password: and of the world that lay <br>
             beyond England he knew only the foreign legion of <span class="hide">46.227638 2.213749</span>France in <br>
             which he spoke of serving.<br> </p>
             <p class="textParagraph"> Coupling this ambition with the young man's diffident hu- <br>
-            mour Stephen had often called him one of the tame geese: and <span class="tag lineNumber">50260</span><br>
+            mour Stephen had often called him one of the tame geese: and <span class="tag lineNumber">260</span><br>
             there was even a point of irritation in the name pointed against <br>
             that very reluctance of speech and deed in his friend which <br>
             seemed so often to stand between Stephen's mind, eager of <br>
             speculation, and the hidden ways of Irish life.<br> </p>
-            <p class="textParagraph"> One night the young peasant, his spirit stung by the violent <span class="tag lineNumber">50265</span><br>
+            <p class="textParagraph"> One night the young peasant, his spirit stung by the violent <br>
             or luxurious language in which Stephen escaped from the cold <br>
             silence of intellectual revolt, had called up before Stephen's <br>
             mind a strange vision. The two were walking slowly towards <br>
             Davin's rooms through the dark narrow streets of the poorer <br>
-            jews. <span class="tag lineNumber">50270</span><br>
+            jews. <span class="tag lineNumber">270</span><br>
             <p class="dialog"><span class="tag dialog">Davin</span>―A thing happened to myself, Stevie, last autumn coming on <br>
             winter and I never told it to a living soul and you are the first <br>
             person now I ever told it to. I disremember if it was October or <br>
             November. It was October because it was before  I came up <br>
-            here to join the matriculation class. <span class="tag lineNumber">50275</span><br></p> </p>
+            here to join the matriculation class. <br></p> </p>
             <p class="textParagraph"> Stephen had turned his smiling eyes towards his friend's <br>
             face, flattered by his confidence and won over to sympathy by <br>
             the speaker's simple accent. <br>
             <p class="dialog"><span class="tag dialog">Davin</span>―I was away all that day from my own place, over in <span class="hide">52.232134 -8.670125</span>Butte- <br>
-            vant (I don't know if you know where that is) at a hurling <span class="tag lineNumber">50280</span><br>
+            vant (I don't know if you know where that is) at a hurling <span class="tag lineNumber">280</span><br>
             match between the Croke's Own Boys and the Fearless Thurles <br>
             and by God, Stevie, that was the hard fight. My first cousin <br>
             Fonsy Davin was stripped to his buff that day minding cool for <br>
             the Limericks but he was up with the forwards half the time <br>
-            and shouting like mad. I never will forget that day. One of the <span class="tag lineNumber">50285</span><br>
+            and shouting like mad. I never will forget that day. One of the <br>
             Crokes made a woful wipe at him one time with his camaun <br>
             and I declare to God he was within an aim's ace of getting it at <br>
             the side of the temple. O, honest to God, if the crook of it <br>
             caught him that time he was done for. <br> </p>
-            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I am glad he escaped, Stephen had said with a laugh, but <span class="tag lineNumber">50290</span><br>
+            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I am glad he escaped, Stephen had said with a laugh, but <span class="tag lineNumber">290</span><br>
             surely that's not the strange thing  that happened you? <br> </p>
             <p class="dialog"><span class="tag dialog">Davin</span>―Well, I suppose that doesn't interest you but leastways there <br>
             was such noise after the match that I missed the train home and <br>
             I couldn't get any kind of a yoke to give me a lift for, as luck <br>
-            would have it, there was a mass meeting that same day over in <span class="tag lineNumber">50295</span><br>
+            would have it, there was a mass meeting that same day over in <br>
             Castletownrocheand all the cars in the country were there. So <br>
             there was nothing for it only to stay the night or to foot it out. <br>
             Well, I started to walk and on I went and it was coming on <br>
             night when I got into the  <span class="hide">52.303056 -8.538611</span>Ballyhoura hills that's better than ten <br>
-            miles from <span class="hide">52.399821 -8.575387</span>Kilmallock and there's a long lonely road after that. <span class="tag lineNumber">50300</span><br>
+            miles from <span class="hide">52.399821 -8.575387</span>Kilmallock and there's a long lonely road after that. <span class="tag lineNumber">300</span><br>
             You wouldn't see the sign of a christian house along the road or <br>
             hear a sound. It was pitch dark almost. Once or twice I stopped <br>
             by the way under a bush to redden my pipe and only for the <br>
             dew was thick I'd have stretched out there and slept. At last <br>
-            after a bend of the road I spied a little cottage with a light in <span class="tag lineNumber">50305</span><br>
+            after a bend of the road I spied a little cottage with a light in <br>
             the window. I went up and knocked at the door. A voice asked <br>
             who was there and I answered I was over at the match in <br>
             Buttevant and was walking back and that I'd be thankful for a <br>
             glass of water. After a while a young woman opened the door <br>
-            and brought me out a big mug of milk. She was half undressed <span class="tag lineNumber">50310</span><br>
+            and brought me out a big mug of milk. She was half undressed <span class="tag lineNumber">310</span><br>
             as if she was going to bed when I knocked and she had her hair <br>
             hanging: and I thought by her figure and by something in the <br>
             look of her eyes that she must be carrying a child. She kept me <br>
             in talk a long while at the door and I thought it strange because <br>
-            her breast and her shoulders were bare. She asked me was I <span class="tag lineNumber">50315</span><br>
+            her breast and her shoulders were bare. She asked me was I <br>
             tired and would I like to stop the night there. She said she was <br>
             all alone in the house and that her husband had gone that <br>
             morning to <span class="hide">53.273188 -6.092767</span>Queenstown with his sister to see her off. And all <br>
             the time she was talking, Stevie, she had her eyes fixed on my <br>
-            face and she stood so close to me I could hear her breathing. <span class="tag lineNumber">50320</span><br>
+            face and she stood so close to me I could hear her breathing. <span class="tag lineNumber">320</span><br>
             When I handed her back the mug at last she took my hand to <br>
             draw me in over the threshold and said: <span class="emph">Come in and stay the <br>
             night here. You've no call to be frightened. There's no-one in it <br>
             but ourselves</span> ........ I didn't go in, Stevie.  I thanked her and <br>
-            went on my way again, all in a fever. At the first bend of the <span class="tag lineNumber">50325</span><br>
+            went on my way again, all in a fever. At the first bend of the <br>
             road I looked back and she was standing in the door. <br></p> </p>
             <p class="textParagraph"> The last words of Davin's story sang in his memory  and the <br>
             figure of the woman in the story stood forth reflected in other <br>
             figures of the peasant women whom he had seen standing in <br>
-            the doorways at <span class="hide">53.293785 -6.687040</span>Clane as the college cars drove by, as a type of <span class="tag lineNumber">50330</span><br>
+            the doorways at <span class="hide">53.293785 -6.687040</span>Clane as the college cars drove by, as a type of <span class="tag lineNumber">330</span><br>
             her race and his own, a batlike soul waking to the conscious- <br>
             ness of itself in darkness and secrecy and loneliness and, <br>
             through the eyes and voice and gesture of a woman without <br>
             guile, calling the stranger to her bed.<br> </p>
-            <p class="textParagraph"> A hand was laid on his arm and a young voice cried: <span class="tag lineNumber">50335</span><br>
+            <p class="textParagraph"> A hand was laid on his arm and a young voice cried: <br>
             <p class="dialog"><span class="tag dialog">???</span>―Ah, gentleman, your own girl, sir! The first handsel today, <br>
             gentleman. Buy  that lovely bunch. Will you, gentleman?<br></p> </p>
             <p class="textParagraph"> The blue flowers which she lifted towards him and her <br>
             young blue eyes seemed to him at that instant images of guile- <br>
-            lessness: and he halted till the image had vanished and he saw <span class="tag lineNumber">50340</span><br>
+            lessness: and he halted till the image had vanished and he saw <span class="tag lineNumber">340</span><br>
             only her ragged dress and damp coarse hair and  hoydenish <br>
             face.&gt; <br>
             <p class="dialog"><span class="tag dialog">???</span>―Do, gentleman! Don't forget your own girl, sir!<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I have no money, said Stephen. <br> </p>
-            <p class="dialog"><span class="tag dialog">???</span>―Buy them lovely ones, will you, sir? Only a penny.<span class="tag lineNumber">50345</span><br> </p>
+            <p class="dialog"><span class="tag dialog">???</span>―Buy them lovely ones, will you, sir? Only a penny.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Did you hear what I said? asked Stephen, bending towards <br>
             her. I told you I had no money. I tell you again now.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―Well, sure, you will some day, sir, please God, the girl <br>
             answered after an instant.<br> </p>
-            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Possibly, said Stephen, but I don't think it likely. <span class="tag lineNumber">50350</span><br></p> </p>
+            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Possibly, said Stephen, but I don't think it likely. <span class="tag lineNumber">350</span><br></p> </p>
             <p class="textParagraph"> He left her quickly, fearing that her intimacy might turn to <br>
             gibing and wishing to be out of the way before she offered her <br>
             ware to another, a tourist from England or a student of Trinity. <span class="hide">53.342300 -6.259747</span> <br>
             Grafton Street, along which he walked prolonged that moment <br>
-            of discouraged poverty. In the roadway at the head of the street <span class="tag lineNumber">50355</span><br>
+            of discouraged poverty. In the roadway at the head of the street <br>
             a slab was set to the memory of Wolfe Tone and he remem- <br>
             bered having been present with his father at its laying. He re- <br>
             membered with bitterness that scene of tawdry tribute. There <br>
             were four French delegates in a brake and one, a plump smiling <br>
-            young man, held, wedged on a stick,  a card on which were <span class="tag lineNumber">50360</span><br>
+            young man, held, wedged on a stick,  a card on which were <span class="tag lineNumber">360</span><br>
             printed the words: Vive l'Irlande!<br> </p>
             <p class="textParagraph"> But the trees in <span class="hide">53.338174 -6.259119</span>Stephen's Green were fragrant of rain and <br>
             the rainsodden earth gave forth its mortal odour, a faint in- <br>
             cense rising upward through the mould from many hearts. The <br>
-            soul of the gallant venal city which his elders had told him of <span class="tag lineNumber">50365</span><br>
+            soul of the gallant venal city which his elders had told him of <br>
             had shrunk with time to a faint mortal odour rising from the <br>
             earth and he knew that in a moment when he entered the <br>
             sombre college he would be conscious of a corruption other <br>
             than that of Buck Egan and Burnchapel Whaley.<br> </p>
-            <p class="textParagraph"> It was too late to go upstairs to the French class. He crossed <span class="tag lineNumber">50370</span><br>
+            <p class="textParagraph"> It was too late to go upstairs to the French class. He crossed <span class="tag lineNumber">370</span><br>
             the hall and took the corridor to the left which led to the <br>
             physics theatre. The corridor was dark and silent but not un- <br>
             watchful. Why did he feel that it was not unwatchful? Was it <br>
             because he had heard that in Buck Whaley's time there was a <br>
-            secret staircase there? Or was the jesuit house extraterritorial <span class="tag lineNumber">50375</span><br>
+            secret staircase there? Or was the jesuit house extraterritorial <br>
             and was he walking among aliens? The Irelandof Tone and of <br>
             Parnell seemed to have receded in space.<br> </p>
             <p class="textParagraph"> He opened the door of the theatre and halted in the chilly <br>
             grey light that struggled through the dusty windows. A figure <br>
-            was crouching before the large grate and by its leanness and <span class="tag lineNumber">50380</span><br>
+            was crouching before the large grate and by its leanness and <span class="tag lineNumber">380</span><br>
             greyness he knew that it was the dean of studies lighting the <br>
             fire. Stephen closed the door quietly and approached the fire- <br>
             place. <br>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Good morning, sir! Can I help you?<br></p> </p>
-            <p class="textParagraph"> The priest looked up quickly and said: <span class="tag lineNumber">50385</span><br>
+            <p class="textParagraph"> The priest looked up quickly and said: <br>
             <p class="dialog"><span class="tag dialog">???</span>―One moment now, Mr Dedalus, and you will see. There is <br>
             an art in lighting a fire. We have the liberal arts and we have <br>
             the useful arts. This is one of the useful arts.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I will try to learn it, said Stephen.<br> </p>
-            <p class="dialog"><span class="tag dialog">???</span>―Not too much coal, said the dean, working briskly at his <span class="tag lineNumber">50390</span><br>
+            <p class="dialog"><span class="tag dialog">???</span>―Not too much coal, said the dean, working briskly at his <span class="tag lineNumber">390</span><br>
             task, that is one of the secrets.<br></p> </p>
             <p class="textParagraph"> He produced four candle butts from the sidepockets of his <br>
             soutane and placed them deftly among the coals and twisted <br>
             papers. Stephen watched him in silence. Kneeling thus on the <br>
-            flagstone to kindle the fire and busied with the disposition of <span class="tag lineNumber">50395</span><br>
+            flagstone to kindle the fire and busied with the disposition of <br>
             his wisps of paper and candle butts he seemed more than ever a <br>
             humble server making ready the place of sacrifice in an empty <br>
             temple, a levite of the Lord. Like a levite's robe of plain linen <br>
             the faded worn soutane draped the kneeling figure of one <br>
-            whom the canonicals or the  bellbordered ephod would irk and <span class="tag lineNumber">50400</span><br>
+            whom the canonicals or the  bellbordered ephod would irk and <span class="tag lineNumber">400</span><br>
             trouble. His very body had waxed old in lowly service of the <br>
             Lord – in tending the fire upon the altar, in bearing tidings se- <br>
             cretly, in waiting upon worldlings, in striking swiftly when <br>
             bidden – and yet had remained ungraced by aught of saintly or <br>
-            of prelatic beauty. Nay, his very soul had waxed old in that <span class="tag lineNumber">50405</span><br>
+            of prelatic beauty. Nay, his very soul had waxed old in that <br>
             service without growing towards light and beauty or spreading <br>
             abroad a sweet odour of her sanctity – a mortified will no more <br>
             responsive to the thrill of its obedience than was to the thrill of <br>
             love or combat his aging body, spare and sinewy, greyed with a <br>
-            silverpointed down.<span class="tag lineNumber">50410</span><br> </p>
+            silverpointed down.<span class="tag lineNumber">410</span><br> </p>
             <p class="textParagraph"> The dean rested back on his hunkers and watched the sticks <br>
             catch. Stephen, to fill the silence, said: <br>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I am sure I could not light a fire.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―You are an artist, are you not, Mr Dedalus? said the dean, <br>
-            glancing up and blinking his pale eyes. The object of the artist <span class="tag lineNumber">50415</span><br>
+            glancing up and blinking his pale eyes. The object of the artist <br>
             is the creation of the beautiful. What the beautiful is is another <br>
             question.<br></p> </p>
             <p class="textParagraph"> He rubbed his hands slowly and drily over the difficulty. <br>
             <p class="dialog"><span class="tag dialog">???</span>―Can you solve that question now? he asked.<br> </p>
-            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Aquinas, answered Stephen, says Pulcra sunt quae visa <span class="tag lineNumber">50420</span><br>
+            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Aquinas, answered Stephen, says Pulcra sunt quae visa <span class="tag lineNumber">420</span><br>
             placent.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―This fire before us, said the dean, will be pleasing to the eye. <br>
             Will it therefore be beautiful?<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―In so far as it is apprehended by the sight, which I suppose <br>
-            means here esthetic intellection, it will be beautiful. But Aqui- <span class="tag lineNumber">50425</span><br>
+            means here esthetic intellection, it will be beautiful. But Aqui- <br>
             nas also says Bonum est in quod tendit appetitus. In so far as it <br>
             satisfies the animal craving for warmth fire is a good. In hell <br>
             however it is an evil.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―Quite so, said the dean, you have certainly hit the nail on the <br>
-            head.<span class="tag lineNumber">50430</span><br></p> </p>
+            head.<span class="tag lineNumber">430</span><br></p> </p>
             <p class="textParagraph"> He rose nimbly and went towards the door, set it ajar and <br>
             said: <br>
             <p class="dialog"><span class="tag dialog">???</span>―A draught is said to be a help in these matters.<br></p> </p>
             <p class="textParagraph"> As he came back to the hearth, limping slightly but with a <br>
-            brisk step, Stephen saw the silent soul of a jesuit look out at <span class="tag lineNumber">50435</span><br>
+            brisk step, Stephen saw the silent soul of a jesuit look out at <br>
             him from the pale loveless eyes. Like Ignatius he was lame but <br>
             in his eyes burned no spark of Ignatius' enthusiasm. Even the <br>
             legendary craft of the company, a craft subtler and more secret <br>
             than its fabled books of secret subtle wisdom, had not fired his <br>
-            soul with the energy of apostleship. It seemed as if he used the <span class="tag lineNumber">50440</span><br>
+            soul with the energy of apostleship. It seemed as if he used the <span class="tag lineNumber">440</span><br>
             shifts and lore and cunning of the world, as bidden to do, for <br>
             the greater glory of God, without joy in their handling or <br>
             hatred of that in them which was evil but turning them, with a <br>
             firm gesture of obedience, back upon themselves: and for all <br>
-            this silent service it seemed as if he loved not at all the master <span class="tag lineNumber">50445</span><br>
+            this silent service it seemed as if he loved not at all the master <br>
             and little, if at all, the ends he served. Similiter atque senis <br>
             baculus, he was, as the founder would have had him, like a <br>
             staff in an old man's hand, to be left in a corner, to be leaned <br>
             on in the road at nightfall or in stress of weather,  to lie with a <br>
-            lady's nosegay on a garden seat, to be raised in menace.<span class="tag lineNumber">50450</span><br> </p>
+            lady's nosegay on a garden seat, to be raised in menace.<span class="tag lineNumber">450</span><br> </p>
             <p class="textParagraph"> The dean returned to the hearth and began to stroke his <br>
             chin. <br>
             <p class="dialog"><span class="tag dialog">the dean</span>―When may we expect to have something from you on the <br>
             esthetic question?</p> he asked.<br>
-            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―From me! said Stephen in astonishment. I stumble on  an idea <span class="tag lineNumber">50455</span><br>
+            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―From me! said Stephen in astonishment. I stumble on  an idea <br>
             once a fortnight if I am lucky.<br> </p>
             <p class="dialog"><span class="tag dialog">the dean</span>―These questions are very profound, Mr Dedalus,</p> said the <br>
             dean. <p class="dialog"><span class="tag dialog">the dean</span>It is like looking down from the <span class="hide">53.545240 -7.943510</span>cliffs of Moher into the <br>
             depths. Many go down into the depths and never come up. <br>
-            Only the trained diver can go down into those depths and <span class="tag lineNumber">50460</span><br>
+            Only the trained diver can go down into those depths and <span class="tag lineNumber">460</span><br>
             explore them and come to the surface again.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―If you mean speculation, sir, said Stephen, I also am sure <br>
             that there is no such thing  as free thinking inasmuch as all <br>
             thinking must be bound by its own laws.<br> </p>
-            <p class="dialog"><span class="tag dialog">the dean</span>―Ha!<span class="tag lineNumber">50465</span><br> </p>
+            <p class="dialog"><span class="tag dialog">the dean</span>―Ha!<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―For my purpose I can work on at present by the light of one <br>
             or two ideas of Aristotle and Aquinas.<br> </p>
             <p class="dialog"><span class="tag dialog">the dean</span>―I see. I quite see your point.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I need them only for my own use and guidance until I have <br>
-            done something for myself by their light. If the lamp smokes or <span class="tag lineNumber">50470</span><br>
+            done something for myself by their light. If the lamp smokes or <span class="tag lineNumber">470</span><br>
             smells I shall try to trim it. If it does not give light enough I <br>
             shall sell it and buy or borrow another.<br> </p>
             <p class="dialog"><span class="tag dialog">the dean</span>―Epictetus also had a lamp,</p> said the dean, <p class="dialog"><span class="tag dialog">the dean</span>which was sold for <br>
             a fancy price after his death. It was the lamp he wrote his <br>
-            philosophical dissertations by. You know Epictetus?<span class="tag lineNumber">50475</span><br> </p>
+            philosophical dissertations by. You know Epictetus?<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―An old gentleman,</p> said Stephen coarsely, <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>who said that the <br>
             soul is very like a bucketful of water.<br> </p>
             <p class="dialog"><span class="tag dialog">the dean</span>―He tells us in his homely way,</p> the dean went on, <p class="dialog"><span class="tag dialog">the dean</span>that he put <br>
             an iron lamp before a statue of one of the gods and that a thief <br>
-            stole the lamp. What did the philosopher do? He reflected that <span class="tag lineNumber">50480</span><br>
+            stole the lamp. What did the philosopher do? He reflected that <span class="tag lineNumber">480</span><br>
             it was in the character of a thief to steal and determined to buy <br>
             an earthen lamp next day instead of the iron lamp.<br></p> </p>
             <p class="textParagraph"> A smell  of molten  tallow came up from the dean's candle <br>
             butts and fused itself in Stephen's consciousness with the jingle <br>
-            of the words, bucket and lamp and lamp and bucket. The <span class="tag lineNumber">50485</span><br>
+            of the words, bucket and lamp and lamp and bucket. The <br>
             priest's voice too had a hard jingling tone. Stephen's mind <br>
             halted by instinct, checked by the strange tone and the  imagery <br>
             and by the priest's face which seemed like an unlit lamp or a <br>
             reflector hung in a false focus. What lay behind it or within it? <br>
-            A dull torpor of the soul or the dullness of the thundercloud, <span class="tag lineNumber">50490</span><br>
+            A dull torpor of the soul or the dullness of the thundercloud, <span class="tag lineNumber">490</span><br>
             charged with intellection and capable of the gloom of God? <br>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I meant a different kind of lamp, sir,</p> said Stephen.<br> 
             <p class="dialog"><span class="tag dialog">the dean</span>―Undoubtedly,</p> said the dean.<br> 
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―One difficulty,</p> said Stephen, <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>in esthetic discussion is to <br>
-            know whether words are being used according to the literary <span class="tag lineNumber">50495</span><br>
+            know whether words are being used according to the literary <br>
             tradition or according to the tradition of the marketplace. I <br>
             remember a sentence of Newman's in which he says of the <br>
             Blessed Virgin that she was detained in the full company of the <br>
             saints. The use of the word in the marketplace is quite differ- <br>
-            ent. <span class="emph">I hope I am not detaining you.</span><span class="tag lineNumber">50500</span><br> </p>
+            ent. <span class="emph">I hope I am not detaining you.</span><span class="tag lineNumber">500</span><br> </p>
             <p class="dialog"><span class="tag dialog">the dean</span>―Not in the least,</p> said the dean politely.<br>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―No, no,</p> said Stephen smiling, <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>I mean ....<br> </p>
             <p class="dialog"><span class="tag dialog">the dean</span>―Yes, yes: I see,</p> said the dean quickly, <p class="dialog"><span class="tag dialog">the dean</span>I quite catch the point: <br>
             <span class="emph">detain</span>.<br></p> </p>
-            <p class="textParagraph"> He thrust forward his under jaw and uttered a dry short <span class="tag lineNumber">50505</span><br>
+            <p class="textParagraph"> He thrust forward his under jaw and uttered a dry short <br>
             cough. <br>
             <p class="dialog"><span class="tag dialog">the dean</span>To return to the lamp,</p> he said, <p class="dialog"><span class="tag dialog">the dean</span>the feeding of it is also a nice <br>
             problem. You must choose the pure oil and you must be careful <br>
             when you pour it in not to overflow it, not to pour in more <br>
-            than the funnel can hold.<span class="tag lineNumber">50510</span><br> </p>
+            than the funnel can hold.<span class="tag lineNumber">510</span><br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―What funnel?</p> asked Stephen.<br>
             <p class="dialog"><span class="tag dialog">the dean</span>The funnel through which you pour the oil into your lamp.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―That?</p> said Stephen. <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>Is that called a funnel? Is it not a tun- <br>
             dish?<br> </p>
-            <p class="dialog"><span class="tag dialog">the dean</span>―What is a tundish?<span class="tag lineNumber">50515</span><br> </p>
+            <p class="dialog"><span class="tag dialog">the dean</span>―What is a tundish?<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―That. The ... the funnel.<br> </p>
             <p class="dialog"><span class="tag dialog">the dean</span>―Is that called a tundish in Ireland?</p> asked the dean. <p class="dialog"><span class="tag dialog">the dean</span>I never <br>
             heard the word in my life.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―It is called a tundish in <span class="hide">53.364757 -6.256734</span>Lower Drumcondra, said Stephen <br>
-            laughing, where they speak the best English.<span class="tag lineNumber">50520</span><br> </p>
+            laughing, where they speak the best English.<span class="tag lineNumber">520</span><br> </p>
             <p class="dialog"><span class="tag dialog">the dean</span>―A tundish!</p> said the dean reflectively. <p class="dialog"><span class="tag dialog">the dean</span>That is a most interest- <br>
             ing word. I must look that word up. Upon my word I must.<br></p> </p>
             <p class="textParagraph"> His courtesy of manner rang a little false and Stephen looked <br>
             at the English convert with the same eyes as the elder brother in <br>
-            the parable may have turned on the prodigal. A humble fol- <span class="tag lineNumber">50525</span><br>
+            the parable may have turned on the prodigal. A humble fol- <br>
             lower in the wake of clamorous conversions,  a poor English- <br>
             man in Ireland, he seemed to have entered on the stage of jesuit <br>
             history when that strange play of intrigue and suffering and <br>
             envy and struggle and indignity had been all but given through <br>
-            – a latecomer, a tardy spirit.  From what had he set out? Per- <span class="tag lineNumber">50530</span><br>
+            – a latecomer, a tardy spirit.  From what had he set out? Per- <span class="tag lineNumber">530</span><br>
             haps he had been born and bred among serious dissenters, <br>
             seeing salvation in Jesus only and abhorring the vain pomps of <br>
             the establishment. Had he felt the need of an implicit faith <br>
             amid the welter of sectarianism and the jargon of its turbulent <br>
-            schisms, six principle men, peculiar people, seed and snake <span class="tag lineNumber">50535</span><br>
+            schisms, six principle men, peculiar people, seed and snake <br>
             baptists, supralapsarian dogmatists? Had he found the true <br>
             church all of a sudden in winding up to the end like a reel of <br>
             cotton some finespun line of reasoning upon insufflation or the <br>
             imposition of hands or the procession of the Holy Ghost? Or <br>
-            had Lord Christ touched him and bidden him follow, like that <span class="tag lineNumber">50540</span><br>
+            had Lord Christ touched him and bidden him follow, like that <span class="tag lineNumber">540</span><br>
             disciple who had sat at the receipt of custom, as he sat by the <br>
             door of some zincroofed chapel, yawning and telling over his <br>
             church pence?<br> </p>
             <p class="textParagraph"> The dean repeated the word yet again. <br>
-            <p class="dialog"><span class="tag dialog">the dean</span>―Tundish! Well now, that is interesting!<span class="tag lineNumber">50545</span><br> </p>
+            <p class="dialog"><span class="tag dialog">the dean</span>―Tundish! Well now, that is interesting!<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―The question you asked me a moment ago seems to me more <br>
             interesting. What is that beauty which the artist struggles to <br>
             express from lumps of earth,</p> said Stephen coldly.<br> </p>
             <p class="textParagraph"> The little word seemed to have turned a rapier point of his <br>
-            sensitiveness against this courteous and vigilant foe. He felt <span class="tag lineNumber">50550</span><br>
+            sensitiveness against this courteous and vigilant foe. He felt <span class="tag lineNumber">550</span><br>
             with a smart of dejection that the man to whom he was speak- <br>
             ing was a countryman of Ben Jonson. He thought: <br>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―The language in which we are speaking is his before it is <br>
             mine. How different are the words <span class="emph">home, Christ, ale, master</span> on <br>
-            his lips and on mine! I cannot speak or write these words with- <span class="tag lineNumber">50555</span><br>
+            his lips and on mine! I cannot speak or write these words with- <br>
             out unrest of spirit. His language, so familiar and so foreign, <br>
             will always be for me an acquired speech. I have not made or <br>
             accepted its words. My voice holds them at bay. My soul frets <br>
             in the shadow of his language.<br> </p>
-            <p class="dialog"><span class="tag dialog">the dean</span>―And to distinguish between the beautiful and the sublime, <span class="tag lineNumber">50560</span><br>
+            <p class="dialog"><span class="tag dialog">the dean</span>―And to distinguish between the beautiful and the sublime, <span class="tag lineNumber">560</span><br>
             the dean added. To distinguish between moral beauty and ma- <br>
             terial beauty. And to inquire what kind of  beauty is proper to <br>
             each of the various arts. These are some interesting points we <br>
             might take up.<br></p> </p>
-            <p class="textParagraph"> Stephen, disheartened suddenly by the dean's firm dry tone, <span class="tag lineNumber">50565</span><br>
+            <p class="textParagraph"> Stephen, disheartened suddenly by the dean's firm dry tone, <br>
             was silent. The dean also was silent: and through the silence a <br>
             distant noise of many boots and confused voices came up the <br>
             staircase. <br>
             <p class="dialog"><span class="tag dialog">the dean</span>―In pursuing these speculations,</p> said the dean conclusively, <br>
-            <p class="dialog"><span class="tag dialog">the dean</span>there is however the danger of perishing of inanition. First you <span class="tag lineNumber">50570</span><br>
+            <p class="dialog"><span class="tag dialog">the dean</span>there is however the danger of perishing of inanition. First you <span class="tag lineNumber">570</span><br>
             must take your degree. Set that before you as your first aim. <br>
             Then, little by little, you will see your way. I mean in every <br>
             sense, your way in life and in thinking. It may be uphill pedal- <br>
             ling at first. Take Mr Moonan. He was a long time before he <br>
-            got to the top. But he got there.<span class="tag lineNumber">50575</span><br> </p>
+            got to the top. But he got there.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I may not have his talent,</p> said Stephen quietly.<br>
             <p class="dialog"><span class="tag dialog">the dean</span>―You never know,</p> said the dean brightly. <p class="dialog"><span class="tag dialog">the dean</span>We never can say <br>
             what is in us. I most certainly should not be despondent. Per <br>
             aspera ad astra.<br></p> </p>
-            <p class="textParagraph"> He left the hearth quickly and went towards the landing to <span class="tag lineNumber">50580</span><br>
+            <p class="textParagraph"> He left the hearth quickly and went towards the landing to <span class="tag lineNumber">580</span><br>
             oversee the arrival of the first arts' class.<br> </p>
             <p class="textParagraph"> Leaning against the fireplace Stephen heard him greet briskly <br>
             and impartially every student of the class and could almost see <br>
             the frank smiles of the coarser students. A desolating pity be- <br>
-            gan to fall like a dew upon his easily embittered heart for this <span class="tag lineNumber">50585</span><br>
+            gan to fall like a dew upon his easily embittered heart for this <br>
             faithful servingman of the knightly Loyola, for this halfbrother <br>
             of the clergy, more venal than they in speech, more steadfast of <br>
             soul than they, one whom he would never call his ghostly fa- <br>
             ther: and he thought how this man and his companions had <br>
-            earned the name of worldlings at the hands not of the un- <span class="tag lineNumber">50590</span><br>
+            earned the name of worldlings at the hands not of the un- <span class="tag lineNumber">590</span><br>
             worldly only but of the worldly also for having pleaded, during <br>
             all their history, at the bar of God's justice for the souls of the <br>
             lax and the lukewarm and the prudent.<br> </p>
             <p class="textParagraph"> The entry of the professor was signalled by a few rounds of <span class="hide">51.278708 0.521725</span> <br>
-            Kentish fire from the heavy boots of those students who sat on <span class="tag lineNumber">50595</span><br>
+            Kentish fire from the heavy boots of those students who sat on <br>
             the highest tier of the gloomy theatre under the grey cob- <br>
             webbed windows. The calling of the roll began and the re- <br>
             sponses to the names were given out in all tones until the name <br>
             of Peter Byrne was reached. <br>
-            <p class="dialog"><span class="tag dialog">???</span>―Here!<span class="tag lineNumber">50600</span><br></p> </p>
+            <p class="dialog"><span class="tag dialog">???</span>―Here!<span class="tag lineNumber">600</span><br></p> </p>
             <p class="textParagraph"> A deep bass note in response came from the upper tier, <br>
             followed by coughs of protest along the other benches.<br> </p>
             <p class="textParagraph"> The professor paused in his reading and called the next <br>
             name: <br>
-            <p class="dialog"><span class="tag dialog">???</span>―Cranly!<span class="tag lineNumber">50605</span><br></p> </p>
+            <p class="dialog"><span class="tag dialog">???</span>―Cranly!<br></p> </p>
             <p class="textParagraph"> No answer. <br>
             <p class="dialog"><span class="tag dialog">???</span>―Mr Cranly!<br></p> </p>
             <p class="textParagraph"> A smile flew across Stephen's face as he thought of his <br>
             friend's studies. <br>
-            <p class="dialog"><span class="tag dialog">???</span>―Try <span class="hide">53.267776 -6.198408</span>Leopardstown! said a voice from the bench behind.<span class="tag lineNumber">50610</span><br></p> </p>
+            <p class="dialog"><span class="tag dialog">???</span>―Try <span class="hide">53.267776 -6.198408</span>Leopardstown! said a voice from the bench behind.<span class="tag lineNumber">610</span><br></p> </p>
             <p class="textParagraph"> Stephen glanced up quickly but Moynihan's snoutish face <br>
             outlined on the grey light was impassive. A formula was given <br>
             out. Amid the rustling of the notebooks Stephen turned back <br>
             again and said: <br>
-            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Give me some paper for God' sake.<span class="tag lineNumber">50615</span><br> </p>
+            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Give me some paper for God' sake.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―Are you as bad as that? asked Moynihan with a broad grin.<br></p> </p>
             <p class="textParagraph"> He tore a sheet from his scribbler and passed it down, whis- <br>
             pering: <br>
             <p class="dialog"><span class="tag dialog">???</span>―In case of necessity any layman or woman can do it.<br></p> </p>
-            <p class="textParagraph"> The formula which he wrote obediently on the sheet of <span class="tag lineNumber">50620</span><br>
+            <p class="textParagraph"> The formula which he wrote obediently on the sheet of <span class="tag lineNumber">620</span><br>
             paper, the coiling and uncoiling calculations of the professor, <br>
             the spectrelike symbols of force and velocity fascinated and <br>
             jaded Stephen's mind. He had heard some say that the old <br>
             professor was an atheist freemason. O the grey dull day! It <br>
-            seemed a limbo of painless patient consciousness through <span class="tag lineNumber">50625</span><br>
+            seemed a limbo of painless patient consciousness through <br>
             which souls of mathematicians might wander, projecting long <br>
             slender fabrics from plane to plane of ever rarer and paler <br>
             twilight, radiating swift eddies to the last verges of a universe <br>
             ever vaster, farther and more impalpable. <br>
-            <p class="dialog"><span class="tag dialog">???</span>―So we must distinguish between elliptical and ellipsoidal. <span class="tag lineNumber">50630</span><br>
+            <p class="dialog"><span class="tag dialog">???</span>―So we must distinguish between elliptical and ellipsoidal. <span class="tag lineNumber">630</span><br>
             Perhaps some of you gentlemen may be familiar with the works <br>
             of Mr W. S. Gilbert. In one of his songs he speaks of the <br>
             billiard sharp who is condemned to play: <br>
             <p class="lg"><span class="tag type">song</span>
               On a cloth untrue <br>
-              With a twisted cue <span class="tag lineNumber">50635</span><br>
+              With a twisted cue <br>
               And elliptical billiard balls. <br>
             </p>
             He means a ball having the form of the ellipsoid of the princi- <br>
             pal axes of which I spoke a moment ago.<br></p> </p>
             <p class="textParagraph"> Moynihan leaned down towards Stephen's ear and mur- <br>
-            mured: <span class="tag lineNumber">50640</span><br>
+            mured: <span class="tag lineNumber">640</span><br>
             <p class="dialog"><span class="tag dialog">Moynihan</span>―What price ellipsoidal balls! Chase me, ladies, I'm in the <br>
             cavalry!<br></p> </p>
             <p class="textParagraph"> His fellowstudent's rude humour ran like a gust through the <br>
             cloister of Stephen's mind, shaking into gay life limp priestly <br>
-            vestments that hung upon the walls, setting them to sway and <span class="tag lineNumber">50645</span><br>
+            vestments that hung upon the walls, setting them to sway and <br>
             caper in a sabbath of misrule. The forms of the community <br>
             emerged from the gustblown vestments, the dean of studies, <br>
             the portly florid bursar with his cap of grey hair, the president, <br>
             the little priest with feathery hair who wrote devout verses, the <br>
-            squat peasant form of the professor of economics, the tall form <span class="tag lineNumber">50650</span><br>
+            squat peasant form of the professor of economics, the tall form <span class="tag lineNumber">650</span><br>
             of the young professor of mental science discussing on the <br>
             landing a case of conscience with his class like a giraffe crop- <br>
             ping high leafage among a herd of antelopes, the grave troubled <br>
             prefect of the sodality, the plump roundheaded professor of <br>
-            Italian with his rogue's eyes. They came ambling and stum- <span class="tag lineNumber">50655</span><br>
+            Italian with his rogue's eyes. They came ambling and stum- <br>
             bling, tumbling and capering, kilting their gowns for leap frog, <br>
             holding one another back, shaken with deep false laughter, <br>
             smacking one another behind and laughing at their rude mal- <br>
             ice, calling to one another by familiar nicknames, protesting <br>
-            with sudden dignity at some rough usage, whispering two and <span class="tag lineNumber">50660</span><br>
+            with sudden dignity at some rough usage, whispering two and <span class="tag lineNumber">660</span><br>
             two behind their hands.<br> </p>
             <p class="textParagraph"> The professor had gone to the glass cases on the sidewall <br>
             from a shelf of which he took down a set of coils, blew away <br>
             the dust from many points and, bearing it carefully to the table, <br>
-            held a finger on it while he proceeded with his lecture. He <span class="tag lineNumber">50665</span><br>
+            held a finger on it while he proceeded with his lecture. He <br>
             explained that the wires in modern coils were of a compound <br>
             called platinoid lately discovered by F. W. Martino.<br> </p>
             <p class="textParagraph"> He spoke clearly the initials and surname of the discoverer. <br>
             Moynihan whispered from behind: <br>
-            <p class="dialog"><span class="tag dialog">Moynihan</span>―Good old Fresh Water Martin!<span class="tag lineNumber">50670</span><br> </p>
+            <p class="dialog"><span class="tag dialog">Moynihan</span>―Good old Fresh Water Martin!<span class="tag lineNumber">670</span><br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Ask him, Stephen whispered back with weary humour, if he <br>
             wants a subject for electrocution. He can have me.<br></p> </p>
             <p class="textParagraph"> Moynihan, seeing the professor bend over the coils, rose in <br>
             his bench and, clacking noiselessly the fingers of his right hand, <br>
-            began to call with the voice of a slobbering urchin: <span class="tag lineNumber">50675</span><br>
+            began to call with the voice of a slobbering urchin: <br>
             <p class="dialog"><span class="tag dialog">Moynihan</span>―Please, teacher! Please, teacher! This boy is after saying a <br>
             bad word, teacher.<br> </p>
             <p class="dialog"><span class="tag dialog">the professor</span>―Platinoid,</p> the professor said solemnly, <p class="dialog"><span class="tag dialog">the professor</span>is preferred to Ger- <br>
             man silver because it has a lower coefficient of resistance <br>
-            variation by changes of temperature. The platinoid wire is in- <span class="tag lineNumber">50680</span><br>
+            variation by changes of temperature. The platinoid wire is in- <span class="tag lineNumber">680</span><br>
             sulated and the covering of silk that insulates it is wound <br>
             double on the ebonite bobbins just where my finger is. If it <br>
             were wound single an extra current would be induced in the <br>
             coils. The bobbins are saturated in hot paraffinwax ...<br></p> </p>
-            <p class="textParagraph"> A sharp <span class="hide">54.407332 -7.024250</span>Ulster voice said from the bench below Stephen: <span class="tag lineNumber">50685</span><br>
+            <p class="textParagraph"> A sharp <span class="hide">54.407332 -7.024250</span>Ulster voice said from the bench below Stephen: <br>
             <p class="dialog"><span class="tag dialog">???</span>―Are we likely to be asked questions on applied science?<br></p> </p>
             <p class="textParagraph"> The professor began to juggle gravely with the terms pure <br>
             science and applied science. A heavybuilt student wearing gold <br>
             spectacles stared with some wonder at the questioner. Moyni- <br>
-            han murmured from behind in his natural voice: <span class="tag lineNumber">50690</span><br>
+            han murmured from behind in his natural voice: <span class="tag lineNumber">690</span><br>
             <p class="dialog"><span class="tag dialog">Moynihan</span>Isn't MacAlister a devil for his pound of flesh?<br></p> </p>
             <p class="textParagraph"> Stephen looked down coldly on the oblong skull beneath <br>
             him overgrown with tangled twinecoloured hair. The voice, the <br>
             accent, the mind of the questioner offended him and he allowed <br>
-            the offence to carry  him towards wilful unkindness, bidding his <span class="tag lineNumber">50695</span><br>
+            the offence to carry  him towards wilful unkindness, bidding his <br>
             mind think that the student's father would have done better <br>
             had he sent his son to <span class="hide">54.597285 -5.930120</span>Belfast to study and have saved some- <br>
             thing on the trainfare by so doing.<br> </p>
             <p class="textParagraph"> The oblong skull beneath did not turn to meet this shaft of <br>
-            thought and yet the shaft came back to its bowstring: for he <span class="tag lineNumber">50700</span><br>
+            thought and yet the shaft came back to its bowstring: for he <span class="tag lineNumber">700</span><br>
             saw in a moment the student's wheypale face. <br></p>
             <p class="textParagraph"><p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―That thought is not mine,</p> he said to himself quickly. <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>It came <br>
             from the comic Irishman in the bench behind. Patience. Can <br>
             you say with certitude by whom the soul of your race was <br>
-            bartered and its elect betrayed – by the questioner or  by the <span class="tag lineNumber">50705</span><br>
+            bartered and its elect betrayed – by the questioner or  by the <br>
             mocker? Patience. Remember Epictetus. It is probably in his <br>
             character to ask such a question at such a moment in such a <br>
             tone and to pronounce the word <span class="emph">science</span> as a monosyllable.<br></p> </p>
             <p class="textParagraph"> The droning voice of the professor continued to wind itself <br>
-            slowly round and round the coils it spoke of, doubling, <span class="tag lineNumber">50710</span><br>
+            slowly round and round the coils it spoke of, doubling, <span class="tag lineNumber">710</span><br>
             trebling, quadrupling its somnolent energy as the coil multi- <br>
             plied its ohms of resistance.<br> </p>
             <p class="textParagraph"> Moynihan's voice called from behind in echo to a distant <br>
             bell: <br>
-            <p class="dialog"><span class="tag dialog">Moynihan</span>―Closing time, gents!<span class="tag lineNumber">50715</span><br></p> </p>
+            <p class="dialog"><span class="tag dialog">Moynihan</span>―Closing time, gents!<br></p> </p>
             <p class="textParagraph"> The entrance hall was crowded and loud with talk. On a <br>
             table near the door were two photographs in frames and be- <br>
             tween them a long roll of paper bearing an irregular tail of <br>
             signatures. MacCann went briskly to and fro among the stu- <br>
-            dents, talking rapidly, answering rebuffs and leading one after <span class="tag lineNumber">50720</span><br>
+            dents, talking rapidly, answering rebuffs and leading one after <span class="tag lineNumber">720</span><br>
             another to the table. In the inner hall the dean of studies stood <br>
             talking to a young professor, stroking his chin gravely and nod- <br>
             ding his head.<br> </p>
             <p class="textParagraph"> Stephen, checked by the crowd at the door, halted irresol- <br>
-            utely. From under the wide falling leaf of a soft hat Cranly's <span class="tag lineNumber">50725</span><br>
+            utely. From under the wide falling leaf of a soft hat Cranly's <br>
             dark eyes were watching him. <br>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Have you signed?</p> Stephen asked.<br></p>
             <p class="textParagraph"> Cranly closed his long thinlipped mouth, communed with <br>
             himself an instant and answered: <br>
-            <p class="dialog"><span class="tag dialog">Cranly</span>―Ego habeo.<span class="tag lineNumber">50730</span><br> </p>
+            <p class="dialog"><span class="tag dialog">Cranly</span>―Ego habeo.<span class="tag lineNumber">730</span><br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―What is it for?<br> </p>
             <p class="dialog"><span class="tag dialog">Cranly</span>―Quod?<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―What is it for?<br></p> </p>
             <p class="textParagraph"> Cranly turned his pale face to Stephen and said blandly and <br>
-            bitterly: <span class="tag lineNumber">50735</span><br>
+            bitterly: <br>
             <p class="dialog"><span class="tag dialog">Cranly</span>―Per pax universalis.<br></p> </p>
             <p class="textParagraph"> Stephen pointed to the Czar's photograph and said: <br>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―He has the face of a besotted Christ.<br></p> </p>
             <p class="textParagraph"> The scorn and anger in his voice brought Cranly's eyes back <br>
-            from a calm survey of the walls of the hall. <span class="tag lineNumber">50740</span><br>
+            from a calm survey of the walls of the hall. <span class="tag lineNumber">740</span><br>
             <p class="dialog"><span class="tag dialog">Cranly</span>―Are you annoyed? he asked.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―No, answered Stephen.<br> </p>
             <p class="dialog"><span class="tag dialog">Cranly</span>―Are you in bad humour?<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―No.<br></p> </p>
-            <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Cranly</span>―Credo ut vos sanguinarius mendax estis, said Cranly, quia <span class="tag lineNumber">50745</span><br>
+            <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Cranly</span>―Credo ut vos sanguinarius mendax estis, said Cranly, quia <br>
             facies vostra monstrat ut vos in damno malo humore estis.<br></p> </p>
             <p class="textParagraph"> Moynihan, on his way to the table, said in Stephen's ear: <br>
             <p class="dialog"><span class="tag dialog">Moynihan</span>―MacCann is in tiptop form. Ready to shed the last drop. <br>
             Brandnew world. No stimulants and votes for the bitches.<br></p> </p>
-            <p class="textParagraph"> Stephen smiled at the manner of this confidence and, when <span class="tag lineNumber">50750</span><br>
+            <p class="textParagraph"> Stephen smiled at the manner of this confidence and, when <span class="tag lineNumber">750</span><br>
             Moynihan had passed, turned again to meet Cranly's eyes. <br>
             <p class="dialog"><span class="tag dialog">???</span>―Perhaps you can tell me,</p> he said, <p class="dialog"><span class="tag dialog">???</span>why he pours his soul so <br>
             freely into my ear. Can you?<br></p> </p>
             <p class="textParagraph"> A dull scowl appeared on Cranly's forehead. He stared at <br>
-            the table where Moynihan had bent to write his name on the <span class="tag lineNumber">50755</span><br>
+            the table where Moynihan had bent to write his name on the <br>
             roll, and then said flatly: <br>
             <p class="dialog"><span class="tag dialog">Cranly</span>―A sugar!<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>"&gt;―Quis est in malo humore,</p> said Stephen, <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>ego aut vos?<br></p> </p>
             <p class="textParagraph"> Cranly did not take up the taunt. He brooded sourly on his <br>
-            judgment and repeated with the same flat force: <span class="tag lineNumber">50760</span><br>
+            judgment and repeated with the same flat force: <span class="tag lineNumber">760</span><br>
             <p class="dialog"><span class="tag dialog">Cranly</span>―A flaming bloody sugar, that's what he is!<br></p> </p>
             <p class="textParagraph"> It was his epitaph for all dead friendships and Stephen won- <br>
             dered whether it would ever be spoken in the same tone over <br>
             his memory. The heavy lumpish phrase sank slowly out of <br>
-            hearing like a stone through a quagmire. Stephen saw it sink as <span class="tag lineNumber">50765</span><br>
+            hearing like a stone through a quagmire. Stephen saw it sink as <br>
             he had seen many an other, feeling its heaviness depress his <br>
             heart. Cranly's speech, unlike that of Davin, had neither rare <br>
             phrases of Elizabethan English nor quaintly turned versions of <br>
             Irish idioms. Its drawl was an echo of the quays of Dublin <br>
-            given back by a bleak decaying seaport, its energy an echo of <span class="tag lineNumber">50770</span><br>
+            given back by a bleak decaying seaport, its energy an echo of <span class="tag lineNumber">770</span><br>
             the sacred eloquence of Dublin given back flatly by a <span class="hide">52.979861 -6.048263</span>Wicklow <br>
             pulpit.<br> </p>
             <p class="textParagraph"> The heavy scowl faded from Cranly's face as MacCann <br>
             marched briskly towards them from the other side of the hall. <br>
-            <p class="dialog"><span class="tag dialog">???</span>―Here you are! said MacCann cheerily.<span class="tag lineNumber">50775</span><br> </p>
+            <p class="dialog"><span class="tag dialog">???</span>―Here you are! said MacCann cheerily.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Here I am! said Stephen.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―Late as usual. Can you not combine the progressive tendency <br>
             with a respect for punctuality?<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―That question is out of order, said Stephen. Next business.<br></p> </p>
-            <p class="textParagraph"> His smiling eyes were fixed on a silverwrapped tablet of milk <span class="tag lineNumber">50780</span><br>
+            <p class="textParagraph"> His smiling eyes were fixed on a silverwrapped tablet of milk <span class="tag lineNumber">780</span><br>
             chocolate which peeped out of the propagandist's breastpocket. <br>
             A little ring of listeners closed round to hear the war of wits. A <br>
             lean student with olive skin and lank black hair thrust his face <br>
             between the two, glancing from one to the other at each phrase <br>
-            and seeming to try to catch each flying phrase in his open moist <span class="tag lineNumber">50785</span><br>
+            and seeming to try to catch each flying phrase in his open moist <br>
             mouth. Cranly took a small grey handball from his pocket and <br>
             began to examine it closely, turning it over and over. <br>
             <p class="dialog"><span class="tag dialog">???</span>―Next business? said MacCann. Hom!<br></p> </p>
             <p class="textParagraph"> He gave a loud cough of laughter, smiled broadly and <br>
-            tugged twice at  the strawcoloured goatee which hung from his <span class="tag lineNumber">50790</span><br>
+            tugged twice at  the strawcoloured goatee which hung from his <span class="tag lineNumber">790</span><br>
             blunt chin. <br>
             <p class="dialog"><span class="tag dialog">???</span>―The next business is to sign the testimonial.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Will you pay me anything if I sign? asked Stephen.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―I thought you were an idealist, said MacCann.<br></p> </p>
-            <p class="textParagraph"> The gipsylike student looked about him and addressed the <span class="tag lineNumber">50795</span><br>
+            <p class="textParagraph"> The gipsylike student looked about him and addressed the <br>
             onlookers in an indistinct bleating voice. <br>
             <p class="dialog"><span class="tag dialog">???</span>―By hell, that's a queer notion. I consider that notion to be a <br>
             mercenary notion.<br></p> </p>
             <p class="textParagraph"> His voice faded into silence. No heed was paid to his words. <br>
-            He turned his olive face, equine in expression, towards Ste- <span class="tag lineNumber">50800</span><br>
+            He turned his olive face, equine in expression, towards Ste- <span class="tag lineNumber">800</span><br>
             phen, inviting him to speak again.<br> </p>
             <p class="textParagraph"> MacCann began to speak with fluent energy of the Czar's <br>
             rescript, of Stead, of general disarmament, arbitration in cases <br>
             of international disputes, of the signs of the times, of the new <br>
-            humanity and the new gospel of life which would make it the <span class="tag lineNumber">50805</span><br>
+            humanity and the new gospel of life which would make it the <br>
             business of the community to secure as cheaply as possible the <br>
             greatest possible happiness of the greatest possible number.<br> </p>
             <p class="textParagraph"> The gipsy student responded to the close of the period by <br>
             crying: <br>
-            <p class="dialog"><span class="tag dialog">???</span>―Three cheers for universal brotherhood!<span class="tag lineNumber">50810</span><br> </p>
+            <p class="dialog"><span class="tag dialog">???</span>―Three cheers for universal brotherhood!<span class="tag lineNumber">810</span><br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―Go on, Temple, said a stout ruddy student near him. I'll <br>
             stand you a pint after.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―I'm a believer in universal brotherhood, said Temple, <br>
             glancing about him out of his dark oval eyes. Marx is only a <br>
-            bloody cod.<span class="tag lineNumber">50815</span><br></p> </p>
+            bloody cod.<br></p> </p>
             <p class="textParagraph"> Cranly gripped his arm tightly to check his tongue, smiling <br>
             uneasily, and repeated: <br>
             <p class="dialog"><span class="tag dialog">???</span>―Easy, easy, easy!<br></p> </p>
             <p class="textParagraph"> Temple struggled to free his arm but continued, his mouth <br>
-            flecked by a thin foam: <span class="tag lineNumber">50820</span><br>
+            flecked by a thin foam: <span class="tag lineNumber">820</span><br>
             <p class="dialog"><span class="tag dialog">???</span>―Socialism was founded by an Irishman and the first man in <br>
             Europe who preached the freedom of thought was Collins. Two <br>
             hundred years ago. He denounced priestcraft. The philosopher <br>
             of <span class="hide">51.520987 -0.415985</span>Middlesex. Three cheers for John Anthony Collins!<br></p> </p>
-            <p class="textParagraph"> A thin voice from the verge of the ring replied: <span class="tag lineNumber">50825</span><br>
+            <p class="textParagraph"> A thin voice from the verge of the ring replied: <br>
             <p class="dialog"><span class="tag dialog">???</span>―Pip! pip!<br></p> </p>
             <p class="textParagraph"> Moynihan murmured beside Stephen's ear: <br>
             <p class="dialog"><span class="tag dialog">???</span>―And what about John Anthony's poor little sister: <br>
             <p class="lg">
               Lottie Collins lost her drawers; <br>
-              Won't you kindly lend her yours? <span class="tag lineNumber">50830</span><br>
+              Won't you kindly lend her yours? <span class="tag lineNumber">830</span><br>
             </p>
             </p></p>
             <p class="textParagraph"> Stephen laughed and Moynihan, pleased with the result, <br>
             murmured again: <br>
             <p class="dialog"><span class="tag dialog">???</span>―We'll have five bob each way on John Anthony Collins.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―I am waiting for your answer, said MacCann briefly.<br> </p>
-            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―The affair doesn't interest me in the least, said Stephen <span class="tag lineNumber">50835</span><br>
+            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―The affair doesn't interest me in the least, said Stephen <br>
             wearily. You knew that well. Why do you make a scene about <br>
             it?<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―Good! said MacCann, smacking his lips. You are a reaction- <br>
             ary then?<br> </p>
-            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Do you think you impress me, Stephen asked, when you <span class="tag lineNumber">50840</span><br>
+            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Do you think you impress me, Stephen asked, when you <span class="tag lineNumber">840</span><br>
             flourish your wooden sword?<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―Metaphors! said MacCann bluntly. Come to facts.<br></p> </p>
             <p class="textParagraph"> Stephen blushed and turned aside. MacCann stood his <br>
             ground and said with hostile humour: <br>
-            <p class="dialog"><span class="tag dialog">???</span>―Minor poets, I suppose, are above such trivial questions as <span class="tag lineNumber">50845</span><br>
+            <p class="dialog"><span class="tag dialog">???</span>―Minor poets, I suppose, are above such trivial questions as <br>
             the question of universal peace.<br></p> </p>
             <p class="textParagraph"> Cranly raised his head and held the handball between the <br>
             two students by way of a peaceoffering, saying: <br>
             <p class="dialog"><span class="tag dialog">???</span>―Pax super totum sanguinarium globum.<br></p> </p>
-            <p class="textParagraph"> Stephen, moving away the bystanders, jerked his shoulder <span class="tag lineNumber">50850</span><br>
+            <p class="textParagraph"> Stephen, moving away the bystanders, jerked his shoulder <span class="tag lineNumber">850</span><br>
             angrily in the direction of the Czar's image, saying: <br>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Keep your icon. If we must have a Jesus let us have a legit- <br>
             imate Jesus.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―By hell, that's a good one! said the gipsy student to those <br>
-            about him. That's a fine expression. I like that expression <span class="tag lineNumber">50855</span><br>
+            about him. That's a fine expression. I like that expression <br>
             immensely.<br></p> </p>
             <p class="textParagraph"> He gulped down the spittle in his throat as if he were gulp- <br>
             ing down the phrase and, fumbling at the peak of his tweed <br>
             cap, turned to Stephen, saying: <br>
-            <p class="dialog"><span class="tag dialog">???</span>―Excuse me, sir, what do you mean by that expression you <span class="tag lineNumber">50860</span><br>
+            <p class="dialog"><span class="tag dialog">???</span>―Excuse me, sir, what do you mean by that expression you <span class="tag lineNumber">860</span><br>
             uttered just now?<br></p> </p>
             <p class="textParagraph"> Feeling himself jostled by the students near him, he said to <br>
             them: <br>
             <p class="dialog"><span class="tag dialog">???</span>―I am curious to know now what he meant by that ex- <br>
-            pression.<span class="tag lineNumber">50865</span><br></p> </p>
+            pression.<br></p> </p>
             <p class="textParagraph"> He turned again to Stephen and said in a whisper: <br>
             <p class="dialog"><span class="tag dialog">???</span>―Do you believe in Jesus? I believe in man. Of course, I don't <br>
             know if you believe in man. I admire you, sir. I admire the <br>
             mind of man independent of all religions. Is that your opinion <br>
-            about the mind of Jesus?<span class="tag lineNumber">50870</span><br> </p>
+            about the mind of Jesus?<span class="tag lineNumber">870</span><br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―Go on, Temple, said the stout ruddy student returning, as <br>
             was his wont, to his first idea, that pint is waiting for you.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―He thinks I'm an imbecile, Temple explained to Stephen, <br>
             because I'm a  believer in the power of mind.<br></p> </p>
-            <p class="textParagraph"> Cranly linked his arms into those of Stephen and his admirer <span class="tag lineNumber">50875</span><br>
+            <p class="textParagraph"> Cranly linked his arms into those of Stephen and his admirer <br>
             and said: <br>
             <p class="dialog"><span class="tag dialog">???</span>―Nos ad manum ballum jocabimus.<br></p> </p>
             <p class="textParagraph"> Stephen, in the act of being led away, caught sight of <br>
             MacCann's flushed bluntfeatured face. <br>
-            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―My signature is of no account,</p> he said politely. <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>You are right <span class="tag lineNumber">50880</span><br>
+            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―My signature is of no account,</p> he said politely. <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>You are right <span class="tag lineNumber">880</span><br>
             to go your way. Leave me to go mine.<br> </p>
             <p class="dialog"><span class="tag dialog">MacCann</span>―Dedalus,</p> said MacCann crisply, <p class="dialog"><span class="tag dialog">MacCann</span>I believe you're a good fel- <br>
             low but you have yet to learn the dignity of altruism and the <br>
             responsibility of the human individual.<br></p> </p>
-            <p class="textParagraph"> A voice said: <span class="tag lineNumber">50885</span><br>
+            <p class="textParagraph"> A voice said: <br>
             <p class="dialog"><span class="tag dialog">MacAlister</span>―Intellectual crankery is better out of this movement than in <br>
             it.<br></p> </p>
             <p class="textParagraph"> Stephen, recognising  the harsh tone of MacAlister's voice, <br>
             did not turn in the direction of the voice. Cranly pushed sol- <br>
-            emnly through the throng of students, linking Stephen and <span class="tag lineNumber">50890</span><br>
+            emnly through the throng of students, linking Stephen and <span class="tag lineNumber">890</span><br>
             Temple like a celebrant attended by his ministers on his way to <br>
             the altar.<br> </p>
             <p class="textParagraph"> Temple bent eagerly across Cranly's breast and said: <br>
             <p class="dialog"><span class="tag dialog">???</span>―Did you hear MacAlister what he said? That youth is jealous <br>
-            of you. Did you see that? I bet Cranly didn't see that. By hell, I <span class="tag lineNumber">50895</span><br>
+            of you. Did you see that? I bet Cranly didn't see that. By hell, I <br>
             saw that at once.<br></p> </p>
             <p class="textParagraph"> As they crossed the inner hall the dean of studies was in  the <br>
             act of escaping from the student with whom he had been con- <br>
             versing. He stood at the foot of the staircase, a foot on the <br>
-            lowest step, his threadbare  soutane gathered about him for <span class="tag lineNumber">50900</span><br>
+            lowest step, his threadbare  soutane gathered about him for <span class="tag lineNumber">900</span><br>
             the ascent with womanish care, nodding his head often and <br>
             repeating: <br>
             <p class="dialog"><span class="tag dialog">???</span>―Not a doubt of it, Mr Hackett! Very true! Not a doubt of it!<br></p> </p>
             <p class="textParagraph"> In the middle of the hall the prefect of the college sodality <br>
-            was speaking earnestly, in a soft querulous voice, with a <span class="tag lineNumber">50905</span><br>
+            was speaking earnestly, in a soft querulous voice, with a <br>
             boarder. As he spoke he wrinkled a little his freckled brow and <br>
             bit, between his phrases, at a tiny bone pencil. <br>
             <p class="dialog"><span class="tag dialog">???</span>―I hope the matric men will all come. The first arts men are <br>
             pretty sure. Second arts too. We must make sure of the new- <br>
-            comers.<span class="tag lineNumber">50910</span><br></p> </p>
+            comers.<span class="tag lineNumber">910</span><br></p> </p>
             <p class="textParagraph"> Temple bent again across Cranly, as they were passing <br>
             through the doorway, and said in a swift whisper: <br>
             <p class="dialog"><span class="tag dialog">???</span>―Do you know that he is a married man? He was a married <br>
             man before they converted him. He has a wife and children <br>
-            somewhere. By hell, I think that's the queerest notion I ever <span class="tag lineNumber">50915</span><br>
+            somewhere. By hell, I think that's the queerest notion I ever <br>
             heard! Eh?<br></p> </p>
             <p class="textParagraph"> His whisper trailed off into sly cackling laughter. The mo- <br>
             ment they were through the doorway Cranly seized him rudely <br>
             by the neck and shook him, saying: <br>
-            <p class="dialog"><span class="tag dialog">???</span>―You flaming floundering fool! I'll take my dying bible there <span class="tag lineNumber">50920</span><br>
+            <p class="dialog"><span class="tag dialog">???</span>―You flaming floundering fool! I'll take my dying bible there <span class="tag lineNumber">920</span><br>
             isn't a bigger bloody ape, do you know, than you in the whole <br>
             flaming bloody world!<br></p> </p>
             <p class="textParagraph"> Temple wriggled in his grip, laughing still with sly content, <br>
             while Cranly repeated flatly at every rude shake: <br>
-            <p class="dialog"><span class="tag dialog">???</span>―A flaming flaring  bloody idiot!<span class="tag lineNumber">50925</span><br></p> </p>
+            <p class="dialog"><span class="tag dialog">???</span>―A flaming flaring  bloody idiot!<br></p> </p>
             <p class="textParagraph"> They crossed the weedy garden together. The president, <br>
             wrapped in a heavy loose cloak, was coming towards them <br>
             along one of the walks, reading his office. At the end of the <br>
             walk he halted before turning and raised his eyes. The students <br>
-            saluted, Temple fumbling as before at the peak of his cap. They <span class="tag lineNumber">50930</span><br>
+            saluted, Temple fumbling as before at the peak of his cap. They <span class="tag lineNumber">930</span><br>
             walked forward in silence. As they neared the alley Stephen <br>
             could hear the thuds of the players' hands and the wet smacks <br>
             of the ball and Davin's voice crying out excitedly at each <br>
             stroke.<br> </p>
-            <p class="textParagraph"> The three students halted round the box on which Davin sat <span class="tag lineNumber">50935</span><br>
+            <p class="textParagraph"> The three students halted round the box on which Davin sat <br>
             to follow the game. Temple, after a few moments, sidled across <br>
             to Stephen and said: <br>
             <p class="dialog"><span class="tag dialog">???</span>―Excuse me, I wanted to ask you do you believe that Jean <br>
             Jacques Rousseau was a sincere man?<br></p> </p>
-            <p class="textParagraph"> Stephen laughed outright. Cranly, picking up the broken <span class="tag lineNumber">50940</span><br>
+            <p class="textParagraph"> Stephen laughed outright. Cranly, picking up the broken <span class="tag lineNumber">940</span><br>
             stave of a cask from the grass at his foot, turned swiftly and <br>
             said sternly: <br>
             <p class="dialog"><span class="tag dialog">???</span>―Temple, I declare to the living God if you say another word, <br>
             do you know, to anybody on any subject I'll kill you super <br>
-            spottum.<span class="tag lineNumber">50945</span><br> </p>
+            spottum.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―He was like you, I fancy, said Stephen, an emotional man.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―Blast him, curse him! said Cranly broadly. Don't talk to him <br>
             at all. Sure you might as well be talking, do you know, to a <br>
             flaming chamberpot as talking to Temple. Go home, Temple. <br>
-            For God' sake go home.<span class="tag lineNumber">50950</span><br> </p>
+            For God' sake go home.<span class="tag lineNumber">950</span><br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―I don't care a damn about you, Cranly, answered Temple, <br>
             moving out of reach of the uplifted stave and pointing at Ste- <br>
             phen. He's the only man I see in this institution that has an <br>
             individual mind.<br> </p>
-            <p class="dialog"><span class="tag dialog">???</span>―Institution! Individual! cried Cranly. Go home, blast you, for <span class="tag lineNumber">50955</span><br>
+            <p class="dialog"><span class="tag dialog">???</span>―Institution! Individual! cried Cranly. Go home, blast you, for <br>
             you're a hopeless bloody man.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―I'm an emotional man, said Temple. That's quite rightly <br>
             expressed. And I'm proud that I'm an emotionalist.<br></p> </p>
             <p class="textParagraph"> He sidled out of the alley, smiling slily. Cranly watched him <br>
-            with a blank expressionless face. <span class="tag lineNumber">50960</span><br></p>
+            with a blank expressionless face. <span class="tag lineNumber">960</span><br></p>
             <p class="textParagraph"><p class="dialog"><span class="tag dialog">???</span>―Look at him!</p> he said. <p class="dialog"><span class="tag dialog">???</span>Did you ever see such a go-by-the- <br>
             wall?<br></p></p>
             <p class="textParagraph"> His phrase was greeted by a strange laugh from a student <br>
             who lounged against the wall, his peaked cap down on his eyes. <br>
-            The laugh, pitched in a high key and coming from a so muscu- <span class="tag lineNumber">50965</span><br>
+            The laugh, pitched in a high key and coming from a so muscu- <br>
             lar frame, seemed like the whinny of an elephant. The student's <br>
             body shook all over and, to ease his mirth, he rubbed both his <br>
             hands delightedly over  his groins. <br>
             <p class="dialog"><span class="tag dialog">???</span>―Lynch is awake, said Cranly.<br></p> </p>
-            <p class="textParagraph"> Lynch, for answer, straightened himself and thrust forward <span class="tag lineNumber">50970</span><br>
+            <p class="textParagraph"> Lynch, for answer, straightened himself and thrust forward <span class="tag lineNumber">970</span><br>
             his chest. <br>
             <p class="dialog"><span class="tag dialog">???</span>―Lynch puts out his chest, said Stephen, as a criticism of life.<br></p> </p>
             <p class="textParagraph"> Lynch smote himself sonorously on the chest and said: <br>
             <p class="dialog"><span class="tag dialog">???</span>―Who has anything to say about my girth?<br></p> </p>
-            <p class="textParagraph"> Cranly took him at the word and the two began to tussle. <span class="tag lineNumber">50975</span><br>
+            <p class="textParagraph"> Cranly took him at the word and the two began to tussle. <br>
             When their faces had flushed with the struggle they drew apart, <br>
             panting. Stephen bent down towards Davin who, intent on the <br>
             game, had paid no heed to the talk of the others. <br>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―And how is my little tame goose? he asked. Did he sign too?<br></p> </p>
-            <p class="textParagraph"> Davin nodded and said: <span class="tag lineNumber">50980</span><br>
+            <p class="textParagraph"> Davin nodded and said: <span class="tag lineNumber">980</span><br>
             <p class="dialog"><span class="tag dialog">???</span>―And you, Stevie?<br></p> </p>
             <p class="textParagraph"> Stephen shook his head. <br>
             <p class="dialog"><span class="tag dialog">???</span>―You're a terrible man, Stevie, said Davin, taking the short <br>
             pipe from his mouth. Always alone.<br> </p>
-            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Now that you have signed the petition for universal peace, <span class="tag lineNumber">50985</span><br>
+            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Now that you have signed the petition for universal peace, <br>
             said Stephen, I suppose you will burn that little copybook I saw <br>
             in your room.<br></p> </p>
             <p class="textParagraph"> As Davin did not answer Stephen began to quote: <br>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Long pace, fianna! Right incline, fianna! Fianna, by num- <br>
-            bers, salute, one, two!<span class="tag lineNumber">50990</span><br> </p>
+            bers, salute, one, two!<span class="tag lineNumber">990</span><br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―That's a different question, said Davin. I'm an Irish nation- <br>
             alist, first and foremost. But that's you all out. You're a born <br>
             sneerer, Stevie.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―When you make the next rebellion with hurleysticks, said <br>
-            Stephen, and want the indispensable informer, tell me. I can <span class="tag lineNumber">50995</span><br>
+            Stephen, and want the indispensable informer, tell me. I can <br>
             find you a few in this college.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―I can't understand you, said Davin. One time I hear you talk <br>
             against English literature. Now you talk against the  Irish in- <br>
             formers. What with your name and your ideas .... Are you Irish <br>
-            at all?<span class="tag lineNumber">51000</span><br> </p>
+            at all?<span class="tag lineNumber">1000</span><br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Come with me now to the office of arms and I will show you <br>
             the tree of my family, said Stephen.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―Then be one of us, said Davin. Why don't you learn Irish? <br>
             Why did you drop out of the league class after the first lesson?<br> </p>
-            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―You know one reason why, answered Stephen.<span class="tag lineNumber">51005</span><br></p> </p>
+            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―You know one reason why, answered Stephen.<br></p> </p>
             <p class="textParagraph"> Davin tossed his head and laughed. <br></p>
             <p class="textParagraph"><p class="dialog"><span class="tag dialog">???</span>―O, come now,</p> he said. <p class="dialog"><span class="tag dialog">???</span>Is it on account of that certain young <br>
             lady and Father Moran? But that's all in your own mind, <br>
             Stevie. They were only talking and laughing.<br></p></p>
-            <p class="textParagraph"> Stephen paused and laid a friendly hand upon Davin's <span class="tag lineNumber">51010</span><br>
+            <p class="textParagraph"> Stephen paused and laid a friendly hand upon Davin's <span class="tag lineNumber">1010</span><br>
             shoulder. <br>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Do you remember,</p> he said, <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>when we knew each other first. <br>
             The first morning we met you asked me to show you the <br>
             way to the matriculation class, putting a very strong stress on <br>
-            the first syllable. You remember? Then you used to address the <span class="tag lineNumber">51015</span><br>
+            the first syllable. You remember? Then you used to address the <br>
             jesuits as father, you remember? I ask myself about you: <span class="emph">Is <br>
             he as innocent as his speech?</span><br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―I'm a simple person, said Davin. You know that. When you <br>
             told me that night in Harcourt Street those things about your <br>
-            private life, honest to God, Stevie, I was not able to eat my <span class="tag lineNumber">51020</span><br>
+            private life, honest to God, Stevie, I was not able to eat my <span class="tag lineNumber">1020</span><br>
             dinner. I was quite bad. I was awake a long time that night. <br>
             Why did you tell me those things?<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Thanks, said Stephen. You mean I am a monster.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―No, said Davin, but I wish you had not told me.<br></p> </p>
-            <p class="textParagraph"> A tide began to surge beneath the calm surface of Stephen's <span class="tag lineNumber">51025</span><br>
+            <p class="textParagraph"> A tide began to surge beneath the calm surface of Stephen's <br>
             friendliness. <br>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―This race and this country and this life produced me, he <br>
             said. I shall express myself as I am.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―Try to be one of us, repeated Davin. In your heart you are an <br>
-            Irishman but your pride is too powerful.<span class="tag lineNumber">51030</span><br> </p>
+            Irishman but your pride is too powerful.<span class="tag lineNumber">1030</span><br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―My ancestors threw off their language and took on another, <br>
             Stephen said. They allowed a handful of foreigners to subject <br>
             them. Do you fancy I am going to pay in my own life and <br>
             person debts they made? What for?<br> </p>
-            <p class="dialog"><span class="tag dialog">???</span>―For our freedom, said Davin.<span class="tag lineNumber">51035</span><br> </p>
+            <p class="dialog"><span class="tag dialog">???</span>―For our freedom, said Davin.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―No honourable and sincere man, said Stephen, has given up <br>
             to you his life and his youth and his affections from the days of <br>
             Tone to those of Parnell but you sold him to the enemy or <br>
             failed him in need or reviled him and left him for another. And <br>
-            you invite me to be one of you. I'd see you damned first.<span class="tag lineNumber">51040</span><br> </p>
+            you invite me to be one of you. I'd see you damned first.<span class="tag lineNumber">1040</span><br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―They died for their ideals, Stevie, said Davin. Our day will <br>
             come yet, believe me.<br></p> </p>
             <p class="textParagraph"> Stephen, following his own thought, was silent for an in- <br>
                 stant. <br></p>
-            <p class="textParagraph"><p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―The soul is born,</p> he said vaguely, <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>first in those moments I <span class="tag lineNumber">51045</span><br>
+            <p class="textParagraph"><p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―The soul is born,</p> he said vaguely, <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>first in those moments I <br>
             told you of. It has a slow and dark birth, more mysterious than <br>
             the birth of the body. When the soul of a man is born in this <br>
             country there are nets flung at it to hold it back from flight. <br>
             You talk to me of nationality, language, religion. I shall try to <br>
-            fly by those nets.<span class="tag lineNumber">51050</span><br></p></p>
+            fly by those nets.<span class="tag lineNumber">1050</span><br></p></p>
             <p class="textParagraph"> Davin knocked the ashes from his pipe. <br>
               <p class="dialog"><span class="tag dialog">Davin</span>―Too deep for me, Stevie,</p> he said. <p class="dialog"><span class="tag dialog">Davin</span>But a man's country comes <br>
             first. Ireland first, Stevie. You can be a poet or a mystic after.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Do you know what Ireland is? asked Stephen with cold <br>
-            violence. Ireland is the old sow that eats her farrow.<span class="tag lineNumber">51055</span><br></p> </p>
+            violence. Ireland is the old sow that eats her farrow.<br></p> </p>
             <p class="textParagraph"> Davin rose from his box and went towards the players, <br>
             shaking his head sadly. But in a moment his sadness left him <br>
             and he was hotly disputing with Cranly and the two players <br>
             who had finished their game. A match of four was arranged, <br>
-            Cranly insisting, however, that his ball should be used. He let it <span class="tag lineNumber">51060</span><br>
+            Cranly insisting, however, that his ball should be used. He let it <span class="tag lineNumber">1060</span><br>
             rebound twice or thrice to his hand and then struck it strongly <br>
             and swiftly towards the base of the alley, exclaiming in answer <br>
             to its thud: <br>
             <p class="dialog"><span class="tag dialog">???</span>―Your soul!<br></p> </p>
-            <p class="textParagraph"> Stephen stood with Lynch till the score began to rise. Then <span class="tag lineNumber">51065</span><br>
+            <p class="textParagraph"> Stephen stood with Lynch till the score began to rise. Then <br>
             he plucked him by the sleeve to come away. Lynch obeyed, <br>
             saying: <br>
             <p class="dialog"><span class="tag dialog">???</span>―Let us eke go, as Cranly has it.<br></p> </p>
             <p class="textParagraph"> Stephen smiled at this sidethrust. They passed back through <br>
-            the garden and out through the hall where the doddering porter <span class="tag lineNumber">51070</span><br>
+            the garden and out through the hall where the doddering porter <span class="tag lineNumber">1070</span><br>
             was pinning up a notice in the frame. At the foot of the steps <br>
             they halted and Stephen took a packet of cigarettes from his <br>
             pocket and offered it to his companion. <br>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I know you are poor, he said.<br> </p>
-            <p class="dialog"><span class="tag dialog">???</span>―Damn your yellow insolence, answered Lynch.<span class="tag lineNumber">51075</span><br></p> </p>
+            <p class="dialog"><span class="tag dialog">???</span>―Damn your yellow insolence, answered Lynch.<br></p> </p>
             <p class="textParagraph"> This second proof of Lynch's culture made Stephen smile <br>
             again. <br></p>
             <p class="textParagraph"><p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―It was a great day for European culture,</p> he said, <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>when you <br>
                     made up your mind to swear in yellow.<br></p></p>
-            <p class="textParagraph"> They lit their cigarettes and turned to the right. After a <span class="tag lineNumber">51080</span><br>
+            <p class="textParagraph"> They lit their cigarettes and turned to the right. After a <span class="tag lineNumber">1080</span><br>
             pause Stephen began: <br>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Aristotle has not defined pity and terror. I have. I say ...<br></p> </p>
             <p class="textParagraph"> Lynch halted and said bluntly: <br>
             <p class="dialog"><span class="tag dialog">???</span>―Stop! I won't listen! I am sick. I was out last night on a <br>
-            yellow drunk with Horan and Goggins.<span class="tag lineNumber">51085</span><br></p> </p>
+            yellow drunk with Horan and Goggins.<br></p> </p>
             <p class="textParagraph"> Stephen went on: <br>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Pity is the feeling which arrests the mind in the presence of <br>
             whatsoever is grave and constant in human sufferings and <br>
             unites it with the human sufferer.  Terror is the feeling which <br>
-            arrests the mind in the presence of whatsoever is grave and <span class="tag lineNumber">51090</span><br>
+            arrests the mind in the presence of whatsoever is grave and <span class="tag lineNumber">1090</span><br>
             constant in human sufferings and unites it with the secret <br>
             cause.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―Repeat, said Lynch.<br></p> </p>
             <p class="textParagraph"> Stephen repeated the definitions slowly. <br>
-            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―A girl got into a hansom a few days ago, he went on, in <span class="hide">51.507351 -0.127758</span> <span class="tag lineNumber">51095</span><br>
+            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―A girl got into a hansom a few days ago, he went on, in <span class="hide">51.507351 -0.127758</span> <br>
             London. She was on her way to meet her mother whom she <br>
             had not seen for many years. At the corner of a street the shaft <br>
             of a lorry shivered the window of the hansom in the shape of a <br>
             star. A long fine needle of the shivered glass pierced her heart. <br>
-            She died on the instant. The reporter called it a tragic death. It <span class="tag lineNumber">51100</span><br>
+            She died on the instant. The reporter called it a tragic death. It <span class="tag lineNumber">1100</span><br>
             is not. It is remote from terror and pity according to the terms <br>
             of my definitions.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>The tragic emotion, in fact, is a face looking two ways, <br>
             towards terror and towards pity, both of which are phases of <br>
-            it. You see I use the word <span class="emph">arrest</span>. I mean that the tragic emotion <span class="tag lineNumber">51105</span><br>
+            it. You see I use the word <span class="emph">arrest</span>. I mean that the tragic emotion <br>
             is static. Or rather the dramatic emotion is. The feelings ex- <br>
             cited by improper art are kinetic, desire or loathing. Desire <br>
             urges us to possess, to go to something, loathing  urges us to <br>
             abandon, to go from something. These are kinetic emotions. <br>
-            The arts which excite them, pornographical or didactic, are <span class="tag lineNumber">51110</span><br>
+            The arts which excite them, pornographical or didactic, are <span class="tag lineNumber">1110</span><br>
             therefore improper arts. The esthetic emotion (I use the general <br>
             term) is therefore static. The mind is arrested and raised above <br>
             desire and loathing.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―You say that art must not excite desire, said Lynch. I told <br>
-            you that one day I wrote my name in pencil on the backside of <span class="tag lineNumber">51115</span><br>
+            you that one day I wrote my name in pencil on the backside of <br>
             the Venus of Praxiteles in the <span class="hide">53.339706 -6.252188</span>Museum. Was that not desire?<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―I speak of normal natures, said Stephen. You also told me <br>
             that when you were a boy in that charming carmelite school <br>
             you ate pieces of dried cowdung.<br></p> </p>
-            <p class="textParagraph"> Lynch broke again into a whinny of laughter and again <span class="tag lineNumber">51120</span><br>
+            <p class="textParagraph"> Lynch broke again into a whinny of laughter and again <span class="tag lineNumber">1120</span><br>
             rubbed both his hands over his groins but without taking them <br>
             from his pockets. <br>
             <p class="dialog"><span class="tag dialog">???</span>―O I did! I did! he cried.<br></p> </p>
             <p class="textParagraph"> Stephen turned towards his companion and looked at him <br>
-            for a moment boldly in the eyes. Lynch, recovering from his <span class="tag lineNumber">51125</span><br>
+            for a moment boldly in the eyes. Lynch, recovering from his <br>
             laughter, answered his look from his humbled eyes. The long <br>
             slender flattened skull beneath the long pointed cap brought <br>
             before Stephen's mind the image of a hooded reptile. The eyes, <br>
             too, were reptilelike in glint and gaze. Yet at that instant, <br>
-            humbled and alert in their look, they were lit by one tiny <span class="tag lineNumber">51130</span><br>
+            humbled and alert in their look, they were lit by one tiny <span class="tag lineNumber">1130</span><br>
             human point, the window of a shrivelled soul, poignant and <br>
             selfembittered. <br>
               <p class="dialog"><span class="tag dialog">Stephen</span>―As for that,</p> Stephen said in polite parenthesis, <p class="dialog"><span class="tag dialog">Stephen</span>we are all <br>
             animals. I also am an animal.<br> </p>
-            <p class="dialog"><span class="tag dialog">???</span>―You are, said Lynch.<span class="tag lineNumber">51135</span><br> </p>
+            <p class="dialog"><span class="tag dialog">???</span>―You are, said Lynch.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>"&gt;―But we are just now in a mental world, Stephen continued. <br>
             The desire and loathing excited by improper esthetic means are <br>
             really not esthetic emotions not only because they are kinetic <br>
             in character but also because they are not more than physical. <br>
-            Our flesh shrinks from what it dreads and responds to the <span class="tag lineNumber">51140</span><br>
+            Our flesh shrinks from what it dreads and responds to the <span class="tag lineNumber">1140</span><br>
             stimulus of what it desires by a purely reflex action of the nerv- <br>
             ous system. Our eyelid closes before we are aware that the fly is <br>
             about to enter our eye.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―Not always, said Lynch critically.<br> </p>
-            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>"&gt;―In the same way, said Stephen, your flesh responded to the <span class="tag lineNumber">51145</span><br>
+            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>"&gt;―In the same way, said Stephen, your flesh responded to the <br>
             stimulus of a naked statue but it was, I say, simply a reflex <br>
             action of the nerves. Beauty expressed by the artist cannot <br>
             awaken in us an emotion which is kinetic or a sensation which <br>
             is purely physical. It awakens, or ought to awaken, or induces, <br>
-            or ought to induce, an esthetic stasis, an ideal pity or an ideal <span class="tag lineNumber">51150</span><br>
+            or ought to induce, an esthetic stasis, an ideal pity or an ideal <span class="tag lineNumber">1150</span><br>
             terror, a stasis called forth, prolonged and at last dissolved by <br>
             what I call the rhythm of beauty.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―What is that exactly? asked Lynch.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Rhythm, said Stephen, is the first formal esthetic relation of <br>
-            part to part in any esthetic whole or of an esthetic whole to its <span class="tag lineNumber">51155</span><br>
+            part to part in any esthetic whole or of an esthetic whole to its <br>
             part or parts or of any part to the esthetic whole of which it is a <br>
             part.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―If that is rhythm, said Lynch, let me hear what you call <br>
             beauty: and, please remember, though I did eat a cake of cow- <br>
-            dung once, that I admire only beauty.<span class="tag lineNumber">51160</span><br></p> </p>
+            dung once, that I admire only beauty.<span class="tag lineNumber">1160</span><br></p> </p>
             <p class="textParagraph"> Stephen raised his cap as if in greeting. Then,  blushing <br>
             slightly, he laid his hand on Lynch's thick tweed sleeve. <br></p>
             <p class="textParagraph"><p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―We are right,</p> he said, <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>and the others are wrong. To speak of <br>
             these things and to try to understand their nature and, having <br>
-            understood it, to try slowly and humbly and constantly to <span class="tag lineNumber">51165</span><br>
+            understood it, to try slowly and humbly and constantly to <br>
             express, to press out again, from the gross earth or what it <br>
             brings forth, from sound and shape and colour which are the <br>
             prison gates of our soul, an image of the beauty we have come <br>
             to understand – that is art.<br></p></p>
-            <p class="textParagraph"> They had reached the <span class="hide">53.342399 -6.238434</span>canal bridge and, turning from their <span class="tag lineNumber">51170</span><br>
+            <p class="textParagraph"> They had reached the <span class="hide">53.342399 -6.238434</span>canal bridge and, turning from their <span class="tag lineNumber">1170</span><br>
             course, went on by the trees. A crude grey light, mirrored in the <br>
             sluggish water, and a smell of wet branches over their heads <br>
             seemed to war against the course of Stephen's thought. <br>
             <p class="dialog"><span class="tag dialog">???</span>―But you have not answered my question, said Lynch. What <br>
-            is art? What is the beauty it expresses?<span class="tag lineNumber">51175</span><br> </p>
+            is art? What is the beauty it expresses?<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―That was the first definition I gave you, you sleepyheaded <br>
             wretch, said Stephen, when I began to try to think out the <br>
             matter for myself. Do you remember the night? Cranly lost his <br>
             temper and began to talk about Wicklow bacon.<br> </p>
-            <p class="dialog"><span class="tag dialog">???</span>―I remember, said Lynch. He told us about them flaming fat <span class="tag lineNumber">51180</span><br>
+            <p class="dialog"><span class="tag dialog">???</span>―I remember, said Lynch. He told us about them flaming fat <span class="tag lineNumber">1180</span><br>
             devils of pigs.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Art, said Stephen, is the human disposition of sensible or <br>
             intelligible matter for an esthetic end. You remember the pigs <br>
             and forget that. You are a distressing pair, you and Cranly.<br></p> </p>
-            <p class="textParagraph"> Lynch made a grimace at the raw grey sky and said: <span class="tag lineNumber">51185</span><br>
+            <p class="textParagraph"> Lynch made a grimace at the raw grey sky and said: <br>
             <p class="dialog"><span class="tag dialog">???</span>―If I am to listen to your esthetic philosophy give me at least <br>
             another cigarette. I don't care about it. I don't even care about <br>
             women. Damn you and damn everything. I want a job of five <br>
             hundred a year. You can't get me one.<br></p> </p>
-            <p class="textParagraph"> Stephen handed him the packet of cigarettes. Lynch took the <span class="tag lineNumber">51190</span><br>
+            <p class="textParagraph"> Stephen handed him the packet of cigarettes. Lynch took the <span class="tag lineNumber">1190</span><br>
             last one that remained, saying simply: <br>
             <p class="dialog"><span class="tag dialog">???</span>―Proceed!<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Aquinas, said Stephen, says that is beautiful the apprehen- <br>
             sion of which pleases.<br></p> </p>
-            <p class="textParagraph"> Lynch nodded. <span class="tag lineNumber">51195</span><br>
+            <p class="textParagraph"> Lynch nodded. <br>
               <p class="dialog"><span class="tag dialog">Lynch</span>―I remember that,</p> he said. <p class="dialog"><span class="tag dialog">Lynch</span>Pulcra sunt quae visa placent.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―He uses the word visa, said Stephen, to cover esthetic appre- <br>
             hension of all kinds, whether through sight or hearing or <br>
             through any other avenue of apprehension. This word, though <br>
-            it is vague, is clear enough to keep away good and evil which <span class="tag lineNumber">51200</span><br>
+            it is vague, is clear enough to keep away good and evil which <span class="tag lineNumber">1200</span><br>
             excite desire and loathing. It means certainly a stasis and not a <br>
             kinesis. How about the true? It produces also a stasis of the <br>
             mind. You would not write your name in pencil across the <br>
             hypothenuse of a rightangled triangle.<br> </p>
-            <p class="dialog"><span class="tag dialog">???</span>―No, said Lynch. Give me the hypothenuse of the Venus of <span class="tag lineNumber">51205</span><br>
+            <p class="dialog"><span class="tag dialog">???</span>―No, said Lynch. Give me the hypothenuse of the Venus of <br>
             Praxiteles.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Static therefore, said Stephen. Plato, I believe, said that <br>
             beauty is the splendour of truth. I don't think that it has a <br>
             meaning but the true and the beautiful are akin. Truth is beheld <br>
-            by the intellect which is appeased by the most satisfying <span class="tag lineNumber">51210</span><br>
+            by the intellect which is appeased by the most satisfying <span class="tag lineNumber">1210</span><br>
             relations of the intelligible:  beauty is beheld by the imagination <br>
             which is appeased by the most satisfying relations of the sen- <br>
             sible. The first step in the direction of truth is to understand the <br>
             frame and scope of the intellect itself, to comprehend the act <br>
-            itself of intellection. Aristotle's entire system of philosophy <span class="tag lineNumber">51215</span><br>
+            itself of intellection. Aristotle's entire system of philosophy <br>
             rests upon his book of psychology and that, I think, rests on his <br>
             statement that the same attribute cannot at the same time and <br>
             in the same connection belong to and not belong to the same <br>
             subject. The first step in the direction of beauty is to under- <br>
-            stand the frame and scope of the imagination, to comprehend <span class="tag lineNumber">51220</span><br>
+            stand the frame and scope of the imagination, to comprehend <span class="tag lineNumber">1220</span><br>
             the act itself of esthetic apprehension. Is that clear?<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―But what is beauty? asked Lynch impatiently. Out with an- <br>
             other definition. Something we see and like! Is that the best you <br>
             and Aquinas can do?<br> </p>
-            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Let us take woman, said Stephen.<span class="tag lineNumber">51225</span><br> </p>
+            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Let us take woman, said Stephen.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―Let us take her! said Lynch fervently.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―The Greek, the Turk, the Chinese, the Copt, the Hottentot,<br> </p>
             said Stephen, <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>all admire a different type of female beauty. That <br>
             seems to be a maze out of which we cannot escape. I see <br>
-            however two ways out. One is this hypothesis: that every physi- <span class="tag lineNumber">51230</span><br>
+            however two ways out. One is this hypothesis: that every physi- <span class="tag lineNumber">1230</span><br>
             cal quality admired by men in women is in direct connection <br>
             with the manifold functions of women for the propagation of <br>
             the species. It may be so. The world, it seems, is drearier than <br>
             even you, Lynch, imagined. For my part I dislike that way out. <br>
-            It leads to eugenics rather than to esthetic. It leads you out of <span class="tag lineNumber">51235</span><br>
+            It leads to eugenics rather than to esthetic. It leads you out of <br>
             the maze into a new gaudy lectureroom where MacCann, with <br>
             one hand on <span class="emph">The Origin of Species</span> and the other hand on the <br>
             new testament, tells you that you admired the great flanks of <br>
             Venus because you felt that she would bear you burly offspring <br>
-            and admired her great breasts because you felt that she would <span class="tag lineNumber">51240</span><br>
+            and admired her great breasts because you felt that she would <span class="tag lineNumber">1240</span><br>
             give good milk to her children and yours.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―Then MacCann is a sulphuryellow liar, said Lynch energeti- <br>
             cally.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―There remains another way out, said Stephen laughing.<br> </p>
-            <p class="dialog"><span class="tag dialog">???</span>―To wit? said Lynch.<span class="tag lineNumber">51245</span><br> </p>
+            <p class="dialog"><span class="tag dialog">???</span>―To wit? said Lynch.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―This hypothesis, Stephen began.<br></p> </p>
             <p class="textParagraph"> A long dray laden with old iron came round the corner of <br>
             <span class="hide">53.339029 -6.241523</span>sir Patrick Dun's hospital covering the end of Stephen's speech <br>
             with the harsh roar of jangled and rattling metal. Lynch closed <br>
-            his ears and gave out oath after oath till the dray had passed. <span class="tag lineNumber">51250</span><br>
+            his ears and gave out oath after oath till the dray had passed. <span class="tag lineNumber">1250</span><br>
             Then he turned on his heel rudely. Stephen turned also and <br>
             waited for a few moments till his companion's illhumour had <br>
             had its vent. <br>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―This hypothesis, Stephen repeated, is the other way out: <br>
-            that, though the same object may not seem beautiful to all <span class="tag lineNumber">51255</span><br>
+            that, though the same object may not seem beautiful to all <br>
             people, all people who admire a beautiful object find in it <br>
             certain relations which satisfy and coincide with the stages <br>
             themselves of all esthetic apprehension. These relations of the <br>
             sensible, visible to you through one form and to me through <br>
-            another, must be therefore the necessary qualities of beauty. <span class="tag lineNumber">51260</span><br>
+            another, must be therefore the necessary qualities of beauty. <span class="tag lineNumber">1260</span><br>
             Now, we can return to our old friend saint Thomas for another <br>
             pennyworth of wisdom.<br></p> </p>
             <p class="textParagraph"> Lynch laughed. <br>
               <p class="dialog"><span class="tag dialog">???</span>―It amuses me vastly,</p> he said, <p class="dialog"><span class="tag dialog">???</span>to hear you quoting him time <br>
-            after time like a jolly round friar. Are you laughing in your <span class="tag lineNumber">51265</span><br>
+            after time like a jolly round friar. Are you laughing in your <br>
             sleeve?<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―MacAlister, answered Stephen, would call my esthetic the- <br>
             ory applied Aquinas. So far as this side of esthetic philosophy <br>
             extends Aquinas will carry me all along the line. When we <br>
-            come to the phenomenon of artistic conception, artistic gesta- <span class="tag lineNumber">51270</span><br>
+            come to the phenomenon of artistic conception, artistic gesta- <span class="tag lineNumber">1270</span><br>
             tion and artistic reproduction I require a new terminology and <br>
             a new personal experience.<br> </p>
             <p class="dialog"><span class="tag dialog">Lynch</span>Of course, said Lynch. After all Aquinas, in spite of his <br>
             intellect, was exactly a good round  friar. But you will tell me <br>
-            about the new personal experience and new terminology some <span class="tag lineNumber">51275</span><br>
+            about the new personal experience and new terminology some <br>
             other day. Hurry up and finish the first part.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Who knows? said Stephen smiling. Perhaps Aquinas would <br>
             understand me better than you. He was a poet himself. He <br>
             wrote a hymn for Maundy Thursday. It begins with the words <br>
-            Pange lingua gloriosi. They say it is the highest glory of the <span class="tag lineNumber">51280</span><br>
+            Pange lingua gloriosi. They say it is the highest glory of the <span class="tag lineNumber">1280</span><br>
             hymnal. It is an intricate and soothing hymn.  I like it: but there <br>
             is no hymn that can be put beside that mournful and majestic <br>
             processional song, the Vexilla Regis of Venantius Fortunatus.<br></p> </p>
             <p class="textParagraph"> Lynch began to sing softly and solemnly in a deep bass <br>
-            voice: <span class="tag lineNumber">51285</span><br>
+            voice: <br>
             <p class="lg"><span class="tag type">song</span>
               Impleta sunt quae concinit <br>
               David fideli carmine <br>
               Dicendo nationibus <br>
               Regnavit a ligno Deus. <br>
             </p>
-            <p class="dialog"><span class="tag dialog">???</span>―That's great!</p> he said, well pleased. <p class="dialog"><span class="tag dialog">???</span>Great music!<span class="tag lineNumber">51290</span><br></p>
+            <p class="dialog"><span class="tag dialog">???</span>―That's great!</p> he said, well pleased. <p class="dialog"><span class="tag dialog">???</span>Great music!<span class="tag lineNumber">1290</span><br></p>
             </p>
             <p class="textParagraph"> They turned into <span class="hide">53.338573 -6.243389</span>Lower Mount Street. A few steps from the <br>
             corner a fat young man, wearing a silk neckcloth, saluted them <br>
             and stopped. <br>
             <p class="dialog"><span class="tag dialog">???</span>―Did you hear the results of the exams? he asked. Griffin was <br>
-            plucked. Halpin and O'Flynn are through the home civil. <span class="tag lineNumber">51295</span><br>
+            plucked. Halpin and O'Flynn are through the home civil. <br>
             Moonan got fifth place in the Indian. O'Shaughenessy got four- <br>
             teenth. The Irish fellows in Clarke's gave them a feed last night. <br>
             They all ate curry.<br></p> </p>
             <p class="textParagraph"> His pallid bloated face expressed benevolent malice and, as <br>
-            he had advanced through his tidings of success, his small <span class="tag lineNumber">51300</span><br>
+            he had advanced through his tidings of success, his small <span class="tag lineNumber">1300</span><br>
             fatencircled eyes vanished out of sight and his weak wheezing <br>
             voice out of hearing.<br> </p>
             <p class="textParagraph"> In reply to a question of Stephen's his eyes and his voice <br>
                 came forth again from their lurkingplaces. <br></p>
-            <p class="textParagraph"><p class="dialog"><span class="tag dialog">???</span>―Yes, MacCullagh and I,</p> he said. <p class="dialog"><span class="tag dialog">???</span>He's taking pure mathemat- <span class="tag lineNumber">51305</span><br>
+            <p class="textParagraph"><p class="dialog"><span class="tag dialog">???</span>―Yes, MacCullagh and I,</p> he said. <p class="dialog"><span class="tag dialog">???</span>He's taking pure mathemat- <br>
             ics and I'm taking constitutional history. There are twenty <br>
             subjects. I'm taking botany too. You know I'm a member of the <br>
             field club.<br></p></p>
             <p class="textParagraph"> He drew back from the other two in a stately fashion and <br>
-            placed a plump woollengloved hand on his breast from which <span class="tag lineNumber">51310</span><br>
+            placed a plump woollengloved hand on his breast from which <span class="tag lineNumber">1310</span><br>
             muttered wheezing laughter at once broke forth. <br>
             <p class="dialog"><span class="tag dialog">???</span>―Bring us a few turnips and onions the next time you go out <br>
             said Stephen drily, to make a stew.<br></p> </p>
             <p class="textParagraph"> The fat student laughed indulgently and said: <br>
-            <p class="dialog"><span class="tag dialog">???</span>―We are all  highly respectable people in the field club. Last <span class="tag lineNumber">51315</span><br>
+            <p class="dialog"><span class="tag dialog">???</span>―We are all  highly respectable people in the field club. Last <br>
             Saturday we went out to <span class="hide">52.957720 -6.354370</span>Glenmalure, seven of us.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―With women, Donovan? said Lynch.<br></p> </p>
             <p class="textParagraph"> Donovan again laid his hand on his chest and said: <br>
             <p class="dialog"><span class="tag dialog">???</span>―Our end is the acquisition of knowledge.<br></p> </p>
-            <p class="textParagraph"> Then he said quickly: <span class="tag lineNumber">51320</span><br>
+            <p class="textParagraph"> Then he said quickly: <span class="tag lineNumber">1320</span><br>
             <p class="dialog"><span class="tag dialog">???</span>―I hear you are writing some essay about esthetics.<br></p> </p>
             <p class="textParagraph"> Stephen made a vague gesture of denial. <br>
             <p class="dialog"><span class="tag dialog">???</span>―Goethe and Lessing, said Donovan, have written a lot on <br>
             that subject, the classical school and the romantic school and <br>
-            all that. The <span class="emph">Laocoon</span> interested me very much when I read it. <span class="tag lineNumber">51325</span><br>
+            all that. The <span class="emph">Laocoon</span> interested me very much when I read it. <br>
             Of course it is idealistic, German, ultraprofound.<br></p> </p>
             <p class="textParagraph"> Neither of the others spoke. Donovan took leave of them <br>
             urbanely. <br></p>
             <p class="textParagraph"><p class="dialog"><span class="tag dialog">???</span>―I must go,</p> he said softly and benevolently. <p class="dialog"><span class="tag dialog">???</span>I have a strong <br>
-            suspicion, amounting almost to a conviction, that my sister <span class="tag lineNumber">51330</span><br>
+            suspicion, amounting almost to a conviction, that my sister <span class="tag lineNumber">1330</span><br>
             intended to make pancakes today for the dinner of the Don- <br>
             ovan family.<br> </p></p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Goodbye,</p> Stephen said in his wake. <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>Don't forget the turnips <br>
             for me and my mate.<br></p>
-            <p class="textParagraph"> Lynch gazed after him, his lip curling in slow scorn till his <span class="tag lineNumber">51335</span><br>
+            <p class="textParagraph"> Lynch gazed after him, his lip curling in slow scorn till his <br>
             face resembled a devil's mask: <br>
             <p class="dialog"><span class="tag dialog">???</span>―To think that that yellow pancakeeating excrement can get a <br>
             good job, he said at length, and I have to smoke cheap ciga- <br>
             rettes!<br></p> </p>
-            <p class="textParagraph"> They turned their faces towards <span class="hide">53.339658 -6.249165</span>Merrion Square and went <span class="tag lineNumber">51340</span><br>
+            <p class="textParagraph"> They turned their faces towards <span class="hide">53.339658 -6.249165</span>Merrion Square and went <span class="tag lineNumber">1340</span><br>
             on for a little in silence. <br>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―To finish what I was saying about beauty, said Stephen, the <br>
             most satisfying relations of the sensible must therefore corre- <br>
             spond to the necessary phases of artistic apprehension. Find <br>
-            these and you find the qualities of universal beauty. Aquinas <span class="tag lineNumber">51345</span><br>
+            these and you find the qualities of universal beauty. Aquinas <br>
             says: ad pulcritudinem tria requiruntur, integritas, consonantia, <br>
             claritas. I translate it so: <span class="emph">Three things are needed for beauty, <br>
             wholeness, harmony and radiance</span>. Do these correspond to the <br>
             phases of apprehension? Are you following?<br> </p>
-            <p class="dialog"><span class="tag dialog">???</span>―Of course, I am, said Lynch. If you think I have an excre- <span class="tag lineNumber">51350</span><br>
+            <p class="dialog"><span class="tag dialog">???</span>―Of course, I am, said Lynch. If you think I have an excre- <span class="tag lineNumber">1350</span><br>
             mentitious intelligence run after Donovan and ask him to listen <br>
             to you.<br></p> </p>
             <p class="textParagraph"> Stephen pointed to a basket which a butcher's boy had slung <br>
             inverted on his head. <br>
-            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Look at that basket, he said.<span class="tag lineNumber">51355</span><br> </p>
+            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Look at that basket, he said.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―I see it, said Lynch.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―In order to see that basket, said Stephen, your mind first of <br>
             all separates the basket from the rest of the visible universe <br>
             which is not the basket. The first phase of apprehension is a <br>
-            bounding line drawn about the object to be apprehended. An <span class="tag lineNumber">51360</span><br>
+            bounding line drawn about the object to be apprehended. An <span class="tag lineNumber">1360</span><br>
             esthetic image is presented to us either in space or in time. <br>
             What is audible is presented in time, what is visible is presented <br>
             in space. But temporal or spatial the esthetic image is first <br>
             luminously apprehended as selfbounded and selfcontained <br>
-            upon the immeasurable background of space or time which is <span class="tag lineNumber">51365</span><br>
+            upon the immeasurable background of space or time which is <br>
             not it. You apprehend it as <span class="emph">one</span> thing. You see it as one whole. <br>
             You apprehend its wholeness. That is integritas.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―Bull's eye! said Lynch laughing. Go on.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Then, said Stephen, you pass from point to point, led by its <br>
-            formal lines; you apprehend it as balanced part against part <span class="tag lineNumber">51370</span><br>
+            formal lines; you apprehend it as balanced part against part <span class="tag lineNumber">1370</span><br>
             within its limits; you feel the rhythm of its structure. In other <br>
             words the synthesis of immediate perception is followed by the <br>
             analysis of apprehension. Having first felt that it is <span class="emph">one</span> thing <br>
             you feel now that it is a <span class="emph">thing</span>. You apprehend it as complex, <br>
-            multiple, divisible, separable, made up of its parts, the result of <span class="tag lineNumber">51375</span><br>
+            multiple, divisible, separable, made up of its parts, the result of <br>
             its parts and their sum, harmonious. That is consonantia.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―Bull's eye again! said Lynch wittily. Tell me now what is <br>
             claritas and you win the cigar.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―The connotation of the word,</p> Stephen said, <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>is rather vague. <br>
-            Aquinas uses a term which seems to be inexact. It baffled me <span class="tag lineNumber">51380</span><br>
+            Aquinas uses a term which seems to be inexact. It baffled me <span class="tag lineNumber">1380</span><br>
             for a long time. It would lead you to believe that he had in <br>
             mind symbolism or idealism, the supreme quality of beauty <br>
             being a light from some other world, the idea of which the <br>
             matter is but the shadow, the reality of which it is but the <br>
-            symbol. I thought he might mean that claritas is the artistic <span class="tag lineNumber">51385</span><br>
+            symbol. I thought he might mean that claritas is the artistic <br>
             discovery and representation of the divine purpose in anything <br>
             or a force of generalisation which would make the esthetic <br>
             image a universal one, make it outshine its proper conditions. <br>
             But that is literary talk. I understand it so. When you have <br>
-            apprehended that basket as one thing and have then  analysed it <span class="tag lineNumber">51390</span><br>
+            apprehended that basket as one thing and have then  analysed it <span class="tag lineNumber">1390</span><br>
             according to its form and apprehended it as a thing you make <br>
             the only synthesis which is logically and esthetically permiss- <br>
             ible. You see that it is that thing which it is and no other thing. <br>
             The radiance of which he speaks is the scholastic quidditas, the <br>
-            <span class="emph">whatness</span> of a thing. This supreme quality is felt by the artist <span class="tag lineNumber">51395</span><br>
+            <span class="emph">whatness</span> of a thing. This supreme quality is felt by the artist <br>
             when the esthetic image is first conceived in his imagination. <br>
             The mind in that mysterious instant Shelley likened beautifully <br>
             to a fading coal. The instant wherein that supreme quality of <br>
             beauty, the clear radiance of the esthetic image, is apprehended <br>
-            luminously by the mind which has been arrested by its whole- <span class="tag lineNumber">51400</span><br>
+            luminously by the mind which has been arrested by its whole- <span class="tag lineNumber">1400</span><br>
             ness and fascinated by its harmony is the luminous silent stasis <br>
             of esthetic pleasure, a spiritual state very like to that cardiac <br>
             condition which the Italian physiologist Luigi Galvani, using a <br>
             phrase almost as beautiful as Shelley's, called the enchantment <br>
-            of the heart.<span class="tag lineNumber">51405</span><br></p> </p>
+            of the heart.<br></p> </p>
             <p class="textParagraph"> Stephen paused and, though his companion did not speak, <br>
             felt that his words had called up around them a thoughten- <br>
             chanted silence. <br>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―What I have said,</p> he began again, <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>refers to beauty in the <br>
-            wider sense of the word, in the sense which the word has in the <span class="tag lineNumber">51410</span><br>
+            wider sense of the word, in the sense which the word has in the <span class="tag lineNumber">1410</span><br>
             literary tradition. In the marketplace it has another sense. <br>
             When we speak of beauty in the second sense of the term our <br>
             judgment is influenced in the first place by the art itself and by <br>
             the form of that art. The image, it is clear, must be set between <br>
-            the mind or senses of the  artist himself and the mind or senses <span class="tag lineNumber">51415</span><br>
+            the mind or senses of the  artist himself and the mind or senses <br>
             of others. If you bear this in memory you will see that art <br>
             necessarily divides itself into three forms progressing from one <br>
             to the next. These forms are: the lyrical form, the form wherein <br>
             the artist presents his image in immediate relation to himself; <br>
-            the epical form, the form wherein he presents his image in <span class="tag lineNumber">51420</span><br>
+            the epical form, the form wherein he presents his image in <span class="tag lineNumber">1420</span><br>
             mediate relation to himself and to others; the dramatic form, <br>
             the form wherein he presents his image in immediate relation to <br>
             others.<br> </p>
             <p class="dialog"><span class="tag dialog">Lynch</span>―That you told me a few nights ago,</p> said Lynch, <p class="dialog"><span class="tag dialog">Lynch</span>and we <br>
-            began the famous discussion.<span class="tag lineNumber">51425</span><br> </p>
+            began the famous discussion.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I have a book at home,</p> said Stephen, <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>in which I have written <br>
             down questions which are more amusing than yours were. In <br>
             finding the answers to them I found the theory of esthetic <br>
             which I am trying to explain. Here are some questions I set <br>
-            myself: <span class="emph">Is a chair finely made tragic or comic? Is the portrait of <span class="tag lineNumber">51430</span><br>
+            myself: <span class="emph">Is a chair finely made tragic or comic? Is the portrait of <span class="tag lineNumber">1430</span><br>
             Mona Lisa good if I desire to see it? Is the bust of sir Philip <br>
             Crampton lyrical, epical or dramatic? Can excrement or a child <br>
             or a louse be a work of art? If not, why not?</span><br> </p>
             <p class="dialog"><span class="tag dialog">Lynch</span>―Why not, indeed?</p> said Lynch laughing.<br>
-            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span><span class="emph">If a man hacking in fury at a block of wood</span>, Stephen con- <span class="tag lineNumber">51435</span><br>
+            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span><span class="emph">If a man hacking in fury at a block of wood</span>, Stephen con- <br>
             tinued, <span class="emph">make there an image &gt;of a cow is that image a work of <br>
             &gt;art? If not, why not?</span><br> </p>
             <p class="dialog"><span class="tag dialog">Lynch</span>―That's a lovely one,</p> said Lynch laughing again. <p class="dialog"><span class="tag dialog">Lynch</span>That has the <br>
             true scholastic stink.<br> </p>
-            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Lessing, said Stephen, should not have taken a group of <span class="tag lineNumber">51440</span><br>
+            <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Lessing, said Stephen, should not have taken a group of <span class="tag lineNumber">1440</span><br>
             statues to write of. The art, being inferior, does not present the <br>
             forms I spoke of distinguished clearly one from another. Even <br>
             in literature, the highest and most spiritual art, the forms are <br>
             often confused. The lyrical form is in fact the simplest verbal <br>
-            vesture of an instant of emotion, a rhythmical cry such as ages <span class="tag lineNumber">51445</span><br>
+            vesture of an instant of emotion, a rhythmical cry such as ages <br>
             ago cheered on the man who pulled at the oar or dragged <br>
             stones up a slope. He who utters it is more conscious of the <br>
             instant of emotion than of himself as feeling emotion. The <br>
             simplest epical form is seen emerging out of lyrical literature <br>
-            when the artist prolongs and broods upon himself as the centre <span class="tag lineNumber">51450</span><br>
+            when the artist prolongs and broods upon himself as the centre <span class="tag lineNumber">1450</span><br>
             of an epical event and this form progresses till the centre of <br>
             emotional gravity is equidistant from the artist himself and <br>
             from others. The narrative is no longer purely personal. The <br>
             personality of the artist passes into the narration itself, flowing <br>
-            round and round the persons and the action like a vital sea. <span class="tag lineNumber">51455</span><br>
+            round and round the persons and the action like a vital sea. <br>
             This progress you will see easily in that old English ballad <br>
             <span class="emph">Turpin Hero</span> which begins in the first person and ends in the <br>
             third person. The dramatic form is reached when the vitality <br>
             which has flowed and eddied round each person fills every <br>
-            person with such vital force that he or she assumes a proper <span class="tag lineNumber">51460</span><br>
+            person with such vital force that he or she assumes a proper <span class="tag lineNumber">1460</span><br>
             and intangible esthetic life. The personality of the artist at first <br>
             a cry or a cadence or a mood and then a fluid and lambent <br>
             narrative finally refines itself out of existence, impersonalises <br>
             itself, so to speak. The esthetic image in the dramatic form is <br>
-            life purified in and reprojected from the human imagination. <span class="tag lineNumber">51465</span><br>
+            life purified in and reprojected from the human imagination. <br>
             The mystery of esthetic like that of material creation is accom- <br>
             plished. The artist, like the God of the creation, remains within <br>
             or behind or beyond or above his handiwork, invisible, refined <br>
             out of existence, indifferent, paring his fingernails.<br> </p>
-            <p class="dialog"><span class="tag dialog">???</span>―Trying to refine them also out of existence, said Lynch.<span class="tag lineNumber">51470</span><br></p> </p>
+            <p class="dialog"><span class="tag dialog">???</span>―Trying to refine them also out of existence, said Lynch.<span class="tag lineNumber">1470</span><br></p> </p>
             <p class="textParagraph"> A fine rain began to fall from the high veiled sky and they <br>
             turned into the duke's lawn to reach <span class="hide">53.341522 -6.254893</span>the national library before <br>
             the shower came. <br>
             <p class="dialog"><span class="tag dialog">???</span>―What do you mean, Lynch asked surlily, by prating about <br>
-            beauty and the imagination in this miserable Godforsaken is- <span class="tag lineNumber">51475</span><br>
+            beauty and the imagination in this miserable Godforsaken is- <br>
             land? No wonder the artist retired within or behind his handi- <br>
             work after having perpetrated this country.<br></p> </p>
             <p class="textParagraph"> The rain fell faster. When they passed through the passage <br>
             beside<span class="hide">53.340762 -6.258382</span>Kildare house they found many students sheltering un- <br>
-            der the arcade of the library. Cranly leaning against a pillar <span class="tag lineNumber">51480</span><br>
+            der the arcade of the library. Cranly leaning against a pillar <span class="tag lineNumber">1480</span><br>
             was picking his teeth with a sharpened match, listening to some <br>
             companions. Some girls stood near the entrance door. Lynch <br>
             whispered to Stephen: <br>
             <p class="dialog"><span class="tag dialog">???</span>―Your beloved is  here.<br></p> </p>
-            <p class="textParagraph"> Stephen took his place silently on the step below the group <span class="tag lineNumber">51485</span><br>
+            <p class="textParagraph"> Stephen took his place silently on the step below the group <br>
             of students, heedless of the rain which fell fast, turning his eyes <br>
             towards her  from time to time. She too stood silently among <br>
             her companions. She has no priest to flirt with, he thought with <br>
             conscious bitterness, remembering how he had seen her last. <br>
-            Lynch was right. His mind, emptied of theory and courage, <span class="tag lineNumber">51490</span><br>
+            Lynch was right. His mind, emptied of theory and courage, <span class="tag lineNumber">1490</span><br>
             lapsed back into a listless peace.<br> </p>
             <p class="textParagraph"> He heard the students talking among themselves. They <br>
             spoke of two friends who had passed the final medical exam- <br>
             ination, of the chances of getting places on ocean liners, of <br>
-            poor and rich practices. <span class="tag lineNumber">51495</span><br>
+            poor and rich practices. <br>
             <p class="dialog"><span class="tag dialog">???</span>―That's all a  bubble. An Irish country practice is better.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―Hynes was two years in <span class="hide">53.408371 -2.991573</span>Liverpool and he says the same. A <br>
             frightful hole he said it was. Nothing but midwifery cases. Half <br>
             a crown cases.<br> </p>
-            <p class="dialog"><span class="tag dialog">???</span>―Do you mean to say it is better to have a job here in the <span class="tag lineNumber">51500</span><br>
+            <p class="dialog"><span class="tag dialog">???</span>―Do you mean to say it is better to have a job here in the <span class="tag lineNumber">1500</span><br>
             country than in a rich city like that? I know a fellow ....<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―Hynes has no brains. He got through by stewing, pure <br>
             stewing.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―Don't mind him. There's  plenty of money to be made in a <br>
-            big commercial city.<span class="tag lineNumber">51505</span><br> </p>
+            big commercial city.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―Depends on the practice.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―Ego credo ut vita pauperum est simpliciter atrox, simpliciter <br>
             sanguinarius atrox, in Liverpoolio.<br></p> </p>
             <p class="textParagraph"> Their voices reached his ears as if from a distance in inter- <br>
-            rupted pulsation. She was preparing to go away with her <span class="tag lineNumber">51510</span><br>
+            rupted pulsation. She was preparing to go away with her <span class="tag lineNumber">1510</span><br>
             companions.<br> </p>
             <p class="textParagraph"> The quick light shower had drawn off, tarrying in clusters of <br>
             diamonds among the shrubs of the quadrangle where an exha- <br>
             lation was breathed forth by the blackened earth. Their trim <br>
-            boots prattled as they stood on the steps of the colonnade <span class="tag lineNumber">51515</span><br>
+            boots prattled as they stood on the steps of the colonnade <br>
             talking quietly and gaily, glancing at the clouds, holding their <br>
             umbrellas at cunning angles against the few last raindrops, <br>
             closing them again, holding their skirts demurely.<br> </p>
             <p class="textParagraph"> And if he had judged her harshly? If her life were a simple <br>
-            rosary of hours, her life simple and strange as a bird's life, gay <span class="tag lineNumber">51520</span><br>
+            rosary of hours, her life simple and strange as a bird's life, gay <span class="tag lineNumber">1520</span><br>
             in the morning, restless all day, tired at sundown? Her heart <br>
             simple and wilful  as a bird's heart?<br> </p>
             <div class="divider">* * *</div>
@@ -7592,256 +7592,256 @@
         
             <p class="textParagraph"> Towards dawn he awoke. O what sweet music! His soul was <br>
             all dewy wet. Over his limbs in sleep pale cool waves of light <br>
-            had passed. He lay still, as if his soul lay amid cool waters, <span class="tag lineNumber">51525</span><br>
+            had passed. He lay still, as if his soul lay amid cool waters, <br>
             conscious of faint sweet music. His mind was waking slowly to <br>
             a tremulous morning knowledge, a morning inspiration. A <br>
             spirit filled him, pure as the purest water, sweet as dew, moving <br>
             as music. But how faintly it was inbreathed, how passionlessly <br>
-            as if the seraphim themselves were breathing upon him! His <span class="tag lineNumber">51530</span><br>
+            as if the seraphim themselves were breathing upon him! His <span class="tag lineNumber">1530</span><br>
             soul was waking slowly, fearing to awake wholly. It was that <br>
             windless hour of dawn when madness wakes and strange plants <br>
             open to the light and the moth flies forth silently.<br> </p>
             <p class="textParagraph"> An enchantment of the heart! The night had been enchanted. In <br>
-            dream or vision he had known the ecstasy of seraphic life. <span class="tag lineNumber">51535</span><br>
+            dream or vision he had known the ecstasy of seraphic life. <br>
             Was it an instant of enchantment only or long hours and days <br>
             and years and ages?<br> </p>
             <p class="textParagraph"> The instant of inspiration seemed now to be reflected from <br>
             all sides at once from a multitude of cloudy circumstance of <br>
-            what had happened or of what might have happened. The in- <span class="tag lineNumber">51540</span><br>
+            what had happened or of what might have happened. The in- <span class="tag lineNumber">1540</span><br>
             stant flashed forth like a point of light and now from cloud on <br>
             cloud of vague circumstance confused form  was veiling softly <br>
             its afterglow. O! In the virgin womb of the imagination the <br>
             word was made flesh. Gabriel the  seraph had come to the <br>
-            virgin's chamber. An afterglow deepened within his spirit, <span class="tag lineNumber">51545</span><br>
+            virgin's chamber. An afterglow deepened within his spirit, <br>
             whence the white flame had passed, deepening to a rose and <br>
             ardent light. That rose and ardent light was her strange wilful <br>
             heart, strange that no man had known or would know, wilful <br>
             from before the beginning of the world: and lured by that <br>
-            ardent roselike glow the choirs of the seraphim were falling <span class="tag lineNumber">51550</span><br>
+            ardent roselike glow the choirs of the seraphim were falling <span class="tag lineNumber">1550</span><br>
             from heaven.<br> </p>
             <p class="lg">
               Are you not weary of ardent ways, <br>
               Lure of the fallen seraphim? <br>
               Tell no more of enchanted days. <br>
             </p>
-            <p class="textParagraph"> The verses passed from his mind to his lips and, murmuring <span class="tag lineNumber">51555</span><br>
+            <p class="textParagraph"> The verses passed from his mind to his lips and, murmuring <br>
             them over, he felt the rhythmic movement of a villanelle pass <br>
             through them. The roselike glow sent forth its rays of rhyme; <br>
             ways, days, blaze, praise, raise. Its rays burned up the world, <br>
             consumed the hearts of men and angels: the rays from the rose <br>
-            that was her wilful heart.<span class="tag lineNumber">51560</span><br> </p>
+            that was her wilful heart.<span class="tag lineNumber">1560</span><br> </p>
             <p class="lg">
               Your eyes have set man's heart ablaze <br>
               And you have had your will of him. <br>
               Are you not weary of ardent ways? <br>
             </p>
             <p class="textParagraph"> And then? The rhythm died away, ceased, began again to <br>
-            move and beat. And then? Smoke, incense ascending from the <span class="tag lineNumber">51565</span><br>
+            move and beat. And then? Smoke, incense ascending from the <br>
             altar of the world.<br> </p>
             <p class="lg">
               Above the flame the smoke of praise <br>
               Goes up from ocean rim to rim. <br>
               Tell no more of enchanted days. <br>
             </p>
-            <p class="textParagraph"> Smoke went up from the whole earth, from the vapoury <span class="tag lineNumber">51570</span><br>
+            <p class="textParagraph"> Smoke went up from the whole earth, from the vapoury <span class="tag lineNumber">1570</span><br>
             oceans, smoke of her praise. The earth was like a swinging <br>
             swaying smoking [swaying] censer, a ball of incense, an ellipsoidal ball. <br>
             The rhythm died out at once; the cry of his heart was broken. <br>
             His lips began to murmur the first verses over and over; then <br>
-            went on stumbling through half verses, stammering and <span class="tag lineNumber">51575</span><br>
+            went on stumbling through half verses, stammering and <br>
             baffled; then stopped. The heart's cry was broken.<br> </p>
             <p class="textParagraph"> The veiled windless hour had passed and behind the panes <br>
             of the naked window the morning light was gathering. A bell <br>
             beat faintly very far away. A bird twittered; two birds, three. <br>
-            The bell and the birds ceased: and the dull white light  spread <span class="tag lineNumber">51580</span><br>
+            The bell and the birds ceased: and the dull white light  spread <span class="tag lineNumber">1580</span><br>
             itself east and west, covering the world, covering the roselight <br>
             in his heart.<br> </p>
             <p class="textParagraph"> Fearing to lose all he raised himself suddenly on his elbow to <br>
             look for paper and pencil. There was neither on the table; only <br>
-            the soup plate he had eaten the rice from for supper and the <span class="tag lineNumber">51585</span><br>
+            the soup plate he had eaten the rice from for supper and the <br>
             candlestick with its tendrils of tallow and its paper socket, <br>
             singed by the last flame. He stretched his arm wearily towards <br>
             the foot of the bed, groping with his hand in the pockets of the <br>
             coat that hung there. His fingers found a pencil and then a <br>
-            cigarette packet.  He  lay back and, tearing open the packet, <span class="tag lineNumber">51590</span><br>
+            cigarette packet.  He  lay back and, tearing open the packet, <span class="tag lineNumber">1590</span><br>
             placed the last cigarette on the window ledge and began to <br>
             write out the stanzas of the villanelle in small neat letters on the <br>
             rough cardboard surface.<br> </p>
             <p class="textParagraph"> Having written them out he lay back on the lumpy pillow, <br>
-            murmuring them again. The lumps of knotted flock under his <span class="tag lineNumber">51595</span><br>
+            murmuring them again. The lumps of knotted flock under his <br>
             head reminded him of the lumps of knotted horsehair in the <br>
             sofa of her parlour on which he used to sit, smiling or serious, <br>
             asking himself why he had come, displeased with her and with <br>
             himself, confounded by the print of the Sacred Heart above the <br>
-            untenanted sideboard. He saw her approach him in a lull of the <span class="tag lineNumber">51600</span><br>
+            untenanted sideboard. He saw her approach him in a lull of the <span class="tag lineNumber">1600</span><br>
             talk and beg him to sing one of his curious songs. Then he saw <br>
             himself sitting at the old piano, striking chords softly from its <br>
             speckled keys and singing, amid the talk which had risen again <br>
             in the room, to her who leaned beside the mantelpiece a dainty <br>
-            song of the Elizabethans, a sad and sweet loth to depart, the <span class="tag lineNumber">51605</span><br>
+            song of the Elizabethans, a sad and sweet loth to depart, the <br>
             victory chant of Agincourt, the happy air of Greensleeves. <br>
             While he sang and she listened, or feigned to listen, his heart <br>
             was at rest but when the quaint old songs had ended and he <br>
             heard again the voices in the room he remembered his own <br>
-            sarcasm: the house where young men are called by their chris- <span class="tag lineNumber">51610</span><br>
+            sarcasm: the house where young men are called by their chris- <span class="tag lineNumber">1610</span><br>
             tian names a little too soon.<br> </p>
             <p class="textParagraph"> At certain instants her eyes seemed about to trust him but he <br>
             had waited in vain. She passed now dancing lightly across his <br>
             memory as she had been that night at the carnival ball. Her <br>
-            white dress a little lifted, a white spray nodding in her hair. She <span class="tag lineNumber">51615</span><br>
+            white dress a little lifted, a white spray nodding in her hair. She <br>
             danced lightly in the round. She was dancing towards him and, <br>
             as she came, her eyes were a little averted and a faint glow was <br>
             on her cheek. At the pause in the chain of hands her hand had <br>
             lain in his an instant, a soft merchandise. <br>
-            <p class="dialog"><span class="tag dialog">???</span>―You are a great stranger now.<span class="tag lineNumber">51620</span><br> </p>
+            <p class="dialog"><span class="tag dialog">???</span>―You are a great stranger now.<span class="tag lineNumber">1620</span><br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Yes. I was born to be a monk.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―I am afraid you are a heretic.<br> </p>
             <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Are you much afraid?<br></p> </p>
             <p class="textParagraph"> For answer she had danced away from him along the chain <br>
-            of hands, dancing lightly and discreetly, giving herself to none. <span class="tag lineNumber">51625</span><br>
+            of hands, dancing lightly and discreetly, giving herself to none. <br>
             The white spray nodded to her dancing and when she was in <br>
             shadow the glow was deeper on her cheek.<br> </p>
             <p class="textParagraph"> A monk! His own image started forth a profaner of the <br>
             cloister, a heretic franciscan, willing and willing not to serve, <br>
-            spinning like Gherardino da Borgo San Donnino a lithe web of <span class="tag lineNumber">51630</span><br>
+            spinning like Gherardino da Borgo San Donnino a lithe web of <span class="tag lineNumber">1630</span><br>
             sophistry and whispering in her ear.<br> </p>
             <p class="textParagraph"> No, it was not his image. It was the image of the young <br>
             priest in whose company he had seen her last, looking at him <br>
             out of dove's eyes, toying with the pages of her Irish phrase- <br>
-            book. <span class="tag lineNumber">51635</span><br>
+            book. <br>
             <p class="dialog"><span class="tag dialog">???</span>―Yes, yes, the ladies are coming round to us. I can see it every <br>
             day. The ladies are with us. The best helpers the language has.<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―And the church, Father Moran?<br> </p>
             <p class="dialog"><span class="tag dialog">???</span>―The church too. Coming round too. The work is going <br>
-            ahead there too. Don't fret about the church.<span class="tag lineNumber">51640</span><br></p> </p>
+            ahead there too. Don't fret about the church.<span class="tag lineNumber">1640</span><br></p> </p>
             <p class="textParagraph"> Bah! he had done well to leave the room in disdain. He had <br>
             done well not to salute her on the steps of the library. He had <br>
             done well to leave her to flirt with her priest, to toy with a <br>
             church which was the scullerymaid of christendom.<br> </p>
-            <p class="textParagraph"> Rude brutal anger routed the last lingering instant of ecstasy <span class="tag lineNumber">51645</span><br>
+            <p class="textParagraph"> Rude brutal anger routed the last lingering instant of ecstasy <br>
             from his soul. It broke up violently her fair image and flung the <br>
             fragments on all sides. On all sides distorted reflections of her <br>
             image started from his memory: the flowergirl in the ragged <br>
             dress with damp coarse hair and a hoyden's face who had <br>
-            called herself his own girl and begged his handsel, the kitchen- <span class="tag lineNumber">51650</span><br>
+            called herself his own girl and begged his handsel, the kitchen- <span class="tag lineNumber">1650</span><br>
             girl in the next house who sang over the clatter of her plates <br>
             with the drawl of a country singer the first bars of <span class="emph">By <br>
             Killarney's Lakes and Fells</span>, a girl who had laughed gaily to see <br>
             him stumble when the iron grating in the footpath near <span class="hide">53.343835 -6.267562</span>Cork <br>
-            Hill had caught the broken sole of his shoe, a girl he had <span class="tag lineNumber">51655</span><br>
+            Hill had caught the broken sole of his shoe, a girl he had <br>
             glanced at, attracted by her small ripe mouth as she passed out <br>
             of Jacob's biscuit factory, who had cried to him over her shoul- <br>
             der: <br>
             <p class="dialog"><span class="tag dialog">???</span>―Do you like what you seen of me, straight hair and curly <br>
-            eyebrows?<span class="tag lineNumber">51660</span><br></p> </p>
+            eyebrows?<span class="tag lineNumber">1660</span><br></p> </p>
             <p class="textParagraph"> And yet he felt that, however he might revile and mock her <br>
             image, his anger was also a form of homage. He had left the <br>
             classroom in disdain that was not wholly sincere, feeling that <br>
             perhaps the secret of her race lay behind those dark eyes upon <br>
-            which her long lashes flung a quick shadow. He had told him- <span class="tag lineNumber">51665</span><br>
+            which her long lashes flung a quick shadow. He had told him- <br>
             self bitterly as he walked through the streets that she was a <br>
             figure of the womanhood of her country, a batlike soul waking <br>
             to the consciousness of itself in darkness and secrecy and lone- <br>
             liness, tarrying a while, loveless and sinless, with her mild lover <br>
-            and leaving him to whisper of innocent transgressions in the <span class="tag lineNumber">51670</span><br>
+            and leaving him to whisper of innocent transgressions in the <span class="tag lineNumber">1670</span><br>
             latticed ear of a priest. His anger against her found vent in <br>
             coarse railing at her paramour, whose name and voice and <br>
             features offended his baffled pride: a priested peasant, with a <br>
             brother a policeman in Dublin and a brother a potboy in <span class="hide">53.338748 -9.181478</span> <br>
-            Moycullen. To him she would unveil her soul's shy nakedness, <span class="tag lineNumber">51675</span><br>
+            Moycullen. To him she would unveil her soul's shy nakedness, <br>
             to one who was but schooled in the discharging of a formal rite <br>
             rather than to him, a priest of the eternal imagination, trans- <br>
             muting the daily bread of experience into the radiant body of <br>
             everliving life.<br> </p>
-            <p class="textParagraph"> The radiant image of the eucharist united again in an instant <span class="tag lineNumber">51680</span><br>
+            <p class="textParagraph"> The radiant image of the eucharist united again in an instant <span class="tag lineNumber">1680</span><br>
             his bitter and despairing thoughts, their cries arising unbroken <br>
             in a hymn of thanksgiving.<br> </p>
             <p class="lg">
               Our broken cries and mournful lays <br>
               Rise in one eucharistic hymn. <br>
-              Are you not weary of ardent ways? <span class="tag lineNumber">51585</span><br>
+              Are you not weary of ardent ways? <br>
               While sacrificing hands upraise <br>
               The chalice flowing to the brim. <br>
               Tell no more of enchanted days. <br>
             </p>
             <p class="textParagraph"> He spoke the verses aloud from the first lines till the music <br>
-            and rhythm suffused his mind, turning it to quiet indulgence; <span class="tag lineNumber">51690</span><br>
+            and rhythm suffused his mind, turning it to quiet indulgence; <span class="tag lineNumber">1690</span><br>
             then copied them painfully to feel them the better by seeing <br>
             them; then lay back on his bolster.<br> </p>
             <p class="textParagraph"> The full morning light had come. No sound was to be heard: <br>
             but he knew that all around him life was about to awaken in <br>
-            common noises, hoarse voices, sleepy prayers. Shrinking from <span class="tag lineNumber">51695</span><br>
+            common noises, hoarse voices, sleepy prayers. Shrinking from <br>
             that life he turned towards the wall, making a cowl of the <br>
             blanket and staring at the great overblown scarlet flowers of <br>
             the tattered wallpaper. He tried to warm his perishing joy in <br>
             their scarlet glow, imagining a roseway from where he lay <br>
-            upwards to heaven all strewn  with scarlet flowers. Weary! <span class="tag lineNumber">51700</span><br>
+            upwards to heaven all strewn  with scarlet flowers. Weary! <span class="tag lineNumber">1700</span><br>
             Weary! He too was weary of ardent ways.<br> </p>
             <p class="textParagraph"> A gradual warmth, a languorous weariness passed over him <br>
             descending along his spine from his closely cowled  head. He <br>
             felt it descend and, seeing himself as he lay, smiled. Soon he <br>
-            would sleep.<span class="tag lineNumber">51705</span><br> </p>
+            would sleep.<br> </p>
             <p class="textParagraph"> He had written verses for her again after ten years. Ten years <br>
             before she had worn her shawl cowlwise about her head, send- <br>
             ing sprays of her warm breath into the night air, tapping her <br>
             foot upon the glassy road. It was the last tram; the lank brown <br>
-            horses knew it and shook their bells to the clear night in <span class="tag lineNumber">51710</span><br>
+            horses knew it and shook their bells to the clear night in <span class="tag lineNumber">1710</span><br>
             admonition. The conductor talked with the driver, both nod- <br>
             ding often in the green light of the lamp. They stood on the <br>
             steps of the tram, he on the upper, she on the lower. She came <br>
             up to his step many times between their phrases and went <br>
-            down again and once or twice remained beside him forgetting <span class="tag lineNumber">51715</span><br>
+            down again and once or twice remained beside him forgetting <br>
             to go down and then went down. Let be! Let be!<br> </p>
             <p class="textParagraph"> Ten years from that wisdom of children to his folly. If he <br>
             sent her the verses? They would be read out at breakfast amid <br>
             the tapping of eggshells. Folly indeed! The brothers would <br>
-            laugh and try to wrest the page from each other with their <span class="tag lineNumber">51720</span><br>
+            laugh and try to wrest the page from each other with their <span class="tag lineNumber">1720</span><br>
             strong hard fingers. The suave priest, her uncle, seated in his <br>
             armchair, would hold the page at arm's length, read it smiling <br>
             and approve of the literary form.<br> </p>
             <p class="textParagraph"> No, no: that was folly. Even if he sent her the verses she <br>
-            would not show them to others. No, no: she could not.<span class="tag lineNumber">51725</span><br> </p>
+            would not show them to others. No, no: she could not.<br> </p>
             <p class="textParagraph"> He began to feel that he had wronged her. A sense of her <br>
             innocence moved him almost to pity her, an innocence he had <br>
             never understood till he had come to the knowledge of it <br>
             through sin, an innocence which she too had not understood <br>
-            while she was innocent or before the strange humiliation of her <span class="tag lineNumber">51730</span><br>
+            while she was innocent or before the strange humiliation of her <span class="tag lineNumber">1730</span><br>
             nature had first come upon her. Then first her soul had begun <br>
             to live as his soul had when he had first sinned: and a tender <br>
             compassion filled his heart as he remembered her frail pallor <br>
             and her eyes, humbled and saddened by the dark shame of <br>
-            womanhood.<span class="tag lineNumber">51735</span><br> </p>
+            womanhood.<br> </p>
             <p class="textParagraph"> While his soul had passed from ecstasy to languor where had <br>
             she been? Might it be, in the mysterious ways of spiritual life, <br>
             that her soul at those same moments had been conscious of his <br>
             homage? It might be.<br> </p>
-            <p class="textParagraph"> A glow of desire kindled again his soul and fired and ful- <span class="tag lineNumber">51740</span><br>
+            <p class="textParagraph"> A glow of desire kindled again his soul and fired and ful- <span class="tag lineNumber">1740</span><br>
             filled all his body. Conscious of his desire she was waking from <br>
             odorous sleep, the temptress of his villanelle. Her eyes, dark <br>
             and with a look of languor, were opening to his eyes. Her <br>
             nakedness yielded to him, radiant, warm, odorous and lavish- <br>
-            limbed, enfolded him like a shining cloud, enfolded him like <span class="tag lineNumber">51745</span><br>
+            limbed, enfolded him like a shining cloud, enfolded him like <br>
             water with a liquid life: and like a cloud of vapour or like <br>
             waters circumfluent in space the liquid letters of speech, sym- <br>
             bols of the element of mystery, flowed forth over his brain.<br> </p>
             <p class="lg">
               Are you not weary of ardent ways? <br>
-              Lure of the fallen seraphim. <span class="tag lineNumber">51750</span><br>
+              Lure of the fallen seraphim. <span class="tag lineNumber">1750</span><br>
               Tell no more of enchanted days. <br>
               Your eyes have set man's heart ablaze <br>
               And you have had your will of him. <br>
               Are you not weary of ardent ways? <br>
-              Above the flame the smoke of praise <span class="tag lineNumber">51755</span><br>
+              Above the flame the smoke of praise <br>
               Goes up from ocean rim to rim. <br>
               Tell no more of enchanted days. <br>
               Our broken cries and mournful lays <br>
               Rise in one eucharistic hymn. <br>
-              Are you not weary of ardent ways? <span class="tag lineNumber">51760</span><br>
+              Are you not weary of ardent ways? <span class="tag lineNumber">1760</span><br>
               While sacrificing hands upraise <br>
               The chalice flowing to the brim. <br>
               Tell no more of enchanted days. <br>
               And still you hold our longing gaze <br>
-              With languorous look and lavish limb. <span class="tag lineNumber">51765</span><br>
+              With languorous look and lavish limb. <br>
               Are you not weary of ardent ways? <br>
               Tell no more of enchanted days. <br>
           </p> 
@@ -7850,846 +7850,846 @@
         
               <p class="textParagraph">What birds were they?<br> </p>
               <p class="textParagraph">He stood on the steps of the library to look at them, leaning <br>
-              wearily on his ashplant. They flew round and round the jutting <span class="tag lineNumber">51770</span><br>
+              wearily on his ashplant. They flew round and round the jutting <span class="tag lineNumber">1770</span><br>
               shoulder of a house in <span class="hide">53.340809 -6.257636</span>Molesworth Street. The air of the late <br>
               March evening made clear their flight, their dark darting <br>
               quivering bodies flying clearly against the sky as against a <br>
               limphung cloth of smoky tenuous blue.<br> </p>
-              <p class="textParagraph"> He watched their flight: bird after bird: a dark flash, a <span class="tag lineNumber">51775</span><br>
+              <p class="textParagraph"> He watched their flight: bird after bird: a dark flash, a <br>
               swerve, a flash again, a dart aside, a curve, a flutter of wings. <br>
               He tried to count them before all their darting quivering bodies <br>
               passed: six, ten, eleven: and wondered were they odd or even in <br>
               number. Twelve, thirteen: for two came wheeling down from <br>
-              the upper sky. They were flying high and low but ever round <span class="tag lineNumber">51780</span><br>
+              the upper sky. They were flying high and low but ever round <span class="tag lineNumber">1780</span><br>
               and round in straight and curving lines and ever flying from left <br>
               to right, circling about a temple of air.<br> </p>
               <p class="textParagraph"> He  listened to their cries: like the squeak of mice behind the <br>
               wainscot: a shrill twofold note. But the notes were long and <br>
-              shrill and whirring, unlike the cry of vermin, falling a third or a <span class="tag lineNumber">51785</span><br>
+              shrill and whirring, unlike the cry of vermin, falling a third or a <br>
               fourth and trilled as the flying beaks clove the air. Their cry <br>
               was shrill and clear and fine and falling like threads of silken <br>
               light unwound from whirring spools.<br> </p>
               <p class="textParagraph"> The inhuman clamour soothed his ears in which his <br>
-              mother's sobs and reproaches murmured insistently and the <span class="tag lineNumber">51790</span><br>
+              mother's sobs and reproaches murmured insistently and the <span class="tag lineNumber">1790</span><br>
               dark frail quivering bodies wheeling and fluttering and swerv- <br>
               ing round an airy temple of the tenuous sky soothed his eyes <br>
               which still saw the image of his mother's face.<br> </p>
               <p class="textParagraph"> Why was he gazing upwards from the steps of the porch, <br>
-              hearing their shrill twofold cry, watching their flight? For an <span class="tag lineNumber">51795</span><br>
+              hearing their shrill twofold cry, watching their flight? For an <br>
               augury of good or evil? A phrase of Cornelius Agrippa flew <br>
               through his mind and then there flew hither and thither shape- <br>
               less thoughts from Swedenborg on the correspondence of birds <br>
               to things of the intellect and of how the creatures of the air <br>
-              have their knowledge and know their times and seasons be- <span class="tag lineNumber">51800</span><br>
+              have their knowledge and know their times and seasons be- <span class="tag lineNumber">1800</span><br>
               cause they, unlike man, are in the order of their life and have <br>
               not perverted that order by reason.<br> </p>
               <p class="textParagraph"> And for ages men had gazed upward as he was gazing at <br>
               birds in flight. The colonnade above him made him think <br>
-              vaguely of an ancient temple and the ashplant on which he <span class="tag lineNumber">51805</span><br>
+              vaguely of an ancient temple and the ashplant on which he <br>
               leaned wearily of the curved stick of an augur. A sense of fear <br>
               of the unknown moved in the heart of his weariness, a fear of <br>
               symbols and portents, of the hawklike man whose name he <br>
               bore soaring out of his captivity on osierwoven wings, of <br>
-              Thoth, the god of writers, writing with a reed upon a tablet <span class="tag lineNumber">51810</span><br>
+              Thoth, the god of writers, writing with a reed upon a tablet <span class="tag lineNumber">1810</span><br>
               and bearing on his narrow ibis head the cusped moon.<br> </p>
               <p class="textParagraph"> He smiled as he thought of the god's image for it made him <br>
               think of a bottlenosed judge in a wig, putting commas into a <br>
               document which he held at arm's length and he knew that he <br>
-              would not have remembered the god's name but that it was like <span class="tag lineNumber">51815</span><br>
+              would not have remembered the god's name but that it was like <br>
               an Irish oath. It was folly. But was it for this folly that he was <br>
               about to leave for ever the house of prayer and prudence into <br>
               which he had been born and the order of life out of which he <br>
               had come?<br> </p>
-              <p class="textParagraph"> They came back with shrill cries over the jutting shoulder of <span class="tag lineNumber">51820</span><br>
+              <p class="textParagraph"> They came back with shrill cries over the jutting shoulder of <span class="tag lineNumber">1820</span><br>
               the house, flying darkly against the fading air. What birds were <br>
               they? He thought that they must be swallows who had come <br>
               back from the south. Then he was to go away? for they were <br>
               birds ever going and coming, building ever an unlasting home <br>
-              under the eaves of men's houses and ever leaving the homes <span class="tag lineNumber">51825</span><br>
+              under the eaves of men's houses and ever leaving the homes <br>
               they had built to wander.<br> </p>
               <p class="lg">
                 Bend down your faces, Oona and Aleel. <br>
                 I gaze upon them as the swallow gazes <br>
                 Upon the nest under the eave before <br>
-                He wander the loud waters. <span class="tag lineNumber">51830</span><br>
+                He wander the loud waters. <span class="tag lineNumber">1830</span><br>
               </p>
               <p class="textParagraph"> A soft liquid joy like the noise of many waters flowed over <br>
               his memory and he felt in his heart the soft peace of silent <br>
               spaces of fading tenuous sky above the waters, of oceanic si- <br>
               lence, of swallows flying through the seadusk over the flowing <br>
-              waters.<span class="tag lineNumber">51835</span><br> </p>
+              waters.<br> </p>
               <p class="textParagraph"> A soft liquid joy flowed through the words where the soft <br>
               long vowels hurtled noiselessly and fell away, lapping and <br>
               flowing back and ever shaking the white bells of their waves in <br>
               mute chime and mute peal and soft low swooning cry: and he <br>
-              felt that the augury he had sought in the wheeling darting birds <span class="tag lineNumber">51840</span><br>
+              felt that the augury he had sought in the wheeling darting birds <span class="tag lineNumber">1840</span><br>
               and in the pale space of sky above him had come forth from his <br>
               heart like a bird from a turret quietly and swiftly.<br> </p>
               <p class="textParagraph"> Symbol of departure or of loneliness? The verses crooned in <br>
               the ear of his memory composed slowly before his remember- <br>
-              ing eyes the scene of the hall on the night of the opening of the <span class="tag lineNumber">51845</span><br>
+              ing eyes the scene of the hall on the night of the opening of the <br>
               national theatre. He was alone at the side of the balcony, <br>
               looking out of jaded eyes at the culture of Dublin in the stalls <br>
               and at the tawdry scenecloths and human dolls framed by the <br>
               garish lamps of the stage. A burly policeman sweated behind <br>
-              him and seemed at every moment about to act. The catcalls <span class="tag lineNumber">51850</span><br>
+              him and seemed at every moment about to act. The catcalls <span class="tag lineNumber">1850</span><br>
               and hisses and mocking cries ran in rude gusts round the hall <br>
               from his scattered fellowstudents. <br>
               <p class="dialog"><span class="tag dialog">???</span>―A libel on Ireland!<br> </p>
               <p class="dialog"><span class="tag dialog">???</span>―Made in Germany!<br> </p>
-              <p class="dialog"><span class="tag dialog">???</span>―Blasphemy!<span class="tag lineNumber">51855</span><br> </p>
+              <p class="dialog"><span class="tag dialog">???</span>―Blasphemy!<br> </p>
               <p class="dialog"><span class="tag dialog">???</span>―We never sold our faith!<br> </p>
               <p class="dialog"><span class="tag dialog">???</span>―No Irish woman ever did it!<br> </p>
               <p class="dialog"><span class="tag dialog">???</span>―We want no amateur atheists.<br> </p>
               <p class="dialog"><span class="tag dialog">???</span>―We want no budding buddhists.<br></p> </p>
-              <p class="textParagraph"> A sudden soft hiss fell from the windows above him and he <span class="tag lineNumber">51860</span><br>
+              <p class="textParagraph"> A sudden soft hiss fell from the windows above him and he <span class="tag lineNumber">1860</span><br>
               knew that the electric lamps had been switched on in the <br>
               readers' room. He turned into the pillared  hall, now calmly lit, <br>
               went up the staircase and passed in through the clicking turn- <br>
               stile.<br> </p>
-              <p class="textParagraph"> Cranly was sitting over near the dictionaries. A thick book, <span class="tag lineNumber">51865</span><br>
+              <p class="textParagraph"> Cranly was sitting over near the dictionaries. A thick book, <br>
               opened at the frontispiece, lay before him on the wooden rest. <br>
               He leaned back in his chair, inclining his ear like that of a <br>
               confessor to the face of the medical student who was reading to <br>
               him a problem from the chess page of a journal. Stephen sat <br>
-              down at his right and the priest at the other side of the  table <span class="tag lineNumber">51870</span><br>
+              down at his right and the priest at the other side of the  table <span class="tag lineNumber">1870</span><br>
               closed his copy of <span class="emph">The Tablet</span> with an angry snap and stood up.<br> </p>
               <p class="textParagraph"> Cranly gazed after him blandly and vaguely. The medical <br>
               student went on in a softer voice: <br>
               <p class="dialog"><span class="tag dialog">???</span>―Pawn to king's fourth.<br> </p>
-              <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―We had better go, Dixon, said Stephen in warning. He has <span class="tag lineNumber">51875</span><br>
+              <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―We had better go, Dixon, said Stephen in warning. He has <br>
               gone to complain.<br></p> </p>
               <p class="textParagraph"> Dixon folded the journal and rose with dignity, saying: <br>
               <p class="dialog"><span class="tag dialog">???</span>―Our men retired in good order.<br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―With guns and cattle, added Stephen, pointing to the title- <br>
-              page of Cranly's book on which was printed <span class="emph">Diseases of the <span class="tag lineNumber">51880</span><br>
+              page of Cranly's book on which was printed <span class="emph">Diseases of the <span class="tag lineNumber">1880</span><br>
               Ox</span>.<br></p> </p>
               <p class="textParagraph"> As they passed through a lane of the tables Stephen said: <br>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Cranly, I want to speak to you.<br></p> </p>
               <p class="textParagraph"> Cranly did not answer or turn. He laid his book on the <br>
-              counter and passed out, his wellshod feet sounding flatly on the <span class="tag lineNumber">51885</span><br>
+              counter and passed out, his wellshod feet sounding flatly on the <br>
               floor. On the staircase he paused and gazing absently at Dixon <br>
               repeated: <br>
               <p class="dialog"><span class="tag dialog">???</span>―Pawn to king's bloody fourth.<br> </p>
               <p class="dialog"><span class="tag dialog">???</span>―Put it that way if you like, Dixon said.<br></p> </p>
-              <p class="textParagraph"> He had a quiet toneless voice and urbane manners and on a <span class="tag lineNumber">51890</span><br>
+              <p class="textParagraph"> He had a quiet toneless voice and urbane manners and on a <span class="tag lineNumber">1890</span><br>
               finger of his plump clean hand he displayed at moments a <br>
               signet ring.<br> </p>
               <p class="textParagraph"> As they crossed the hall a man of dwarfish stature came <br>
               towards them. Under the dome of his tiny hat his unshaven <br>
-              face began to smile with pleasure and he was heard to murmur. <span class="tag lineNumber">51895</span><br>
+              face began to smile with pleasure and he was heard to murmur. <br>
               The eyes were melancholy as those of a monkey. <br>
               <p class="dialog"><span class="tag dialog">???</span>―Good evening, captain, said Cranly, halting.<br> </p>
               <p class="dialog"><span class="tag dialog">???</span>―Good evening, gentlemen, said the stubblegrown monkeyish <br>
               face.<br> </p>
-              <p class="dialog"><span class="tag dialog">???</span>―Warm weather for March, said Cranly. They have the win- <span class="tag lineNumber">51900</span><br>
+              <p class="dialog"><span class="tag dialog">???</span>―Warm weather for March, said Cranly. They have the win- <span class="tag lineNumber">1900</span><br>
               dows open upstairs.<br></p> </p>
               <p class="textParagraph"> Dixon smiled and turned his ring. The blackish monkey- <br>
               puckered face pursed its human mouth with gentle pleasure <br>
               and its voice purred: <br>
-              <p class="dialog"><span class="tag dialog">???</span>―Delightful weather for March. Simply delightful.<span class="tag lineNumber">51905</span><br> </p>
+              <p class="dialog"><span class="tag dialog">???</span>―Delightful weather for March. Simply delightful.<br> </p>
               <p class="dialog"><span class="tag dialog">???</span>―There are two nice young ladies upstairs, captain, tired of <br>
               waiting, Dixon said.<br></p> </p>
               <p class="textParagraph"> Cranly smiled and said kindly: <br>
               <p class="dialog"><span class="tag dialog">???</span>―The captain has only one love: sir Walter Scott. Isn't that so, <br>
-              captain?<span class="tag lineNumber">51910</span><br> </p>
+              captain?<span class="tag lineNumber">1910</span><br> </p>
               <p class="dialog"><span class="tag dialog">???</span>―What are you reading now, captain? Dixon asked. <span class="emph">The Bride <br>
               of <span class="hide">55.775902 -4.136255</span>Lammermoor?</span><br> </p>
               <p class="dialog"><span class="tag dialog">???</span>―I love old Scott,</p> the flexible lips said. <p class="dialog"><span class="tag dialog">???</span>I think he writes some- <br>
               thing lovely. There is no writer can touch sir Walter Scott.<br></p> </p>
-              <p class="textParagraph"> He moved a thin shrunken brown hand gently in the air in <span class="tag lineNumber">51915</span><br>
+              <p class="textParagraph"> He moved a thin shrunken brown hand gently in the air in <br>
               time to his praise and his thin quick eyelids beat often over his <br>
               sad eyes.<br> </p>
               <p class="textParagraph"> Sadder to Stephen's ear was his speech: a genteel accent, low <br>
               and moist, marred by errors: and listening to it he wondered <br>
-              was the story true and was the thin blood that flowed in his <span class="tag lineNumber">51920</span><br>
+              was the story true and was the thin blood that flowed in his <span class="tag lineNumber">1920</span><br>
               shrunken frame noble and come of an incestuous  love?<br> </p>
               <p class="textParagraph"> The park trees were heavy with rain and rain fell still and <br>
               ever in the lake, lying grey like a shield. A game of swans flew <br>
               there and the water and the shore beneath were fouled with <br>
-              their greenwhite slime. They embraced softly impelled by the <span class="tag lineNumber">51925</span><br>
+              their greenwhite slime. They embraced softly impelled by the <br>
               grey rainy light, the wet silent trees, the shieldlike witnessing <br>
               lake, the swans. They embraced without joy or passion, his <br>
               arm about his sister's neck. A grey woollen cloak was wrapped <br>
               athwart her from her shoulder to her waist: and her fair head was <br>
-              bent in willing shame. He had loose redbrown hair and tender <span class="tag lineNumber">51930</span><br>
+              bent in willing shame. He had loose redbrown hair and tender <span class="tag lineNumber">1930</span><br>
               shapely strong freckled hands. Face? There was no face seen. <br>
               The brother's face was bent upon her fair rainfragrant hair. <br>
               The hand freckled and strong and shapely and caressing was <br>
               Davin's hand.<br> </p>
-              <p class="textParagraph"> He frowned angrily upon his thought and on the shrivelled <span class="tag lineNumber">51935</span><br>
+              <p class="textParagraph"> He frowned angrily upon his thought and on the shrivelled <br>
               mannikin who had called it forth. His father's gibes at the <span class="hide">51.680080 -9.452576</span> <br>
               Bantry gang leaped out of his memory. He held them at a <br>
               distance and brooded uneasily on his own thought again. Why <br>
               were they not  Cranly's hands? Had Davin's simplicity and in- <br>
-              nocence stung him more secretly?<span class="tag lineNumber">51940</span><br> </p>
+              nocence stung him more secretly?<span class="tag lineNumber">1940</span><br> </p>
               <p class="textParagraph"> He walked on across the hall with Dixon, leaving Cranly to <br>
               take leave elaborately of the dwarf.<br> </p>
               <p class="textParagraph"> Under the colonnade Temple was standing in the midst of a <br>
               little group of students. One of them cried: <br>
-              <p class="dialog"><span class="tag dialog">???</span>―Dixon, come over till you hear. Temple is in grand form.<span class="tag lineNumber">51945</span><br></p> </p>
+              <p class="dialog"><span class="tag dialog">???</span>―Dixon, come over till you hear. Temple is in grand form.<br></p> </p>
               <p class="textParagraph"> Temple turned on him his dark gipsy eyes. <br>
               <p class="dialog"><span class="tag dialog">???</span>―You're a hypocrite, O'Keeffe,</p> he said. <p class="dialog"><span class="tag dialog">???</span>And Dixon's a smiler. <br>
               By hell, I think that's a good literary expression.<br></p> </p>
               <p class="textParagraph"> He laughed slily, looking in Stephen's face, repeating: <br>
-              <p class="dialog"><span class="tag dialog">???</span>―By hell, I'm delighted with that name. A smiler.<span class="tag lineNumber">51950</span><br></p> </p>
+              <p class="dialog"><span class="tag dialog">???</span>―By hell, I'm delighted with that name. A smiler.<span class="tag lineNumber">1950</span><br></p> </p>
               <p class="textParagraph"> A stout student who stood below them on the steps said: <br>
               <p class="dialog"><span class="tag dialog">???</span>―Come back to the mistress, Temple. We want to hear about <br>
               that.<br> </p>
               <p class="dialog"><span class="tag dialog">Temple</span>―He had, faith,</p> Temple said. <p class="dialog"><span class="tag dialog">Temple</span>And he was a married man too. <br>
-              And all the priests used to be dining there. By hell, I think they <span class="tag lineNumber">51955</span><br>
+              And all the priests used to be dining there. By hell, I think they <br>
               all had a touch.<br> </p>
               <p class="dialog"><span class="tag dialog">???</span>―We shall call it riding a hack to spare the hunter,</p> said Dixon.<br> 
               <p class="dialog"><span class="tag dialog">O'Keeffe</span>―Tell us, Temple,</p> O'Keeffe said. <p class="dialog"><span class="tag dialog">O'Keeffe</span>How many quarts of porter <br>
               have you in you?<br> </p>
-              <p class="dialog"><span class="tag dialog">???</span>―All your intellectual soul is in that phrase, O'Keeffe, said <span class="tag lineNumber">51960</span><br>
+              <p class="dialog"><span class="tag dialog">???</span>―All your intellectual soul is in that phrase, O'Keeffe, said <span class="tag lineNumber">1960</span><br>
               Temple with open scorn.<br></p> </p>
               <p class="textParagraph"> He moved with a shambling gait round the group and spoke <br>
               to Stephen. <br>
               <p class="dialog"><span class="tag dialog">???</span>―Did you know that the Forsters are the kings of Belgium? he <br>
-              asked.<span class="tag lineNumber">51965</span><br></p> </p>
+              asked.<br></p> </p>
               <p class="textParagraph"> Cranly came out through the door of the entrance hall, his <br>
               hat thrust back on the nape of his neck and picking his teeth <br>
               with care. <br>
               <p class="dialog"><span class="tag dialog">???</span>―And here's the wiseacre, said Temple. Do you know that <br>
-              about the Forsters?<span class="tag lineNumber">51970</span><br></p> </p>
+              about the Forsters?<span class="tag lineNumber">1970</span><br></p> </p>
               <p class="textParagraph"> He paused for an answer. Cranly dislodged a figseed from <br>
               his teeth on the point of his rude toothpick and gazed at it <br>
               intently. <br>
               <p class="dialog"><span class="tag dialog">Temple</span>―The Forster family,</p> Temple said, <p class="dialog"><span class="tag dialog">Temple</span>is descended from Baldwin <br>
-              the First, king of Flanders. He was called the Forester. Forester <span class="tag lineNumber">51975</span><br>
+              the First, king of Flanders. He was called the Forester. Forester <br>
               and Forster are the same name. A descendant of Baldwin the <br>
               First, captain Francis Forster, settled in Ireland and married <br>
               the daughter of the last chieftain of Clanbrassil. Then there are <br>
               the Blake Forsters. That's a different branch.<br> </p>
-              <p class="dialog"><span class="tag dialog">Cranly</span>―From Baldhead, king of Flanders,</p> Cranly repeated, rooting <span class="tag lineNumber">51980</span><br>
+              <p class="dialog"><span class="tag dialog">Cranly</span>―From Baldhead, king of Flanders,</p> Cranly repeated, rooting <span class="tag lineNumber">1980</span><br>
               again deliberately at his gleaming uncovered teeth.<br>
               <p class="dialog"><span class="tag dialog">O'Keeffe</span>―Where did you pick up all that history?</p> O'Keeffe asked.<br>
               <p class="dialog"><span class="tag dialog">Temple</span>―I know all the history of your family too,</p> Temple said, <br>
               turning to Stephen. <p class="dialog"><span class="tag dialog">Temple</span>Do you know what Giraldus Cambrensis <br>
-              says about your family?<span class="tag lineNumber">51985</span><br> </p>
+              says about your family?<br> </p>
               <p class="dialog"><span class="tag dialog">???</span>―Is he descended from Baldwin too?</p> asked a tall consumptive <br>
               student with dark eyes.<br> 
               <p class="dialog"><span class="tag dialog">Cranly</span>―Baldhead,</p> Cranly repeated, sucking at a crevice in his teeth.<br> 
               <p class="dialog"><span class="tag dialog">Temple</span>―Pernobilis et pervetusta familia,</p> Temple said to Stephen.<br></p>
-              <p class="textParagraph"> The stout student who stood below them on the steps farted <span class="tag lineNumber">51990</span><br>
+              <p class="textParagraph"> The stout student who stood below them on the steps farted <span class="tag lineNumber">1990</span><br>
               briefly. Dixon turned towards him saying in a soft voice: <br>
               <p class="dialog"><span class="tag dialog">Dixon</span>―Did an angel speak?<br></p> </p>
               <p class="textParagraph"> Cranly turned also and said vehemently but without anger: <br>
               <p class="dialog"><span class="tag dialog">Cranly</span>―Goggins, you're the flamingest dirty devil I ever met, do you <br>
-              know.<span class="tag lineNumber">51995</span><br> </p>
+              know.<br> </p>
               <p class="dialog"><span class="tag dialog">Goggins</span>―I had it on my mind to say that,</p> Goggins answered firmly. <p class="dialog"><span class="tag dialog">Goggins</span>It <br>
               did no-one any harm, did it?<br> </p>
               <p class="dialog"><span class="tag dialog">Dixon</span>―We hope,</p> Dixon said suavely, <p class="dialog"><span class="tag dialog">Dixon</span>that it was not of the kind <br>
               known to science as a paulo post futurum.<br> </p>
-              <p class="dialog"><span class="tag dialog">Temple</span>―Didn't I tell you he was a smiler?</p> said Temple, turning right <span class="tag lineNumber">52000</span><br>
+              <p class="dialog"><span class="tag dialog">Temple</span>―Didn't I tell you he was a smiler?</p> said Temple, turning right <span class="tag lineNumber">2000</span><br>
               and left. <p class="dialog"><span class="tag dialog">Temple</span>Didn't I give him that name?<br> </p>
               <p class="dialog"><span class="tag dialog">???</span>―You did. We're not deaf,</p> said the tall consumptive.<br> </p>
               <p class="textParagraph"> Cranly still frowned at the stout student below him. Then, <br>
               with a snort of disgust, he shoved him violently down the steps. <br>
-              <p class="dialog"><span class="tag dialog">Cranly</span>―Go away from here,</p> he said rudely. <p class="dialog"><span class="tag dialog">Cranly</span>Go away, you stinkpot. <span class="tag lineNumber">52005</span><br>
+              <p class="dialog"><span class="tag dialog">Cranly</span>―Go away from here,</p> he said rudely. <p class="dialog"><span class="tag dialog">Cranly</span>Go away, you stinkpot. <br>
               And you are a stinkpot.<br></p> </p>
               <p class="textParagraph"> Goggins skipped down on to the gravel and at once returned <br>
               to his place with good humour. Temple turned back to Stephen <br>
               and asked: <br>
-              <p class="dialog"><span class="tag dialog">Temple</span>―Do you believe in the law of heredity?<span class="tag lineNumber">52010</span><br> </p>
+              <p class="dialog"><span class="tag dialog">Temple</span>―Do you believe in the law of heredity?<span class="tag lineNumber">2010</span><br> </p>
               <p class="dialog"><span class="tag dialog">Cranly</span>―Are you drunk or what are you or what are you trying to <br>
               say?</p> asked Cranly, facing round on him with an expression of <br>
               wonder.<br> 
               <p class="dialog"><span class="tag dialog">Temple</span>―The most profound sentence ever written,</p> Temple said with <br>
-              enthusiasm, <p class="dialog"><span class="tag dialog">Temple</span>is the sentence at the end of the zoology. Repro- <span class="tag lineNumber">52015</span><br>
+              enthusiasm, <p class="dialog"><span class="tag dialog">Temple</span>is the sentence at the end of the zoology. Repro- <br>
               duction is the beginning of death.<br></p> </p>
               <p class="textParagraph"> He touched Stephen timidly at the elbow and said eagerly: <br>
               <p class="dialog"><span class="tag dialog">???</span>―Do you feel how profound that is because you are a poet?<br></p> </p>
               <p class="textParagraph"> Cranly pointed his long forefinger. <br>
-              <p class="dialog"><span class="tag dialog">???</span>―Look at him! he said with scorn to the others. Look at <span class="tag lineNumber">52020</span><br>
+              <p class="dialog"><span class="tag dialog">???</span>―Look at him! he said with scorn to the others. Look at <span class="tag lineNumber">2020</span><br>
               Ireland's hope!<br></p> </p>
               <p class="textParagraph"> They laughed at his words and gesture. Temple turned on <br>
               him bravely, saying: <br>
               <p class="dialog"><span class="tag dialog">Temple</span>―Cranly, you're always sneering at me. I can see that. But I <br>
-              am as good as you are any day. Do you know what I think <span class="tag lineNumber">52025</span><br>
+              am as good as you are any day. Do you know what I think <br>
               about you now as compared with myself?<br> </p>
               <p class="dialog"><span class="tag dialog">Cranly</span>―My dear man,</p> said Cranly urbanely, <p class="dialog"><span class="tag dialog">Cranly</span>you are incapable, do <br>
               you know, absolutely incapable of thinking.<br> </p>
               <p class="dialog"><span class="tag dialog">Temple</span>―But do you know,</p> Temple went on, <p class="dialog"><span class="tag dialog">Temple</span>what I think of you and <br>
-              of myself compared together?<span class="tag lineNumber">52030</span><br> </p>
+              of myself compared together?<span class="tag lineNumber">2030</span><br> </p>
               <p class="dialog"><span class="tag dialog">a student</span>―Out with it, Temple!</p> the stout student cried from the steps. <br>
               <p class="dialog"><span class="tag dialog">a student</span>Get it out in bits!<br></p> </p>
               <p class="textParagraph"> Temple turned right and left, making sudden feeble gestures <br>
               as he spoke. <br>
-              <p class="dialog"><span class="tag dialog">???</span>―I'm a ballocks,</p> he said, shaking his head in despair. <p class="dialog"><span class="tag dialog">???</span>I am. <span class="tag lineNumber">52035</span><br>
+              <p class="dialog"><span class="tag dialog">???</span>―I'm a ballocks,</p> he said, shaking his head in despair. <p class="dialog"><span class="tag dialog">???</span>I am. <br>
               And I know I am. And I admit it that I am.<br></p> </p>
               <p class="textParagraph"> Dixon patted him lightly on the shoulder and said mildly: <br>
               <p class="dialog"><span class="tag dialog">Dixon</span>―And it does you every credit, Temple.<br> </p>
               <p class="dialog"><span class="tag dialog">???</span>―But he,</p> Temple said, pointing to Cranly. <p class="dialog"><span class="tag dialog">???</span>He is a ballocks too <br>
-              like me. Only he doesn't know it. And that's the only difference <span class="tag lineNumber">52040</span><br>
+              like me. Only he doesn't know it. And that's the only difference <span class="tag lineNumber">2040</span><br>
               I see.<br></p> </p>
               <p class="textParagraph"> A burst of laughter covered his words. But he turned again <br>
               to Stephen and said with a sudden eagerness: <br>
               <p class="dialog"><span class="tag dialog">???</span>―That word is a most interesting word. That's the only Eng- <br>
-              lish dual number. Did you know?<span class="tag lineNumber">52045</span><br> </p>
+              lish dual number. Did you know?<br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Is it?</p> Stephen said vaguely.<br> </p>
               <p class="textParagraph"> He was watching Cranly's firmfeatured suffering face, lit up <br>
               now by a smile of false patience. The gross name had passed <br>
               over it like foul water poured over an old stone image, patient <br>
-              of injuries: and, as he watched him, he saw him raise his hat in <span class="tag lineNumber">52050</span><br>
+              of injuries: and, as he watched him, he saw him raise his hat in <span class="tag lineNumber">2050</span><br>
               salute and uncover the black hair that stood up stiffly from his <br>
               forehead like an iron crown.<br> </p>
               <p class="textParagraph"> She passed out from the porch of the library and bowed <br>
               across Stephen in reply to Cranly's greeting. He also? Was there <br>
-              not a slight flush on Cranly's cheek? Or had it come forth at <span class="tag lineNumber">52055</span><br>
+              not a slight flush on Cranly's cheek? Or had it come forth at <br>
               Temple's words? The light had waned. He could not see.<br> </p>
               <p class="textParagraph"> Did that explain his friend's listless silence, his harsh com- <br>
               ments, the sudden intrusions of rude speech with which he had <br>
               shattered so often Stephen's ardent wayward confessions? Ste- <br>
-              phen had forgiven freely for he had found this rudeness also in <span class="tag lineNumber">52060</span><br>
+              phen had forgiven freely for he had found this rudeness also in <span class="tag lineNumber">2060</span><br>
               himself towards himself. And he remembered an evening when <br>
               he had dismounted from a borrowed creaking bicycle to pray <br>
               to God in a wood near <span class="hide">53.450924 -6.150138</span>Malahide. He had lifted up his arms <br>
               and spoken in ecstasy to the sombre nave of the trees, knowing <br>
-              that he stood on holy ground and in a holy hour. And when <span class="tag lineNumber">52065</span><br>
+              that he stood on holy ground and in a holy hour. And when <br>
               two constabularymen had come into sight round a bend in the <br>
               gloomy road he had broken off his prayer to whistle loudly an <br>
               air from the last pantomime.<br> </p>
               <p class="textParagraph"> He began to beat the frayed end of his ashplant against the <br>
-              base of a pillar. Had Cranly not heard him? Yet he could wait. <span class="tag lineNumber">52070</span><br>
+              base of a pillar. Had Cranly not heard him? Yet he could wait. <span class="tag lineNumber">2070</span><br>
               The talk about him ceased for a moment: and a soft hiss fell <br>
               again from a window above. But no other sound was in the air <br>
               and the swallows whose flight he had followed with idle eyes <br>
               were sleeping.<br> </p>
-              <p class="textParagraph"> She had passed through the dusk. And therefore the air was <span class="tag lineNumber">52075</span><br>
+              <p class="textParagraph"> She had passed through the dusk. And therefore the air was <br>
               silent save for one soft hiss that fell. And therefore the tongues <br>
               about him had ceased their babble. Darkness  was falling.<br> </p>
               <p class="textParagraph"> <span class="emph">Darkness falls from the air.</span><br> </p>
               <p class="textParagraph"> A trembling joy, lambent as a faint light, played like a fairy <br>
-              host around him. But why? Her passage through the darkening <span class="tag lineNumber">52080</span><br>
+              host around him. But why? Her passage through the darkening <span class="tag lineNumber">2080</span><br>
               air or the verse with its black vowels and its opening sound, <br>
               rich and lutelike?<br> </p>
               <p class="textParagraph"> He walked away slowly towards the deeper shadows at the <br>
               end of the colonnade, beating the stone softly with his stick to <br>
-              hide his revery from the students whom he had left: and <span class="tag lineNumber">52085</span><br>
+              hide his revery from the students whom he had left: and <br>
               allowed his mind to summon back to itself the age of Dowland <br>
               and Byrd and Nash.<br> </p>
               <p class="textParagraph"> Eyes, opening from the darkness of desire, eyes that dimmed <br>
               the breaking east. What was their languid grace but the soft- <br>
-              ness of chambering? And what was their shimmer but the <span class="tag lineNumber">52090</span><br>
+              ness of chambering? And what was their shimmer but the <span class="tag lineNumber">2090</span><br>
               shimmer of the scum that mantled the cesspool of the court of a <br>
               slobbering Stuart. And he tasted in the language of memory <br>
               ambered wines, dying fallings of sweet airs, the proud pavan: <br>
               and saw with the eyes of memory kind gentlewomen in <span class="hide">51.511732 -0.123270</span>Covent <br>
-              Garden wooing from their balconies with sucking mouths and <span class="tag lineNumber">52095</span><br>
+              Garden wooing from their balconies with sucking mouths and <br>
               the poxfouled wenches of the taverns and young wives that, <br>
               gaily yielding to their ravishers, clipped and clipped again.<br> </p>
               <p class="textParagraph"> The images he had summoned gave him no pleasure. They <br>
               were secret and enflaming but her image was not entangled by <br>
-              them. That was not the way to think of her. It was not even the <span class="tag lineNumber">52100</span><br>
+              them. That was not the way to think of her. It was not even the <span class="tag lineNumber">2100</span><br>
               way in which he thought of her. Could his mind then not trust <br>
               itself? Old phrases, sweet only with a disinterred sweetness like <br>
               the figseeds Cranly rooted out of his gleaming teeth.<br> </p>
               <p class="textParagraph"> It was not thought nor vision though he knew vaguely that <br>
-              her figure was passing homeward through the city. Vaguely <span class="tag lineNumber">52105</span><br>
+              her figure was passing homeward through the city. Vaguely <br>
               first and then more sharply he smelt her body. A conscious <br>
               unrest seethed in his blood. Yes, it was her body that he smelt: <br>
               a wild and languid smell: the tepid limbs over which his music <br>
               had flowed desirously and the secret soft linen upon which her <br>
-              flesh distilled odour and a dew.<span class="tag lineNumber">52110</span><br> </p>
+              flesh distilled odour and a dew.<span class="tag lineNumber">2110</span><br> </p>
               <p class="textParagraph"> A louse crawled over the nape of his neck and, putting his <br>
               thumb and forefinger deftly beneath his loose collar, he caught <br>
               it. He rolled its body, tender yet brittle as a grain of rice, be- <br>
               tween thumb and finger for an instant before he let it fall from <br>
-              him and wondered would it live or die. There came to his mind <span class="tag lineNumber">52115</span><br>
+              him and wondered would it live or die. There came to his mind <br>
               a curious phrase from Cornelius a Lapide which said that the <br>
               lice born of human sweat were not created by God with the <br>
               other animals on the sixth day. But the tickling of the skin of <br>
               his neck made his mind raw and red. The life of his body, <br>
-              illclad, illfed, louseeaten, made him close his eyelids in a sud- <span class="tag lineNumber">52120</span><br>
+              illclad, illfed, louseeaten, made him close his eyelids in a sud- <span class="tag lineNumber">2120</span><br>
               den spasm of despair: and in the darkness he saw the brittle <br>
               bright bodies of lice falling from the air and turning often as <br>
               they fell. Yes: and it was not darkness that fell from the air. It <br>
               was brightness.<br> </p>
-              <p class="textParagraph"> <span class="emph">Brightness falls from the air.</span> <span class="tag lineNumber">52125</span><br></p>
+              <p class="textParagraph"> <span class="emph">Brightness falls from the air.</span> <br></p>
               <p class="textParagraph"> He had not even remembered rightly Nash's line. All the <br>
               images it  had awakened were false. His mind bred vermin. His <br>
               thoughts were lice born of the sweat of sloth.<br> </p>
               <p class="textParagraph"> He came back quickly along the colonnade towards the <br>
-              group of students. Well then let her go and be damned to her. <span class="tag lineNumber">52130</span><br>
+              group of students. Well then let her go and be damned to her. <span class="tag lineNumber">2130</span><br>
               She could love some clean athlete who washed himself every <br>
               morning to the waist and had black hair on his chest. Let her.<br> </p>
               <p class="textParagraph"> Cranly had taken another dried fig from the supply in his <br>
               pocket and was eating it slowly and noisily. Temple sat on the <br>
-              pediment of a pillar, leaning back, his cap pulled down on his <span class="tag lineNumber">52135</span><br>
+              pediment of a pillar, leaning back, his cap pulled down on his <br>
               sleepy eyes. A squat young man came out of the porch, a <br>
               leather portfolio tucked under his armpit. He marched towards <br>
               the group, striking the flags with the heels of his boots and <br>
               with the ferrule of his heavy umbrella. Then, raising the um- <br>
-              brella in salute, he said to all: <span class="tag lineNumber">52140</span><br>
+              brella in salute, he said to all: <span class="tag lineNumber">2140</span><br>
               <p class="dialog"><span class="tag dialog">???</span>―Good evening, sirs.<br></p> </p>
               <p class="textParagraph"> He struck the flags again and tittered while his head <br>
               trembled with a slight nervous movement. The tall consump- <br>
               tive student and Dixon and O'Keeffe were speaking in Irish and <br>
-              did not answer him. Then, turning to Cranly, he said: <span class="tag lineNumber">52145</span><br>
+              did not answer him. Then, turning to Cranly, he said: <br>
               <p class="dialog"><span class="tag dialog">???</span>―Good evening, particularly to you.<br></p> </p>
               <p class="textParagraph"> He moved the umbrella in indication and tittered again. <br>
               Cranly, who was still chewing the fig, answered with loud <br>
               movements of his jaws. <br>
-              <p class="dialog"><span class="tag dialog">???</span>―Good? Yes. It is a good evening.<span class="tag lineNumber">52150</span><br></p> </p>
+              <p class="dialog"><span class="tag dialog">???</span>―Good? Yes. It is a good evening.<span class="tag lineNumber">2150</span><br></p> </p>
               <p class="textParagraph"> The squat student looked at him seriously and shook his <br>
               umbrella gently and reprovingly. <br>
               <p class="dialog"><span class="tag dialog">???</span>―I can see, he said, that you are about to make obvious <br>
               remarks.<br> </p>
-              <p class="dialog"><span class="tag dialog">???</span>―Um, Cranly answered, holding out what remained of the <span class="tag lineNumber">52155</span><br>
+              <p class="dialog"><span class="tag dialog">???</span>―Um, Cranly answered, holding out what remained of the <br>
               halfchewed fig and jerking it towards the squat student's <br>
               mouth in sign that he should eat.<br></p> </p>
               <p class="textParagraph"> The squat student did not eat it but, indulging his  special <br>
               humour, said gravely, still tittering and prodding his phrase <br>
-              with his  umbrella: <span class="tag lineNumber">52160</span><br>
+              with his  umbrella: <span class="tag lineNumber">2160</span><br>
               <p class="dialog"><span class="tag dialog">???</span>―Do you intend that ...<br></p> </p>
               <p class="textParagraph"> He broke off, pointed bluntly to the munched pulp of the fig <br>
               and said loudly: <br>
               <p class="dialog"><span class="tag dialog">???</span>―I allude to that.<br> </p>
-              <p class="dialog"><span class="tag dialog">???</span>―Um, Cranly said as before.<span class="tag lineNumber">52165</span><br> </p>
+              <p class="dialog"><span class="tag dialog">???</span>―Um, Cranly said as before.<br> </p>
               <p class="dialog"><span class="tag dialog">???</span>―Do you intend that now, the squat student said, as <span class="emph">ipso facto</span> <br>
               or, let us say, as so to speak?<br></p></p>
               <p class="textParagraph"> Dixon turned aside from his group, saying: <br>
               <p class="dialog"><span class="tag dialog">???</span>―Goggins was waiting for you, Glynn. He has gone round to <br>
-              the Adelphi to look for you and Moynihan. What have you <span class="tag lineNumber">52170</span><br>
+              the Adelphi to look for you and Moynihan. What have you <span class="tag lineNumber">2170</span><br>
               there? he asked, tapping the portfolio under Glynn's arm.<br> </p></p>
               <p class="textParagraph"> <p class="dialog"><span class="tag dialog">???</span>―Examination papers, Glynn answered. I give them monthly <br>
               examinations to see that they are profiting by my tuition.<br></p> </p>
               <p class="textParagraph"> He also tapped the portfolio and coughed gently and smiled. <br>
-              <p class="dialog"><span class="tag dialog">???</span>―Tuition! said Cranly rudely. I suppose you mean the bare- <span class="tag lineNumber">52175</span><br>
+              <p class="dialog"><span class="tag dialog">???</span>―Tuition! said Cranly rudely. I suppose you mean the bare- <br>
               footed children that are taught by a bloody ape like you. God <br>
               help them!<br></p> </p>
               <p class="textParagraph"> He bit off the rest of the fig and flung away the butt. <br>
               <p class="dialog"><span class="tag dialog">???</span>―I suffer little children to come unto me, Glynn said amiably.<br> </p>
-              <p class="dialog"><span class="tag dialog">???</span>―A bloody ape, Cranly repeated with emphasis, and a blas- <span class="tag lineNumber">52180</span><br>
+              <p class="dialog"><span class="tag dialog">???</span>―A bloody ape, Cranly repeated with emphasis, and a blas- <span class="tag lineNumber">2180</span><br>
               phemous bloody ape!<br></p> </p>
               <p class="textParagraph"> Temple stood up and, pushing past Cranly, addressed <br>
               Glynn: <br>
               <p class="dialog"><span class="tag dialog">???</span>―That phrase you said now,</p> he said, <p class="dialog"><span class="tag dialog">???</span>is from the new testa- <br>
-              ment about suffer the children to come to me.<span class="tag lineNumber">52185</span><br> </p>
+              ment about suffer the children to come to me.<br> </p>
               <p class="dialog"><span class="tag dialog">???</span>―Go to sleep again, Temple, said O'Keeffe.<br> </p>
               <p class="dialog"><span class="tag dialog">???</span>―Very well, then, Temple continued, still addressing Glynn, <br>
               and if Jesus suffered the children to come why does the church <br>
               send them all to hell if they die unbaptised? Why is that?<br> </p>
-              <p class="dialog"><span class="tag dialog">???</span>―Were you baptised yourself, Temple? the consumptive stu- <span class="tag lineNumber">52190</span><br>
+              <p class="dialog"><span class="tag dialog">???</span>―Were you baptised yourself, Temple? the consumptive stu- <span class="tag lineNumber">2190</span><br>
               dent asked.<br> </p>
               <p class="dialog"><span class="tag dialog">???</span>―But why are they sent to hell if Jesus said they were all to <br>
               come?</p> Temple said, his eyes searching in Glynn's eyes.<br> </p>
               <p class="textParagraph"> Glynn coughed and said gently, holding back with difficulty <br>
-              the nervous titter in his voice and moving his umbrella at every <span class="tag lineNumber">52195</span><br>
+              the nervous titter in his voice and moving his umbrella at every <br>
               word: <br></p>
               <p class="textParagraph"><p class="dialog"><span class="tag dialog">Glynn</span>―And, as you remark, if it is thus I ask emphatically whence <br>
               comes this thusness.<br> </p></p>
               <p class="dialog"><span class="tag dialog">Temple</span>―Because the church is cruel like all old sinners,</p> Temple said.<br>
-              <p class="dialog"><span class="tag dialog">Dixon</span>―Are you quite orthodox on that point, Temple?</p> Dixon said <span class="tag lineNumber">52200</span><br>
+              <p class="dialog"><span class="tag dialog">Dixon</span>―Are you quite orthodox on that point, Temple?</p> Dixon said <span class="tag lineNumber">2200</span><br>
               suavely.<br>
               <p class="dialog"><span class="tag dialog">Temple</span>―Saint Augustine says that about unbaptised children going to <br>
               hell,</p> Temple answered, <p class="dialog"><span class="tag dialog">Temple</span>because he was a cruel old sinner too.<br> </p>
               <p class="dialog"><span class="tag dialog">Dixon</span>―I bow to you,</p> Dixon said, <p class="dialog"><span class="tag dialog">Dixon</span>but I had the impression that <br>
-              limbo existed for such cases.<span class="tag lineNumber">52205</span><br> </p>
+              limbo existed for such cases.<br> </p>
               <p class="dialog"><span class="tag dialog">Cranly</span>―Don't argue with him, Dixon,</p> Cranly said brutally. <p class="dialog"><span class="tag dialog">Cranly</span>Don't <br>
               talk to him or look at him. Lead him home with a sugan the <br>
               way you'd lead a bleating goat.<br> </p>
               <p class="dialog"><span class="tag dialog">Temple</span>―Limbo!</p> Temple cried. <p class="dialog"><span class="tag dialog">Temple</span>That's a fine invention too. Like hell.<br> </p>
-              <p class="dialog"><span class="tag dialog">???</span>―But with the unpleasantness left out,</p> Dixon said.<span class="tag lineNumber">52210</span><br>
+              <p class="dialog"><span class="tag dialog">???</span>―But with the unpleasantness left out,</p> Dixon said.<span class="tag lineNumber">2210</span><br>
               <p class="textParagraph"> He turned smiling to the others and said: <br>
               <p class="dialog"><span class="tag dialog">???</span>―I think I am voicing the opinions of all present in saying so <br>
               much.<br> </p>
               <p class="dialog"><span class="tag dialog">Glynn</span>―You are,</p> Glynn said in a firm tone. <p class="dialog"><span class="tag dialog">Glynn</span>On that point Ireland is <br>
-              united.<span class="tag lineNumber">52215</span><br></p> </p>
+              united.<br></p> </p>
               <p class="textParagraph"> He struck the ferrule of his umbrella on the stone floor of <br>
               the colonnade. <br>
               <p class="dialog"><span class="tag dialog">Temple</span>―Hell,</p> Temple said. <p class="dialog"><span class="tag dialog">Temple</span>I can respect that invention of the grey <br>
               spouse of Satan. Hell is Roman, like the walls of the Romans, <br>
-              strong and ugly. But what is limbo?<span class="tag lineNumber">52220</span><br> </p>
+              strong and ugly. But what is limbo?<span class="tag lineNumber">2220</span><br> </p>
               <p class="dialog"><span class="tag dialog">???</span>―Put him back into  the perambulator, Cranly,</p> O'Keeffe called <br>
               out.<br></p>
               Cranly made a swift step towards Temple, halted, stamping <br>
               his foot and crying as if to a fowl: <br>
-              <p class="dialog"><span class="tag dialog">Cranly</span>―Hoosh!<span class="tag lineNumber">52225</span><br></p>
+              <p class="dialog"><span class="tag dialog">Cranly</span>―Hoosh!<br></p>
               Temple moved away nimbly. <br>
               <p class="dialog"><span class="tag dialog">Temple</span>―Do you know what limbo is?</p> he cried. <p class="dialog"><span class="tag dialog">Temple</span>Do you know what <br>
               we call a notion like that in Roscommon?<br> </p>
               <p class="dialog"><span class="tag dialog">Cranly</span>―Hoosh! Blast you!</p> Cranly cried, clapping his hands.<br>
-              <p class="dialog"><span class="tag dialog">Temple</span>―Neither my arse nor my elbow!</p> Temple cried out scornfully. <span class="tag lineNumber">52230</span><br>
+              <p class="dialog"><span class="tag dialog">Temple</span>―Neither my arse nor my elbow!</p> Temple cried out scornfully. <span class="tag lineNumber">2230</span><br>
               <p class="dialog"><span class="tag dialog">Temple</span>And that's what I call limbo.<br> </p>
               <p class="dialog"><span class="tag dialog">Cranly</span>―Give us that stick here,</p> Cranly said.<br>
               <p class="textParagraph"> He snatched the ashplant roughly from Stephen's hand and <br>
               sprang down the steps: but Temple, hearing him move in pur- <br>
-              suit, fled through the dusk like a wild creature, nimble and <span class="tag lineNumber">52235</span><br>
+              suit, fled through the dusk like a wild creature, nimble and <br>
               fleetfooted. Cranly's heavy boots were heard loudly charging <br>
               across the quadrangle and then returning heavily, foiled and <br>
               spurning the gravel at each step.<br> </p>
               <p class="textParagraph"> His step was angry and with an angry abrupt gesture he <br>
-              thrust the stick back into Stephen's hand. Stephen felt that his <span class="tag lineNumber">52240</span><br>
+              thrust the stick back into Stephen's hand. Stephen felt that his <span class="tag lineNumber">2240</span><br>
               anger had another cause but, feigning patience, touched his <br>
               arm slightly and said quietly: <br>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Cranly, I told you I wanted to speak to you. Come away.<br></p> </p>
               <p class="textParagraph"> Cranly looked at him for a few moments and asked: <br>
-              <p class="dialog"><span class="tag dialog">Cranly</span>―Now?<span class="tag lineNumber">52245</span><br> </p>
+              <p class="dialog"><span class="tag dialog">Cranly</span>―Now?<br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Yes, now,</p> Stephen said. <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>We can't speak here. Come away.<br></p> </p>
               <p class="textParagraph"> They crossed the quadrangle together without speaking. The <br>
               birdcall from <span class="emph">Siegfried</span> whistled softly followed them from the <br>
               steps of the porch. Cranly turned: and Dixon, who had <br>
-              whistled, called out: <span class="tag lineNumber">52250</span><br>
+              whistled, called out: <span class="tag lineNumber">2250</span><br>
               <p class="dialog"><span class="tag dialog">Dixon</span>―Where are you fellows off to? What about that  game, <br>
               Cranly?<br></p> </p>
               <p class="textParagraph"> They parleyed in shouts across the still air about a game of <br>
               billiards to be played in the <span class="hide">53.350570 -6.254002</span>Adelphi hotel. Stephen walked on <br>
-              alone and out into the quiet of Kildare Street. Opposite <span class="tag lineNumber">52255</span><br>
+              alone and out into the quiet of Kildare Street. Opposite <br>
               Maple's hotel he stood to wait, patient again. The name of the <br>
               hotel, a colourless polished wood, and its colourless quiet front <br>
               stung him like a glance of polite disdain. He stared angrily back <br>
               at the softly lit drawingroom of the hotel in which he imagined <br>
-              the sleek lives of the patricians of Ireland housed in calm. They <span class="tag lineNumber">52260</span><br>
+              the sleek lives of the patricians of Ireland housed in calm. They <span class="tag lineNumber">2260</span><br>
               thought of army commissions and land agents: peasants greeted <br>
               them along the roads  in the country: they knew the names of <br>
               certain French dishes and gave orders to jarvies in highpitched <br>
               provincial voices which pierced through their skintight accents.<br> </p>
-              <p class="textParagraph"> How could he hit their conscience or how cast his shadow <span class="tag lineNumber">52265</span><br>
+              <p class="textParagraph"> How could he hit their conscience or how cast his shadow <br>
               over the imagination of their daughters, before their squires <br>
               begat upon them, that they might breed a race less ignoble than <br>
               their own? And under the deepened dusk he felt the thoughts <br>
               and desires of the race to which he belonged flitting like bats <br>
-              across the dark country lanes,  under trees by the edges of <span class="tag lineNumber">52270</span><br>
+              across the dark country lanes,  under trees by the edges of <span class="tag lineNumber">2270</span><br>
               streams and near the poolmottled bogs. A woman had waited <br>
               in the doorway as Davin had passed by at night and, offering <br>
               him a cup of milk, had all but wooed him to her bed: for Davin <br>
               had the mild eyes of one that could be secret. But him no <br>
-              woman's eyes had wooed.<span class="tag lineNumber">52275</span><br> </p>
+              woman's eyes had wooed.<br> </p>
               <p class="textParagraph"> His arm was taken in a strong grip and Cranly's voice said: <br>
               <p class="dialog"><span class="tag dialog">Cranly</span>―Let us eke go.<br></p> </p>
               <p class="textParagraph"> They walked southward in silence. Then Cranly said: <br>
               <p class="dialog"><span class="tag dialog">Cranly</span>―That blithering idiot Temple! I swear to Moses, do you <br>
-              know, that I'll be the death of that fellow one time.<span class="tag lineNumber">52280</span><br></p> </p>
+              know, that I'll be the death of that fellow one time.<span class="tag lineNumber">2280</span><br></p> </p>
               <p class="textParagraph"> But his voice was no longer angry and Stephen wondered <br>
               was he thinking of her greeting to him under the porch.<br> </p>
               <p class="textParagraph"> They turned to the left and walked on as before. When they <br>
               had gone on so for some time Stephen said: <br>
-              <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Cranly, I had an unpleasant quarrel this evening.<span class="tag lineNumber">52285</span><br> </p>
+              <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Cranly, I had an unpleasant quarrel this evening.<br> </p>
               <p class="dialog"><span class="tag dialog">???</span>―With your people? Cranly asked.<br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―With my mother.<br> </p>
               <p class="dialog"><span class="tag dialog">???</span>―About religion?<br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Yes, Stephen answered.<br></p> </p>
-              <p class="textParagraph"> After a pause Cranly asked: <span class="tag lineNumber">52290</span><br>
+              <p class="textParagraph"> After a pause Cranly asked: <span class="tag lineNumber">2290</span><br>
               <p class="dialog"><span class="tag dialog">???</span>―What age is your mother?<br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Not old,</p> Stephen said. <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>She wishes me to make my easter <br>
               duty.<br> </p>
               <p class="dialog"><span class="tag dialog">???</span>―And will you?<br> </p>
-              <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I will not,</p> Stephen said.<span class="tag lineNumber">52295</span><br>
+              <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I will not,</p> Stephen said.<br>
               <p class="dialog"><span class="tag dialog">???</span>―Why not?</p> Cranly said.<br> 
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I will not serve,</p> answered Stephen.<br> 
               <p class="dialog"><span class="tag dialog">???</span>―That remark was made before,</p> Cranly said calmly.<br>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―It is made behind now,</p> said Stephen hotly.<br> </p>
-              <p class="textParagraph"> Cranly pressed Stephen's arm, saying: <span class="tag lineNumber">52300</span><br>
+              <p class="textParagraph"> Cranly pressed Stephen's arm, saying: <span class="tag lineNumber">2300</span><br>
               <p class="dialog"><span class="tag dialog">???</span>―Go easy, my dear man. You're an excitable bloody man, do <br>
               you know.<br></p> </p>
               <p class="textParagraph"> He laughed nervously as he spoke and, looking up into Ste- <br>
               phen's face with moved and friendly eyes, said: <br>
-              <p class="dialog"><span class="tag dialog">???</span>―Do you know that you are an excitable man?<span class="tag lineNumber">52305</span><br> </p>
+              <p class="dialog"><span class="tag dialog">???</span>―Do you know that you are an excitable man?<br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I daresay I am,</p> said Stephen, laughing also.<br> </p>
               <p class="textParagraph"> Their minds, lately estranged, seemed suddenly to have been <br>
               drawn closer, one to the other. <br>
               <p class="dialog"><span class="tag dialog">???</span>―Do you believe in the eucharist?</p> Cranly asked.<br>
-              <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I do not,</p> Stephen said.<span class="tag lineNumber">52310</span><br> 
+              <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I do not,</p> Stephen said.<span class="tag lineNumber">2310</span><br> 
               <p class="dialog"><span class="tag dialog">???</span>―Do you disbelieve then?<br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I neither believe in it nor disbelieve in it,</p> Stephen answered.<br> 
               <p class="dialog"><span class="tag dialog">Cranly</span>―Many persons have doubts, even religious persons, yet they <br>
               overcome them or put them aside,</p> Cranly said. <p class="dialog"><span class="tag dialog">Cranly</span>Are your <br>
-              doubts on that point too strong?<span class="tag lineNumber">52315</span><br> </p>
+              doubts on that point too strong?<br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I do not wish to overcome them,</p> Stephen answered.<br></p>
               <p class="textParagraph"> Cranly, embarrassed for a moment, took another fig from <br>
               his pocket and was about to eat it when Stephen said: <br>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Don't, please. You cannot discuss this question with your <br>
-              mouth full of chewed fig.<span class="tag lineNumber">52320</span><br></p> </p>
+              mouth full of chewed fig.<span class="tag lineNumber">2320</span><br></p> </p>
               <p class="textParagraph"> Cranly examined the fig by the light of a lamp under which <br>
               he halted. Then he smelt it with both nostrils, bit a tiny piece, <br>
               spat it out and threw the fig rudely into the gutter. Addressing <br>
               it as it lay, he said: <br>
-              <p class="dialog"><span class="tag dialog">???</span>―Depart from me, ye cursed, into everlasting fire!<span class="tag lineNumber">52325</span><br></p> </p>
+              <p class="dialog"><span class="tag dialog">???</span>―Depart from me, ye cursed, into everlasting fire!<br></p> </p>
               <p class="textParagraph"> Taking Stephen's arm he went on again and said: <br>
               <p class="dialog"><span class="tag dialog">???</span>―Do you not fear that those words may be spoken to you on <br>
               the day of judgment?<br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―What is offered me on the other hand?</p> Stephen asked. <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>An <br>
-              eternity of bliss in the company of the dean of studies?<span class="tag lineNumber">52330</span><br> </p>
+              eternity of bliss in the company of the dean of studies?<span class="tag lineNumber">2330</span><br> </p>
               <p class="dialog"><span class="tag dialog">Cranly</span>―Remember,</p> Cranly said, <p class="dialog"><span class="tag dialog">Cranly</span>that he would be glorified.<br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Ay,</p> Stephen said somewhat bitterly. <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>Bright, agile, impassible <br>
               and, above all, subtle.<br> </p>
               <p class="dialog"><span class="tag dialog">Cranly</span>―It is a curious thing, do you know,</p> Cranly said dispassion- <br>
-              ately, <p class="dialog"><span class="tag dialog">Cranly</span>how your mind is supersaturated with the religion in <span class="tag lineNumber">52335</span><br>
+              ately, <p class="dialog"><span class="tag dialog">Cranly</span>how your mind is supersaturated with the religion in <br>
               which you say you disbelieve. Did you believe in it when you <br>
               were at school? I bet you did.<br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I did,</p> Stephen answered.<br>
               <p class="dialog"><span class="tag dialog">Cranly</span>―And were you happier then?</p> Cranly asked softly. <p class="dialog"><span class="tag dialog">Cranly</span>Happier <br>
-              than you are now, for instance?<span class="tag lineNumber">52340</span><br> </p>
+              than you are now, for instance?<span class="tag lineNumber">2340</span><br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Often happy,</p> Stephen said, <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>and often unhappy. I was some- <br>
               one else then.<br> </p>
               <p class="dialog"><span class="tag dialog">Cranly</span>―How someone else? What do you mean by that  statement?<br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I mean,</p> said Stephen, <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>that I was not myself as I am now, as I <br>
-              had to become.<span class="tag lineNumber">52345</span><br> </p>
+              had to become.<br> </p>
               <p class="dialog"><span class="tag dialog">Cranly</span>―Not as you are now, not as you had to become,</p> Cranly <br>
               repeated. <p class="dialog"><span class="tag dialog">Cranly</span>Let me ask you a question. Do you love your mother?<br></p> </p>
               <p class="textParagraph"> Stephen shook his head slowly. <br>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I don't know what your words mean,</p> he said simply.<br>
-              <p class="dialog"><span class="tag dialog">Cranly</span>―Have you never loved anyone?</p> Cranly asked.<span class="tag lineNumber">52350</span><br>
+              <p class="dialog"><span class="tag dialog">Cranly</span>―Have you never loved anyone?</p> Cranly asked.<span class="tag lineNumber">2350</span><br>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Do you mean women?<br> </p>
               <p class="dialog"><span class="tag dialog">Cranly</span>―I am not speaking of that,</p> Cranly said in a colder tone. <p class="dialog"><span class="tag dialog">Cranly</span>I ask <br>
               you if you ever felt love towards anyone or anything.<br></p> </p>
               <p class="textParagraph"> Stephen walked on beside his friend, staring gloomily at the <br>
-              footpath. <span class="tag lineNumber">52355</span><br>
+              footpath. <br>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I tried to love God,</p> he said at length. <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>It seems now I failed. It <br>
               is very difficult. I tried to unite my will with the will of God <br>
               instant by instant. In that I did not always fail. I could perhaps <br>
               do that still .....<br></p> </p>
-              <p class="textParagraph"> Cranly cut him short by asking: <span class="tag lineNumber">52360</span><br>
+              <p class="textParagraph"> Cranly cut him short by asking: <span class="tag lineNumber">2360</span><br>
               <p class="dialog"><span class="tag dialog">Cranly</span>―Has your mother had a happy life?<br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―How do I know?</p> Stephen said.<br>
               <p class="dialog"><span class="tag dialog">Cranly</span>―How many children had she?<br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Nine or ten,</p> Stephen answered. <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>Some died.<br> </p>
-              <p class="dialog"><span class="tag dialog">Cranly</span>―Was your father ....</p> Cranly interrupted himself for an in- <span class="tag lineNumber">52365</span><br>
+              <p class="dialog"><span class="tag dialog">Cranly</span>―Was your father ....</p> Cranly interrupted himself for an in- <br>
               stant: and then said: <p class="dialog"><span class="tag dialog">Cranly</span>I don't want to pry  into your family <br>
               affairs. But was your father what is called  well-to-do? I mean <br>
               when you were growing up?<br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Yes,</p> Stephen said.<br>
-              <p class="dialog"><span class="tag dialog">Cranly</span>―What was he?</p> Cranly asked after a pause.<span class="tag lineNumber">52370</span><br></p>
+              <p class="dialog"><span class="tag dialog">Cranly</span>―What was he?</p> Cranly asked after a pause.<span class="tag lineNumber">2370</span><br></p>
               <p class="textParagraph"> Stephen began to enumerate glibly his father's attributes. <br>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―A medical student, an oarsman, a tenor, an amateur actor, a <br>
               shouting politician, a small landlord, a small investor, a <br>
               drinker, a good fellow, a storyteller, somebody's secretary, <br>
-              something in a distillery, a taxgatherer, a bankrupt and at <span class="tag lineNumber">52375</span><br>
+              something in a distillery, a taxgatherer, a bankrupt and at <br>
               present a praiser of his own past.<br></p> </p>
               <p class="textParagraph"> Cranly laughed, tightening  his grip on Stephen's arm, and <br>
               said: <br>
               <p class="dialog"><span class="tag dialog">Cranly</span>―The distillery is damn good.<br> </p>
-              <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Is there anything else you want to know?</p> Stephen asked.<span class="tag lineNumber">52380</span><br>
+              <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Is there anything else you want to know?</p> Stephen asked.<span class="tag lineNumber">2380</span><br>
               <p class="dialog"><span class="tag dialog">Cranly</span>―Are you in good circumstances at present?<br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Do I look it?</p> Stephen asked bluntly.<br>
               <p class="dialog"><span class="tag dialog">Cranly</span>―So then,</p> Cranly went on musingly, <p class="dialog"><span class="tag dialog">Cranly</span>you were born in the lap <br>
               of luxury.<br></p> </p>
-              <p class="textParagraph"> He used the phrase broadly and loudly as he often used <span class="tag lineNumber">52385</span><br>
+              <p class="textParagraph"> He used the phrase broadly and loudly as he often used <br>
               technical expressions as if he wished his hearer to understand <br>
               that they were used by him without conviction. <br>
               <p class="dialog"><span class="tag dialog">???</span>―Your mother must have gone through a good deal of suffer- <br>
               ing, he said then. Would you not try to save her from suffering <br>
-              more even if .... or would you?<span class="tag lineNumber">52390</span><br> </p>
+              more even if .... or would you?<span class="tag lineNumber">2390</span><br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―If I could,</p> Stephen said. <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>That would cost me very little.<br> </p>
               <p class="dialog"><span class="tag dialog">Cranly</span>―Then do so,</p> Cranly said. <p class="dialog"><span class="tag dialog">Cranly</span>Do as she wishes you to do. What <br>
               is it for you? You disbelieve in it. It is a form: nothing else. And <br>
               you will set her mind at rest.<br></p> </p>
-              <p class="textParagraph"> He ceased and, as Stephen did not reply, remained silent. <span class="tag lineNumber">52395</span><br>
+              <p class="textParagraph"> He ceased and, as Stephen did not reply, remained silent. <br>
               Then, as if giving utterance to the process of his own thought, <br>
               he said: <br>
               <p class="dialog"><span class="tag dialog">Cranly</span>―Whatever else is unsure in this stinking dunghill of a world a <br>
               mother's love is not. Your mother brings you into the world, <br>
-              carries you first in her body. What do we know about what she <span class="tag lineNumber">52400</span><br>
+              carries you first in her body. What do we know about what she <span class="tag lineNumber">2400</span><br>
               feels? But whatever she feels, it, at least, must be real. It must <br>
               be. What are our ideas or ambitions? Play. Ideas! Why, that <br>
               bloody bleating goat Temple has ideas. MacCann has ideas too. <br>
               Every jackass going the roads thinks he has ideas.<br></p> </p>
-              <p class="textParagraph"> Stephen, who had been listening to the unspoken speech <span class="tag lineNumber">52405</span><br>
+              <p class="textParagraph"> Stephen, who had been listening to the unspoken speech <br>
               behind the words, said with assumed carelessness: <br>
               <p class="textParagraph"> <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Pascal, if I remember rightly, would not suffer his mother to <br>
               kiss him as he feared the contact of her sex.<br> </p>
               <p class="dialog"><span class="tag dialog">Cranly</span>―Pascal was a pig,</p> said Cranly.<br>
-              <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Aloysius Gonzaga, I think, was of the same mind,</p> Stephen <span class="tag lineNumber">52410</span><br>
+              <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Aloysius Gonzaga, I think, was of the same mind,</p> Stephen <span class="tag lineNumber">2410</span><br>
               said.<br>
               <p class="dialog"><span class="tag dialog">Cranly</span>―And he was another pig then,</p> said Cranly.<br>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―The church calls him a saint,</p> Stephen objected.<br>
               <p class="dialog"><span class="tag dialog">Cranly</span>―I don't care a flaming damn what anyone calls him,</p> Cranly <br>
-              said rudely and flatly. <p class="dialog"><span class="tag dialog">Cranly</span>I call him a pig.<span class="tag lineNumber">52415</span><br></p> </p>
+              said rudely and flatly. <p class="dialog"><span class="tag dialog">Cranly</span>I call him a pig.<br></p> </p>
               <p class="textParagraph"> Stephen, preparing the words neatly in his mind, continued: <br>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Jesus too seems to have treated his mother with scant cour- <br>
               tesy in public but Suarez, a jesuit theologian and Spanish <br>
               gentleman, has apologised for him.<br> </p>
-              <p class="dialog"><span class="tag dialog">Cranly</span>―Did the idea ever occur to you,</p> Cranly asked, <p class="dialog"><span class="tag dialog">Cranly</span>that Jesus was <span class="tag lineNumber">52420</span><br>
+              <p class="dialog"><span class="tag dialog">Cranly</span>―Did the idea ever occur to you,</p> Cranly asked, <p class="dialog"><span class="tag dialog">Cranly</span>that Jesus was <span class="tag lineNumber">2420</span><br>
               not what he pretended to be?<br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―The first person to whom that idea occurred,</p> Stephen <br>
               answered, <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>was Jesus himself.<br> </p>
               <p class="dialog"><span class="tag dialog">Cranly</span>―I mean,</p> Cranly said, hardening in his speech, <p class="dialog"><span class="tag dialog">Cranly</span>did the idea <br>
-              ever occur to you that he was himself a conscious hypocrite, <span class="tag lineNumber">52425</span><br>
+              ever occur to you that he was himself a conscious hypocrite, <br>
               what he called the jews of his time, a whited sepulchre? Or, to <br>
               put it more plainly, that he was a blackguard?<br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―That idea never occurred to me,</p> Stephen answered. <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>But I am <br>
               curious to know are you trying to make a convert of me or a <br>
-              pervert of yourself?<span class="tag lineNumber">52430</span><br></p> </p>
+              pervert of yourself?<span class="tag lineNumber">2430</span><br></p> </p>
               <p class="textParagraph"> He turned towards his friend's face and saw there a raw <br>
               smile which some force of will strove to make finely significant.<br> </p>
               <p class="textParagraph"> Cranly asked suddenly in a plain sensible tone: <br>
               <p class="dialog"><span class="tag dialog">Cranly</span>―Tell me the truth. Were you at all shocked by what I said?<br> </p>
-              <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Somewhat,</p> Stephen said.<span class="tag lineNumber">52435</span><br> 
+              <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Somewhat,</p> Stephen said.<br> 
               <p class="dialog"><span class="tag dialog">Cranly</span>―And why were you shocked,</p> Cranly pressed on in the same <br>
               tone, <p class="dialog"><span class="tag dialog">Cranly</span>if you feel sure that our religion is false and that Jesus <br>
               was not the son of God?<br> </p>
              <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I am not at all sure of it,</p> Stephen said. <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>He is more like a son <br>
-              of God than a son of Mary.<span class="tag lineNumber">52440</span><br> </p>
+              of God than a son of Mary.<span class="tag lineNumber">2440</span><br> </p>
               <p class="dialog"><span class="tag dialog">Cranly</span>―And is that why you will not communicate,</p> Cranly asked, <br>
               <p class="dialog"><span class="tag dialog">Cranly</span>because you are not sure of that too, because you feel that the <br>
               host too may be the body and blood of the son of God and not <br>
               a wafer of bread? And because you fear that it may be?<br> </p>
-              <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Yes,</p> Stephen said quietly. <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>I feel that and I also fear it.<span class="tag lineNumber">52445</span><br> </p>
+              <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Yes,</p> Stephen said quietly. <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>I feel that and I also fear it.<br> </p>
               <p class="dialog"><span class="tag dialog">Cranly</span>―I see,</p> Cranly said.<br></p>
               <p class="textParagraph"> Stephen, struck by his tone of closure, reopened the dis- <br>
               cussion at once by saying: <br>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I fear many things: dogs, horses, firearms, the sea, thunder- <br>
-              storms, machinery, the country roads at night.<span class="tag lineNumber">52450</span><br> </p>
+              storms, machinery, the country roads at night.<span class="tag lineNumber">2450</span><br> </p>
               <p class="dialog"><span class="tag dialog">Cranly</span>―But why do you fear a bit of bread?<br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I imagine,</p> Stephen said, <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>that there is a malevolent reality <br>
               behind those things I say I fear.<br> </p>
               <p class="dialog"><span class="tag dialog">Cranly</span>―Do you fear then,</p> Cranly asked, <p class="dialog"><span class="tag dialog">Cranly</span>that the God of the Roman <br>
-              catholics would strike you dead and damn you if you made a <span class="tag lineNumber">52455</span><br>
+              catholics would strike you dead and damn you if you made a <br>
               sacrilegious communion?<br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―The God of the Roman catholics could do that now,</p> Stephen <br>
               said. <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>I fear more than that the chemical action which would be <br>
               set up in my soul by a false homage to a symbol behind which <br>
-              are massed twenty centuries of authority and veneration.<span class="tag lineNumber">52460</span><br> </p>
+              are massed twenty centuries of authority and veneration.<span class="tag lineNumber">2460</span><br> </p>
               <p class="dialog"><span class="tag dialog">Cranly</span>―Would you,</p> Cranly asked, <p class="dialog"><span class="tag dialog">Cranly</span>in extreme danger commit that <br>
               particular sacrilege? For instance, if you lived in the penal days?<br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I cannot answer for the past,</p> Stephen replied. <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>Possibly not.<br> </p>
               <p class="dialog"><span class="tag dialog">Cranly</span>―Then,</p> said Cranly, <p class="dialog"><span class="tag dialog">Cranly</span>you do not intend to become a protes- <br>
-              tant?<span class="tag lineNumber">52465</span><br> </p>
+              tant?<br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I said that I had lost the faith,</p> Stephen answered, <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>but not <br>
               that I had lost selfrespect. What kind of liberation would that <br>
               be to forsake an absurdity which is logical and coherent and to <br>
               embrace one which is illogical and incoherent?<br></p> </p>
-              <p class="textParagraph"> They had walked on towards the township of <span class="hide">51.873620 -8.347738</span>Pembroke and <span class="tag lineNumber">52470</span><br>
+              <p class="textParagraph"> They had walked on towards the township of <span class="hide">51.873620 -8.347738</span>Pembroke and <span class="tag lineNumber">2470</span><br>
               now, as they went on slowly along the avenues, the trees and <br>
               the scattered lights in the villas soothed their minds. The air of <br>
               wealth and repose diffused about them seemed to comfort their <br>
               neediness. Behind a hedge of laurel a light glimmered in the <br>
-              window of a kitchen and the voice of a servant was heard <span class="tag lineNumber">52475</span><br>
+              window of a kitchen and the voice of a servant was heard <br>
               singing as she sharpened knives. She sang in short broken bars <br>
               <span class="emph">Rosie O'Grady</span>.<br> </p>
               <p class="textParagraph"> Cranly stopped to listen, saying: <br>
               <p class="dialog"><span class="tag dialog">Cranly</span>―Mulier cantat.<br></p> </p>
-              <p class="textParagraph"> The soft beauty of the Latin word touched with an enchant- <span class="tag lineNumber">52480</span><br>
+              <p class="textParagraph"> The soft beauty of the Latin word touched with an enchant- <span class="tag lineNumber">2480</span><br>
               ing touch the  dark of the evening, with a touch fainter and <br>
               more persuading than the touch of music or of a woman's <br>
               hand. The strife of their minds was quelled. The figure of <br>
               woman as she appears in the liturgy of the church passed si- <br>
-              lently through the darkness: a whiterobed figure, small and <span class="tag lineNumber">52485</span><br>
+              lently through the darkness: a whiterobed figure, small and <br>
               slender as a boy and with a falling girdle. Her voice, frail and <br>
               high as a boy's, was heard intoning from a distant choir the <br>
               first words of a woman which pierce the gloom and clamour of <br>
               the first chanting of the passion: <br>
-              <p class="dialog"><span class="tag dialog">a female servant</span>―Et tu cum Jesu Galilaeo eras.<span class="tag lineNumber">52490</span><br></p> </p>
+              <p class="dialog"><span class="tag dialog">a female servant</span>―Et tu cum Jesu Galilaeo eras.<span class="tag lineNumber">2490</span><br></p> </p>
               <p class="textParagraph"> And all  hearts were touched and turned to her voice, shining <br>
               like a young star, shining clearer as the voice intoned the pro- <br>
               paroxyton and more faintly as the cadence died.<br> </p>
               <p class="textParagraph"> The singing ceased. They went on together, Cranly repeating <br>
-              in strongly stressed rhythm the end of the refrain: <span class="tag lineNumber">52495</span><br>
+              in strongly stressed rhythm the end of the refrain: <br>
               <p class="lg">
                 And when we are married <br>
                 O, how happy we'll be <br>
                 For I love sweet Rosie O'Grady <br>
                 And Rosie O'Grady loves me. <br>
               </p>
-              <p class="dialog"><span class="tag dialog">Cranly</span>―There's real poetry for you,</p> he said. <p class="dialog"><span class="tag dialog">Cranly</span>There's real love.<span class="tag lineNumber">52500</span><br></p> </p>
+              <p class="dialog"><span class="tag dialog">Cranly</span>―There's real poetry for you,</p> he said. <p class="dialog"><span class="tag dialog">Cranly</span>There's real love.<span class="tag lineNumber">2500</span><br></p> </p>
               <p class="textParagraph"> He glanced sideways at Stephen with a strange smile and <br>
               said: <br>
               <p class="dialog"><span class="tag dialog">???</span>―Do you consider that poetry? Or do you know what the <br>
               words mean?<br> </p>
-              <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I want to see Rosie first,</p> said Stephen.<span class="tag lineNumber">52505</span><br>
+              <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I want to see Rosie first,</p> said Stephen.<br>
               <p class="dialog"><span class="tag dialog">???</span>―She's easy to find,</p> Cranly said.<br></p>
               <p class="textParagraph"> His hat had come down on his forehead. He shoved it back: <br>
               and in the shadow of the trees Stephen saw his pale face, <br>
               framed by the dark, and his large dark eyes. Yes. His face was <br>
-              handsome: and his body was strong and hard. He had spoken <span class="tag lineNumber">52510</span><br>
+              handsome: and his body was strong and hard. He had spoken <span class="tag lineNumber">2510</span><br>
               of a mother's love. He felt then the sufferings of women, the <br>
               weaknesses of their bodies and souls: and would shield them <br>
               with a strong  and resolute arm and bow his mind to them.<br> </p>
               <p class="textParagraph"> Away then: it is time to go. A voice spoke softly to Stephen's <br>
-              lonely heart, bidding him go and telling him that his friendship <span class="tag lineNumber">52515</span><br>
+              lonely heart, bidding him go and telling him that his friendship <br>
               was coming to an end. Yes: he would go. He could not strive <br>
               against another. He knew his part. <br>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Probably I shall go away,</p> he said.<br>
               <p class="dialog"><span class="tag dialog">???</span>―Where?</p> Cranly asked.<br> 
-              <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Where I can,</p> Stephen said.<span class="tag lineNumber">52520</span><br> 
+              <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Where I can,</p> Stephen said.<span class="tag lineNumber">2520</span><br> 
               <p class="dialog"><span class="tag dialog">???</span>―Yes,</p> Cranly said. <p class="dialog"><span class="tag dialog">Cranly</span>It might be difficult for you to live here <br>
               now. But is it that that makes you go?<br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I have to go,</p> Stephen answered.<br> </p>
               <p class="dialog"><span class="tag dialog">???</span>―Because,</p> Cranly continued, <p class="dialog"><span class="tag dialog">Cranly</span>you need not look upon yourself <br>
-              as driven away if you do not wish to go or as a heretic or an <span class="tag lineNumber">52525</span><br>
+              as driven away if you do not wish to go or as a heretic or an <br>
               outlaw. There are many good believers who think as you do. <br>
               Would that surprise you? The church is not the stone building <br>
               nor even the clergy and their dogmas. It is the whole mass of <br>
               those born into it. I don't know what you wish to do in life. Is <br>
-              it what you told me the night we were standing outside <span class="hide">53.333446 -6.262433</span>Har- <span class="tag lineNumber">52530</span><br>
+              it what you told me the night we were standing outside <span class="hide">53.333446 -6.262433</span>Har- <span class="tag lineNumber">2530</span><br>
               court Street station?<br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Yes,</p> Stephen said, smiling in spite of himself at Cranly's way <br>
               of remembering thoughts in connection with places. <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>The night <br>
               you spent half an hour wrangling with Doherty about the <br>
-              shortest way from <span class="hide">53.136900 -6.310000</span>Sallygap to Larras.<span class="tag lineNumber">52535</span><br> </p>
+              shortest way from <span class="hide">53.136900 -6.310000</span>Sallygap to Larras.<br> </p>
               <p class="dialog"><span class="tag dialog">Cranly</span>―Pothead!</p> Cranly said with calm contempt. <p class="dialog"><span class="tag dialog">Cranly</span>What does he <br>
               know about the way from Sallygap to Larras? Or what does he <br>
               know about anything for that matter? And the big slobbering <br>
               washingpot head of him!<br></p> </p>
-              <p class="textParagraph"> He broke out into a loud long laugh. <span class="tag lineNumber">52540</span><br>
+              <p class="textParagraph"> He broke out into a loud long laugh. <span class="tag lineNumber">2540</span><br>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Well?</p> Stephen said. <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>Do you remember the rest?<br> </p>
               <p class="dialog"><span class="tag dialog">Cranly</span>―What you said, is it?</p> Cranly asked. <p class="dialog"><span class="tag dialog">Cranly</span>Yes, I remember it. To <br>
               discover the mode of life or of art whereby your spirit could <br>
               express itself in unfettered freedom.<br></p> </p>
-              <p class="textParagraph"> Stephen raised his hat in acknowledgment. <span class="tag lineNumber">52545</span><br>
+              <p class="textParagraph"> Stephen raised his hat in acknowledgment. <br>
               <p class="dialog"><span class="tag dialog">Cranly</span>―Freedom! Cranly repeated. But you are not free enough yet <br>
               to commit a sacrilege. Tell me, would you rob?<br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I would beg first,</p> Stephen said.<br>
               <p class="dialog"><span class="tag dialog">Cranly</span>―And if you got nothing would you rob?<br> </p>
-              <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―You wish me to say,</p> Stephen answered, <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>that the rights of <span class="tag lineNumber">52550</span><br>
+              <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―You wish me to say,</p> Stephen answered, <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>that the rights of <span class="tag lineNumber">2550</span><br>
               property are provisional and that in certain circumstances it is <br>
               not unlawful to rob. Everyone would act in that belief. So I will <br>
               not make you that answer. Apply to the jesuit theologian Juan <br>
               Mariana de Talavera who will also explain to you in what <br>
-              circumstances you may lawfully kill your king and whether you <span class="tag lineNumber">52555</span><br>
+              circumstances you may lawfully kill your king and whether you <br>
               had better hand him his poison in a goblet or smear it for him <br>
               upon his robe or his saddlebow. Ask me rather would I suffer <br>
               others to rob me or, if they did, would I call down upon them <br>
               what I believe is called the chastisement of the secular arm.<br> </p>
-              <p class="dialog"><span class="tag dialog">Cranly</span>―And would you?<span class="tag lineNumber">52560</span><br> </p>
+              <p class="dialog"><span class="tag dialog">Cranly</span>―And would you?<span class="tag lineNumber">2560</span><br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I think, Stephen said, it would pain me as much to do so as <br>
               to be robbed.<br> </p>
               <p class="dialog"><span class="tag dialog">Cranly</span>―I see,</p> Cranly said.<br></p>
               <p class="textParagraph"> He produced his match and began to clean the crevice be- <br>
-              tween two teeth. Then he said carelessly: <span class="tag lineNumber">52565</span><br>
+              tween two teeth. Then he said carelessly: <br>
               <p class="dialog"><span class="tag dialog">Cranly</span>―Tell me, for example, would you deflower a virgin?<br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Excuse me,</p> Stephen said politely. <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>Is that not the ambition of <br>
               most young gentlemen?<br> </p>
               <p class="dialog"><span class="tag dialog">???</span>―What then is your point of view?</p> Cranly asked.<br></p>
-              <p class="textParagraph"> His last phrase, soursmelling as the smoke of charcoal and <span class="tag lineNumber">52570</span><br>
+              <p class="textParagraph"> His last phrase, soursmelling as the smoke of charcoal and <span class="tag lineNumber">2570</span><br>
               disheartening, excited Stephen's brain over which its fumes <br>
               seemed to brood. <br>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Look here, Cranly,</p> he said. <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>You have asked me what I would <br>
               do and what I would not do. I will tell you what I will do and <br>
-              what I will not do. I will not serve that in which I no longer <span class="tag lineNumber">52575</span><br>
+              what I will not do. I will not serve that in which I no longer <br>
               believe whether it call itself my home, my fatherland or my <br>
               church: and I will try to express myself in some mode of life or <br>
               art as freely as I can and as wholly as I can, using for my <br>
               defence the only arms I allow myself to use, - silence, exile and <br>
-              cunning.<span class="tag lineNumber">52580</span><br></p> </p>
+              cunning.<span class="tag lineNumber">2580</span><br></p> </p>
               <p class="textParagraph"> Cranly seized his arm and steered him round so as to lead <br>
               him back towards <span class="hide">53.328562 -6.251897</span>Leeson Park. He laughed almost slily and <br>
               pressed Stephen's arm with an elder's affection. <br>
               <p class="dialog"><span class="tag dialog">Cranly</span>―Cunning indeed!</p> he said. <p class="dialog"><span class="tag dialog">Cranly</span>Is it you? You poor poet, you!<br> </p>
-              <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―And you made me confess to you,</p> Stephen said, <p class="dialog"><span class="tag dialog">Stephen Deadlus</span>thrilled by <span class="tag lineNumber">52585</span><br>
+              <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―And you made me confess to you,</p> Stephen said, <p class="dialog"><span class="tag dialog">Stephen Deadlus</span>thrilled by <br>
               his touch, as I have confessed to you so  many other things, <br>
               have I not?<br> </p>
               <p class="dialog"><span class="tag dialog">???</span>―Yes, my child,</p> Cranly said, still gaily.<br>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―You made me confess the fears that I have. But I will tell you <br>
-              also what I do not fear. I do not fear to be alone or to be <span class="tag lineNumber">52590</span><br>
+              also what I do not fear. I do not fear to be alone or to be <span class="tag lineNumber">2590</span><br>
               spurned for another or to leave whatever I have to leave. And I <br>
               am not afraid to make a mistake, even  a great  mistake, a <br>
               lifelong mistake and perhaps as long as eternity too.<br></p> </p>
               <p class="textParagraph"> Cranly, now grave again, slowed his pace and said: <br>
-              <p class="dialog"><span class="tag dialog">Cranly</span>―Alone, quite alone. You have no fear of that. And you know <span class="tag lineNumber">52595</span><br>
+              <p class="dialog"><span class="tag dialog">Cranly</span>―Alone, quite alone. You have no fear of that. And you know <br>
               what that word means? Not only to be separate from all others <br>
               but to have not even one friend.<br> </p>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―I will take the risk,</p> said Stephen.<br>
               <p class="dialog"><span class="tag dialog">Cranly</span>―And not to have any one person,</p> Cranly said, <p class="dialog"><span class="tag dialog">Cranly</span>who would be <br>
-              more than a friend, more even than the noblest and truest <span class="tag lineNumber">52600</span><br>
+              more than a friend, more even than the noblest and truest <span class="tag lineNumber">2600</span><br>
               friend a man ever had.<br></p> </p>
               <p class="textParagraph"> His words seemed to have struck some deep chord in his <br>
               own nature. Had he spoken of himself, of himself as he was or <br>
               wished to be? Stephen watched his face for some moments in <br>
-              silence. A cold sadness was there. He had spoken of himself, of <span class="tag lineNumber">52605</span><br>
+              silence. A cold sadness was there. He had spoken of himself, of <br>
               his own loneliness which he feared. <br>
               <p class="dialog"><span class="tag dialog">Stephen Dedalus</span>―Of whom are you speaking?</p> Stephen asked at length.<br></p>
               <p class="textParagraph"> Cranly did not answer.<br> </p>
@@ -8697,190 +8697,190 @@
           
         
               <p class="textParagraph"> <span class="emph">20 March:</span> Long talk with Cranly on the subject of my re- <br>
-              volt. He had his grand manner on. I supple and suave. Attacked <span class="tag lineNumber">52610</span><br>
+              volt. He had his grand manner on. I supple and suave. Attacked <span class="tag lineNumber">2610</span><br>
               me on the score of love for one's mother. Tried to imagine his <br>
               mother: cannot. Told me once, in a moment of thoughtlessness, <br>
               his father was sixtyone when he was born. Can see him. Strong <br>
               farmer type. Pepper and salt suit. Square feet. Unkempt <br>
-              grizzled beard. Probably attends coursing matches. Pays his <span class="tag lineNumber">52615</span><br>
+              grizzled beard. Probably attends coursing matches. Pays his <br>
               dues regularly but not plentifully to Father Dwyer of Larras. <br>
               Sometimes talks to girls after nightfall. But his mother? Very <br>
               young or very old? Hardly the first. If so, Cranly would not <br>
               have spoken as he did. Old then. Probably: and neglected. <br>
-              Hence Cranly's despair of soul: the child of exhausted loins.<span class="tag lineNumber">52620</span><br> </p>
+              Hence Cranly's despair of soul: the child of exhausted loins.<span class="tag lineNumber">2620</span><br> </p>
               <p class="textParagraph"> <span class="emph">21 March, morning:</span> Thought this in bed last night but was <br>
               too lazy and free to add it. Free, yes. The exhausted loins are <br>
               those of Elizabeth and Zachary. Then is he [is] the precursor. Item: <br>
               he eats chiefly belly bacon and dried figs. Read locusts and wild <br>
-              honey. Also, when thinking of him, saw always a stern severed <span class="tag lineNumber">52625</span><br>
+              honey. Also, when thinking of him, saw always a stern severed <br>
               head or deathmask as if outlined on a grey curtain or veronica. <br>
               Decollation they call it in the fold. Puzzled for the moment by <br>
               saint John at the Latin gate. What do I see? A decollated <br>
               precursor trying to pick the lock.<br> </p>
-              <p class="textParagraph"> <span class="emph">21 March, night:</span> Free. Soulfree and fancyfree. Let the dead <span class="tag lineNumber">52630</span><br>
+              <p class="textParagraph"> <span class="emph">21 March, night:</span> Free. Soulfree and fancyfree. Let the dead <span class="tag lineNumber">2630</span><br>
               bury the dead. Ay. And let the dead marry the dead.<br> </p>
               <p class="textParagraph"> <span class="emph">22 March:</span> In company with Lynch followed a sizable hos- <br>
               pital nurse. Lynch's idea. Dislike it. Two lean hungry grey- <br>
               hounds walking after a heifer.<br> </p>
-              <p class="textParagraph"> <span class="emph">23 March:</span> Have not seen her since that night. Unwell? Sits at <span class="tag lineNumber">52635</span><br>
+              <p class="textParagraph"> <span class="emph">23 March:</span> Have not seen her since that night. Unwell? Sits at <br>
               the fire perhaps with mamma's shawl on her shoulders. But not <br>
               peevish. A nice bowl of gruel? Won't you now?<br> </p>
               <p class="textParagraph"> <span class="emph">24 March:</span> Began with a discussion with my mother. Subject: <br>
               B. V. M. Handicapped by my sex and youth. To escape held up <br>
-              relations between Jesus and Papa against those between Mary <span class="tag lineNumber">52640</span><br>
+              relations between Jesus and Papa against those between Mary <span class="tag lineNumber">2640</span><br>
               and her son. Said religion is not a lying-in hospital. Mother <br>
               indulgent. Said I have a queer mind and have read too much. <br>
               Not true. Have read little and understood less. Then she said I <br>
               would come back to faith because I had a restless mind. This <br>
-              means to leave church by backdoor of sin and reenter through <span class="tag lineNumber">52645</span><br>
+              means to leave church by backdoor of sin and reenter through <br>
               the skylight of repentance. Cannot repent. Told her so and <br>
               asked for sixpence. Got threepence.<br> </p>
               <p class="textParagraph"> Then went to college. Other wrangle with little roundhead <br>
               rogue's eye Ghezzi. This time about Bruno the Nolan. Began in <br>
-              Italian and ended in pidgin English. He said Bruno was a ter- <span class="tag lineNumber">52650</span><br>
+              Italian and ended in pidgin English. He said Bruno was a ter- <span class="tag lineNumber">2650</span><br>
               rible heretic. I said he was terribly burned. He agreed to this <br>
               with some sorrow. Then gave me recipe for what he calls <br>
               <span class="emph">risotto alla bergamasca</span>. When he pronounces a soft <span class="emph">o</span> he pro- <br>
               trudes his full carnal lips as if he kissed the vowel. Has he? And <br>
-              could he repent? Yes, he could: and cry two round rogue's <span class="tag lineNumber">52655</span><br>
+              could he repent? Yes, he could: and cry two round rogue's <br>
               tears, one from each eye.<br> </p>
               <p class="textParagraph"> Crossing Stephen's, that is, <span class="hide">53.338174 -6.259119</span>my green, remembered that his <br>
               countrymen and not mine had invented what Cranly the other <br>
               night called our religion. A quartet of them, soldiers  of the <br>
-              ninetyseventh infantry regiment, sat at the foot of the cross and <span class="tag lineNumber">52660</span><br>
+              ninetyseventh infantry regiment, sat at the foot of the cross and <span class="tag lineNumber">2660</span><br>
               tossed up dice for the overcoat of the crucified.<br> </p>
               <p class="textParagraph"> Went to library. Tried to read three reviews. Useless. She is <br>
               not out yet. Am I alarmed? About what? That she will never be <br>
               out again. Blake wrote:<br> </p>
               <p class="lg">
-                <span class="emph">I wonder if William Bond will die.</span> <span class="tag lineNumber">52665</span><br>
+                <span class="emph">I wonder if William Bond will die.</span> <br>
                 <span class="emph">For assuredly he is very ill.</span> <br>
               </p>
               <p class="textParagraph"> Alas, poor William!<br> </p>
               <p class="textParagraph"> I was once at a diorama in <span class="hide">53.353368 -6.262135</span>Rotunda. At the end were pic- <br>
               tures of big nobs. Among them William Ewart Gladstone, just <br>
-              then dead. Orchestra played <span class="emph">O Willie, we have missed you</span>.<span class="tag lineNumber">52670</span><br> </p>
+              then dead. Orchestra played <span class="emph">O Willie, we have missed you</span>.<span class="tag lineNumber">2670</span><br> </p>
               <p class="textParagraph"> A race of clodhoppers.<br> </p>
               <p class="textParagraph"> <span class="emph">25 March, morning:</span> A troubled night of dreams. Want to get <br>
               them off my chest.<br> </p>
               <p class="textParagraph"> A long curving gallery. From the floor ascend pillars of dark <br>
-              vapours. It is peopled by the images of fabulous kings, set in <span class="tag lineNumber">52675</span><br>
+              vapours. It is peopled by the images of fabulous kings, set in <br>
               stone. Their hands are folded upon their knees in token of <br>
               weariness and their eyes are darkened for the errors of men go <br>
               up before them for ever as dark vapours.<br> </p>
               <p class="textParagraph"> Strange figures advance from a cave. They are not as tall as <br>
-              men. One does not seem to stand quite apart from another. <span class="tag lineNumber">52680</span><br>
+              men. One does not seem to stand quite apart from another. <span class="tag lineNumber">2680</span><br>
               Their faces are phosphorescent, with darker streaks. They peer <br>
               at me and their eyes seem to ask me something. They do not <br>
               speak.<br> </p>
               <p class="textParagraph"> <span class="emph">30 March:</span> This evening Cranly was in the porch of the <br>
-              library, proposing a problem to Dixon and her brother. A <span class="tag lineNumber">52685</span><br>
+              library, proposing a problem to Dixon and her brother. A <br>
               mother let her child fall into the Nile. Still harping on the <br>
               mother. A crocodile seized the child. Mother asked it back. <br>
               Crocodile said all right if she told him what he was going to do <br>
               with the child, eat it or not eat it.<br> </p>
-              <p class="textParagraph"> This mentality, Lepidus would say, is indeed bred out of <span class="tag lineNumber">52690</span><br>
+              <p class="textParagraph"> This mentality, Lepidus would say, is indeed bred out of <span class="tag lineNumber">2690</span><br>
               your mud by the operation of your sun.<br> </p>
               <p class="textParagraph"> And mine? Is it not too? Then into Nilemud with it!<br> </p>
               <p class="textParagraph"> <span class="emph">1 April:</span> Disapprove of this last phrase.<br> </p>
               <p class="textParagraph"> <span class="emph">2 April:</span> Saw her drinking tea and eating cakes in Johnston, <br>
-              Mooney and O'Brien's. Rather, lynxeyed Lynch saw her as we <span class="tag lineNumber">52695</span><br>
+              Mooney and O'Brien's. Rather, lynxeyed Lynch saw her as we <br>
               passed. He tells me Cranly was invited there by brother. Did he <br>
               bring his crocodile? Is he the shining light now? Well, I dis- <br>
               covered him. I protest I did. Shining quietly behind a bushel of <span class="hide">52.979861 -6.048263</span> <br>
               Wicklow bran.<br> </p>
-              <p class="textParagraph"> <span class="emph">3 April:</span> Met Davin at the <span class="hide">53.353437 -6.261749</span>cigar shop opposite Findlater's <span class="tag lineNumber">52700</span><br>
+              <p class="textParagraph"> <span class="emph">3 April:</span> Met Davin at the <span class="hide">53.353437 -6.261749</span>cigar shop opposite Findlater's <span class="tag lineNumber">2700</span><br>
               church. He was in a black sweater and had a hurleystick. <br>
               Asked me was it true I was going away and why. Told him the <br>
               shortest way to <span class="hide">53.412910 -8.243890</span>Tara was <br>
               <span class="hide">53.309441 -4.633038</span>Holyhead. Just then my father
               came up. Introduction. Father polite and observant. Asked <br>
-              Davin if he might offer him some refreshment. Davin could <span class="tag lineNumber">52705</span><br>
+              Davin if he might offer him some refreshment. Davin could <br>
               not, was going to a meeting. When we came away father told <br>
               me he had a good honest eye. Asked me why I did not join a <br>
               rowing club. I pretended to think it over. Told me then how he <br>
               broke Pennyfeather's heart. Wants me to read law. Says I was <br>
-              cut out for that. More mud, more crocodiles.<span class="tag lineNumber">52710</span><br> </p>
+              cut out for that. More mud, more crocodiles.<span class="tag lineNumber">2710</span><br> </p>
               <p class="textParagraph"> <span class="emph">5 April:</span> Wild spring. Scudding clouds. O life! Dark stream of <br>
               swirling bogwater on which appletrees have cast down their <br>
               delicate flowers. Eyes of girls among the leaves. Girls demure <br>
               and romping. All fair or auburn: no dark ones. They blush <br>
-              better. Houp-la!<span class="tag lineNumber">52715</span><br> </p>
+              better. Houp-la!<br> </p>
               <p class="textParagraph"> <span class="emph">6 April:</span> Certainly she remembers the past. Lynch says all <br>
               women do. Then she remembers the time of her childhood – <br>
               and mine if I was ever a child. The past is consumed in the <br>
               present and the present is living only because it brings forth the <br>
-              future. Statues of women, if Lynch be right, should always be <span class="tag lineNumber">52720</span><br>
+              future. Statues of women, if Lynch be right, should always be <span class="tag lineNumber">2720</span><br>
               fully draped, one hand of the woman feeling regretfully her <br>
               own hinder parts.<br> </p>
               <p class="textParagraph"> <span class="emph">6 April: later:</span> Michael Robartes remembers forgotten beauty <br>
               and, when his arms wrap her round, he presses in his arms the <br>
-              loveliness which has long faded from the world. Not this. Not <span class="tag lineNumber">52725</span><br>
+              loveliness which has long faded from the world. Not this. Not <br>
               at all. I desire to press in my arms the loveliness which has not <br>
               yet come into the world.<br> </p>
               <p class="textParagraph"> 10 April:<span class="emph"></span> Faintly, under the heavy night, through  the silence <br>
               of the city which has turned from dreams to dreamless sleep as <br>
-              a weary lover whom no caresses move, the sound of hoofs <span class="tag lineNumber">52730</span><br>
+              a weary lover whom no caresses move, the sound of hoofs <span class="tag lineNumber">2730</span><br>
               upon the road. Not so faintly now as they come near the <br>
               bridge; and in a moment as they pass the darkened windows <br>
               the silence is cloven by alarm as by an arrow. They are heard <br>
               now far away, hoofs that shine amid the heavy  night as gems, <br>
-              hurrying beyond the sleeping fields to what journey's end – <span class="tag lineNumber">52735</span><br>
+              hurrying beyond the sleeping fields to what journey's end – <br>
               what heart? – bearing what tidings?<br> </p>
               <p class="textParagraph"> <span class="emph">11 April:</span> Read what I wrote last night. Vague words for a <br>
               vague emotion. Would she like it? I think so. Then I should <br>
               have to like it also.<br> </p>
-              <p class="textParagraph"> <span class="emph">13 April:</span> That tundish has been on my mind for a long time. <span class="tag lineNumber">52740</span><br>
+              <p class="textParagraph"> <span class="emph">13 April:</span> That tundish has been on my mind for a long time. <span class="tag lineNumber">2740</span><br>
               I looked it up and find it is English and good old blunt English <br>
               too. Damn the dean of studies and his funnel! What did he <br>
               come here for to teach us his own language or to learn it from <br>
               us. Damn him one way or the other!<br> </p>
-              <p class="textParagraph"> <span class="emph">14 April:</span> John Alphonsus Mulrennan has just returned from <span class="tag lineNumber">52745</span><br>
+              <p class="textParagraph"> <span class="emph">14 April:</span> John Alphonsus Mulrennan has just returned from <br>
               the west of Ireland (European and Asiatic papers please copy). <br>
               He told us he met an old man there in a mountain cabin. Old <br>
               man had red eyes and short pipe. Old man spoke Irish. <br>
               Mulrennan spoke Irish. Then old man and Mulrennan spoke <br>
-              English. Mulrennan spoke to him about universe and stars. Old <span class="tag lineNumber">52750</span><br>
+              English. Mulrennan spoke to him about universe and stars. Old <span class="tag lineNumber">2750</span><br>
               man sat, listened, smoked, spat. Then said: <br>
               <p class="dialog"><span class="tag dialog">???</span>―Ah, there must be terrible queer creatures at the latter end of <br>
               the world.<br></p> </p>
               <p class="textParagraph"> I fear him. I fear his redrimmed horny eyes. It is with him I <br>
-              must struggle all through this night till day come, till he or I lie <span class="tag lineNumber">52755</span><br>
+              must struggle all through this night till day come, till he or I lie <br>
               dead, gripping him by the sinewy throat till .... Till what? Till <br>
               he yield to me? No. I mean him no harm.<br> </p>
               <p class="textParagraph"> <span class="emph">15 April:</span> Met her today pointblank in <span class="hide">53.342556 -6.259573</span>Grafton Street. The <br>
               crowd brought us together. We both stopped. She asked me <br>
-              why I never came, said she had heard all sorts of stories about <span class="tag lineNumber">52760</span><br>
+              why I never came, said she had heard all sorts of stories about <span class="tag lineNumber">2760</span><br>
               me. This was only to gain time. Asked me was I writing poems. <br>
               About whom? I asked her. This confused her more and I felt <br>
               sorry and mean. Turned off that valve at once and opened the <br>
               spiritual-heroic refrigerating apparatus, invented and patented <br>
-              in all countries by Dante Alighieri. Talked rapidly of myself <span class="tag lineNumber">52765</span><br>
+              in all countries by Dante Alighieri. Talked rapidly of myself <br>
               and my plans. In the midst of it unluckily I made a sudden <br>
               gesture of a revolutionary nature. I must have looked like a <br>
               fellow throwing a handful of peas up into the air. People began <br>
               to look at us.  She shook hands a moment after and, in going <br>
-              away, said she hoped I would do what I said.<span class="tag lineNumber">52770</span><br> </p>
+              away, said she hoped I would do what I said.<span class="tag lineNumber">2770</span><br> </p>
               <p class="textParagraph"> Now I call that friendly, don't you?<br> </p>
               <p class="textParagraph"> Yes. I liked her today. A little or much? Don't know. I liked <br>
               her – and it seems a new feeling to me. Then, in that case, all <br>
               the rest, all that I thought I thought and all that I felt I felt, all <br>
-              the rest before now, in fact ...... O, give it up, old chap! Sleep it <span class="tag lineNumber">52775</span><br>
+              the rest before now, in fact ...... O, give it up, old chap! Sleep it <br>
               off!<br> </p>
               <p class="textParagraph"> <span class="emph">16 April:</span> Away! Away!<br> </p>
               <p class="textParagraph"> The spell of arms and voices: the white arms of roads, their <br>
               promise of close embraces and the black arms of tall ships that <br>
-              stand against the moon, their tale of distant nations. They are <span class="tag lineNumber">52780</span><br>
+              stand against the moon, their tale of distant nations. They are <span class="tag lineNumber">2780</span><br>
               held out to say: We are alone. Come. And the voices say with <br>
               them: We are your kinsmen.  And  the air is thick with their <br>
               company as they call to me, their kinsman, making ready to go, <br>
               shaking the wings of their exultant and terrible youth.<br> </p>
-              <p class="textParagraph"> <span class="emph">26 April:</span> Mother is putting my new secondhand clothes in <span class="tag lineNumber">52785</span><br>
+              <p class="textParagraph"> <span class="emph">26 April:</span> Mother is putting my new secondhand clothes in <br>
               order. She prays now, she says, that I may learn in my own life <br>
               and away from home and friends what the heart is and what it <br>
               feels. Amen. So be it. Welcome, O life! I go to encounter for the <br>
               millionth time the reality of experience and to forge in the <br>
-              smithy of my soul the uncreated conscience of my race.<span class="tag lineNumber">52790</span><br> </p>
+              smithy of my soul the uncreated conscience of my race.<span class="tag lineNumber">2790</span><br> </p>
               <p class="textParagraph"> <span class="emph">27 April:</span> Old father, old artificer, stand me now and ever in <br>
               good stead.<br> </p>
               <p class="textParagraph"> <span class="hide">53.342556 -6.259573</span>Dublin1904<br> </p>

--- a/portrait.xsl
+++ b/portrait.xsl
@@ -1,14 +1,14 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"> 
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
-<xsl:template match="/"> 
+<xsl:template match="/">
 	<html>
-		<head> 
+		<head>
 		<link rel="stylesheet" href="portrait.css" />
 		<link href='https://fonts.googleapis.com/css?family=Droid+Serif' rel='stylesheet' type='text/css'/>
 		<script src="vendor/jquery-2.1.4.min.js"></script>
 		<script src="portrait.js"></script>
-		</head> 
+		</head>
 		<body>
 			<h1 class="mainTitle"><em>A Portrait of the Artist as a Young Man</em></h1>
 			<h2 class="mainTitle">James Joyce</h2>
@@ -19,11 +19,11 @@
 				<input type="checkbox" id="type" name="type" value="" checked="checked"/>Text genre (poem, song, prayer)<br/>
 				<input type="checkbox" id="lang" name="lang" value="" checked="checked"/>Language<br/>
 				<input type="checkbox" id="lineNumber" name="lineNumber" value="" checked="checked"/>Line numbers
-			</div> 
+			</div>
 			<xsl:apply-templates/>
 		</body>
 	</html>
-</xsl:template> 
+</xsl:template>
 
 <xsl:template match="TEI/teiHeader">
 	<div id="metadata">
@@ -44,11 +44,11 @@
 
 <xsl:template match="lb">
 	<xsl:apply-templates/>
-  <xsl:if test="@n mod 5 = 0" > 
+  <xsl:if test="@n mod 10 = 0" >
     <span class="tag lineNumber">
-      <xsl:value-of select="@n" />
+      <xsl:value-of select="number(substring(@n, 2))" />
     </span>
-  </xsl:if> 
+  </xsl:if>
   <br/>
 </xsl:template>
 
@@ -70,9 +70,9 @@
 	<h2 class="heading"><xsl:apply-templates/></h2>
 </xsl:template>
 
-<!-- Match <milestone unit="section" rend="asterixes"/> --> 
+<!-- Match <milestone unit="section" rend="asterixes"/> -->
 <xsl:template match="milestone">
-  <div class="divider">* * *</div> 
+  <div class="divider">* * *</div>
 </xsl:template>
 
 <xsl:template match="said">
@@ -86,7 +86,7 @@
 	<span class="tag dialog">
 		<xsl:value-of select="."/>
 	</span>
-</xsl:template> 
+</xsl:template>
 
 <xsl:template match="quote/ref">
   <span class="hide"><xsl:apply-templates/></span>
@@ -101,18 +101,18 @@
 <xsl:template match="@xml:lang">
 	<span class="tag lang">
 		<xsl:choose>
-			<xsl:when test=".='la'"> 
+			<xsl:when test=".='la'">
 				Latin
 			</xsl:when>
-			<xsl:when test=".='fr'"> 
+			<xsl:when test=".='fr'">
 				French
 			</xsl:when>
 			<xsl:otherwise>
 				<xsl:value-of select="."/>
 			</xsl:otherwise>
-		</xsl:choose> 
+		</xsl:choose>
 	</span>
-</xsl:template> 
+</xsl:template>
 
 <xsl:template match="lg[@type]">
 	<p class="lg">
@@ -124,7 +124,7 @@
 	<span class="tag type">
 		<xsl:value-of select="."/>
 	</span>
-</xsl:template> 
+</xsl:template>
 
 <!--<xsl:template match="TEI/teiHeader/fileDesc/titleStmt">-->
 	<!--<h1 id="bookTitle">-->
@@ -170,4 +170,4 @@
 	<!--</div>-->
 <!--</xsl:template>-->
 
-</xsl:stylesheet> 
+</xsl:stylesheet>


### PR DESCRIPTION
Only display line numbers in multiples of 10

Fixes #73
Fixes #74 

The relevant changes are at line 47 and line 49. Sorry about the whitespace commit noise -- my editor strips trailing whitespace automatically. I can resubmit with that setting turned off if it's a bother.

Lemme know what you think! Hopefully this works better than modifying the XML :)