### PR TITLE
standardized <geo> contents formatting, fixed tag caps

### DIFF
--- a/portrait.xml
+++ b/portrait.xml
@@ -35,7 +35,7 @@
         <availability n="OTA-new" status="free" rend="visible">
           <licence target="http://creativecommons.org/licenses/by-nc-sa/3.0/">
             Distributed by the University of Oxford under a Creative Commons
-            Attribution-NonCommercial-ShareAlike 3.0 Unported License. 
+            Attribution-NonCommercial-ShareAlike 3.0 Unported License.
           </licence>
         </availability>
       </publicationStmt>
@@ -791,7 +791,7 @@
             <p> <persName> Stephen </persName> thought what could be the answer and then said:<lb n="10648"/> </p>
             <p> <said who="Stephen">―I give it up. <lb n="10649"/></said> </p>
             <p><said who="Athy">―Because there is a thigh in it,</said> he said. <said who="Athy">Do you see the joke? <lb n="10650"></lb>
-            <placename> <persname> Athy </persname> </placename> is the town in the county <placename> Kildare </placename> and a thigh is the other <lb n="10651"></lb>
+            <placeName> <persName> Athy </persName> </placeName> is the town in the county <placeName> Kildare </placeName> and a thigh is the other <lb n="10651"></lb>
             thigh. <lb n="10652"></lb></said></p>
             <p> <said who="Stephen">―O, I see, <persName> Stephen </persName> said. <lb n="10653"/></said> </p>
             <p><said who="Athy">―That's an old riddle,</said> he said. <lb n="10654"></lb></p>
@@ -858,8 +858,8 @@
              silently past the people who knelt by the waters' edge.<lb n="10715"/> </p>
 
             <milestone unit="section" rend="asterixes"/>
-        </div> <!-- 1.2 --> 
-        <div n="1.3" type="section"> 
+        </div> <!-- 1.2 -->
+        <div n="1.3" type="section">
             <p>  A great fire, banked high and red, flamed in the grate and <lb n="10716"/>
              under the <seg type="neologism">ivytwined</seg> branches of the chandelier the Christmas <lb n="10717"/>
              table was spread. They had come home a little late and still <lb n="10718"/>
@@ -901,7 +901,7 @@
              see how much he had poured in. Then replacing the jar in the <lb n="10754"/>
              locker he poured out a little of the whisky into two glasses, <lb n="10755"/>
              added a little water and came with them back to the fireplace. <lb n="10756"/>
-             <said who="Simon Dedalus">―A thimbleful, <persname>John</persname>,</said> he said. <said who="Simon Dedalus">Just to whet your appetite. <lb n="10757"></lb></said></p>
+             <said who="Simon Dedalus">―A thimbleful, <persName>John</persName>,</said> he said. <said who="Simon Dedalus">Just to whet your appetite. <lb n="10757"></lb></said></p>
             <p>  <persName>Mr Casey</persName> took the glass, drank, and placed it near him on <lb n="10758"/>
              the mantelpiece. Then he said: <lb n="10759"/>
              <said who="John Casey">―Well, I can't help thinking of our friend <persName>Christopher</persName> manu- <lb n="10760"/>
@@ -909,7 +909,7 @@
             <p>  He broke into a fit of laughter and coughing and added: <lb n="10762"/>
              <said who="John Casey">―... manufacturing that champagne for those fellows. <lb n="10763"/></said> </p>
             <p><persName>Mr Dedalus</persName> laughed loudly. <lb n="10764"/>
-              <said who="Simon Dedalus">―Is it <persname>Christy</persname>?</said> he said. <said who="Simon Dedalus">There's more cunning in one of those <lb n="10765"></lb>
+              <said who="Simon Dedalus">―Is it <persName>Christy</persName>?</said> he said. <said who="Simon Dedalus">There's more cunning in one of those <lb n="10765"></lb>
             warts on his bald head than in a pack of jack foxes. <lb n="10766"></lb></said></p>
             <p>  He inclined his head, closed his eyes, and, licking his lips <lb n="10767"/>
              profusely, began to speak with the voice of the hotel keeper. <lb n="10768"/>
@@ -1068,7 +1068,7 @@
              where there is no respect for the pastors of the church. <lb n="10921"/></said> </p>
             <p>  Mr Dedalus threw his knife and fork noisily on his plate. <lb n="10922"/>
               <said who="Simon Dedalus">―Respect!</said> he said. <said who="Simon Dedalus">Is it for Billy with the lip or for the tub of <lb n="10923"></lb>
-             guts up in <place><location><geo>54.350280 -6.652792</geo></location><placename>Armagh</placename></place>? Respect! <lb n="10924"></lb> </said>
+             guts up in <place><location><geo>54.350280 -6.652792</geo></location><placeName>Armagh</placeName></place>? Respect! <lb n="10924"></lb> </said>
              <said who="John Casey">―Princes of the church, said Mr Casey with slow scorn. <lb n="10925"/> </said>
              <said who="Simon Dedalus">―Lord Leitrim's coachman, yes, said Mr Dedalus. <lb n="10926"/> </said>
              <said who="Dante">―They are the Lord's anointed,</said> Dante said. <said who="Dante">They are an hon- <lb n="10927"/>
@@ -1300,8 +1300,8 @@
             <p>  He sobbed loudly and bitterly.<lb n="11149"/> </p>
             <p>  Stephen, raising his <seg type="neologism">terrorstricken</seg> face, saw that his father's <lb n="11150"/>
              eyes were full of tears.<lb n="11151"/> </p>
-        <milestone unit="section" rend="asterixes"/> 
-        </div> <!-- 1.3 --> 
+        <milestone unit="section" rend="asterixes"/>
+        </div> <!-- 1.3 -->
         <div n="1.4" type="section">
             <p>  The fellows talked together in little groups.<lb n="11152"/> </p>
             <p>  One fellow said: <lb n="11153"/>
@@ -1468,7 +1468,7 @@
              fellows are wrong because a flogging wears off after a bit but a <lb n="11314"/>
              fellow that has been expelled from college is known all his life <lb n="11315"/>
              on  account of it. Besides Gleeson won't flog him hard. <lb n="11316"/> </said>
-            <said who="Fleming">―It's best of his play not to,</said> Fleming said. <lb n="11317"/> 
+            <said who="Fleming">―It's best of his play not to,</said> Fleming said. <lb n="11317"/>
              <said who="Cecil Thunder">―I wouldn't like to be Simon Moonan and Tusker,</said> Cecil <lb n="11318"/>
              Thunder said. <said who="Cecil Thunder">But I don't believe they will be flogged. Perhaps <lb n="11319"/>
              they will be sent up for twice nine. <lb n="11320"/> </said>
@@ -1671,7 +1671,7 @@
             <p>  Stephen stumbled into the middle of the class, blinded by <lb n="11513"/>
              fear and haste. <lb n="11514"/>
              <said who="Father Dolan">―Where did you break your glasses?</said> repeated the prefect of <lb n="11515"/>
-             studies. <lb n="11516"/> 
+             studies. <lb n="11516"/>
              <said who="Stephen">―The <seg type="neologism">cinderpath</seg>, sir. <lb n="11517"/> </said>
              <said who="Father Dolan">―Hoho! The <seg type="neologism">cinderpath</seg>!</said> cried the prefect of studies. <said who="Father Dolan">I know <lb n="11518"/>
              that trick. <lb n="11519"/></said> </p>
@@ -2006,11 +2006,11 @@
              the sound of the cricket bats: pick, pack, pock, puck: like drops <lb n="11847"/>
              of water in a fountain falling softly in the brimming bowl.<lb n="11848"/> </p>
 
-        </div><!-- 1.4 --> 
+        </div><!-- 1.4 -->
 
-      </div><!-- Chapter 1 --> 
+      </div><!-- Chapter 1 -->
 
-      <div n="2" type="chapter"> 
+      <div n="2" type="chapter">
         <div n="2.1" type="section">
           <head><l>II</l></head>
           <p>  Uncle Charles smoked such black twist that at last his out- <lb n="20001"/>
@@ -2039,7 +2039,7 @@
           Charles was Stephen's constant companion. Uncle Charles was <lb n="20024"/>
           a hale old man with a well tanned skin, rugged features and <lb n="20025"/>
           white side whiskers. On week days he did messages between <lb n="20026"/>
-          the house in <place><location><geo>53.293248, -6.180109</geo></location><placeName>Carysfort Avenue</placeName></place> and those shops in the main <lb n="20027"/>
+          the house in <place><location><geo>53.293248 -6.180109</geo></location><placeName>Carysfort Avenue</placeName></place> and those shops in the main <lb n="20027"/>
           street of the town with which the family dealt. Stephen was <lb n="20028"/>
           glad to go with him on these errands for uncle Charles helped <lb n="20029"/>
           him very liberally to handfuls of whatever was exposed in open <lb n="20030"/>
@@ -2088,11 +2088,11 @@
           <p>  On Sundays Stephen with his father and his granduncle took <lb n="20073"/>
           their constitutional. The old man was a nimble walker in spite <lb n="20074"/>
           of his corns and often ten or twelve miles of the road were <lb n="20075"/>
-          covered. The little village of <place><location><geo>53.287857, -6.203573</geo></location><placeName>Stillorgan</placeName></place> was the parting of the <lb n="20076"/>
+          covered. The little village of <place><location><geo>53.287857 -6.203573</geo></location><placeName>Stillorgan</placeName></place> was the parting of the <lb n="20076"/>
           ways. Either they went to the left towards the Dublin moun- <lb n="20077"/>
-          tains or along the <place><location><geo>53.297702, -6.233964</geo></location><placeName>Goatstown road</placeName></place> and thence <lb n="20078"/>
-          into <place><location><geo>53.289154, -6.243264</geo></location><placeName>Dundrum</placeName></place>,
-          coming home by  <place><location><geo>53.269979, -6.224923</geo></location><placeName>Sandyford</placeName></place>. Trudging along the road or <lb n="20079"/>
+          tains or along the <place><location><geo>53.297702 -6.233964</geo></location><placeName>Goatstown road</placeName></place> and thence <lb n="20078"/>
+          into <place><location><geo>53.289154 -6.243264</geo></location><placeName>Dundrum</placeName></place>,
+          coming home by  <place><location><geo>53.269979 -6.224923</geo></location><placeName>Sandyford</placeName></place>. Trudging along the road or <lb n="20079"/>
           standing in some grimy wayside publichouse his elders spoke <lb n="20080"/>
           constantly of the subjects nearest their hearts, of Irish politics, <lb n="20081"/>
           of Munster and of the legends of their own family, to all of <lb n="20082"/>
@@ -2112,9 +2112,8 @@
           paper and strips of the silver and golden paper in which choc- <lb n="20096"/>
           olate is wrapped. When he had broken up this scenery, weary <lb n="20097"/>
           of its tinsel, there would come to his mind the bright picture of <lb n="20098"/>
-           <place><location><geo>43.295207, <lb n="20099"/>
-          5.364077</geo></location><placeName>Marseilles</placeName></place>, of sunny trellisses and of Mercedes. Outside <place><location><geo>53.300907,
-          -6.177049</geo></location><placeName>Black-
+           <place><location><geo>43.295207 <lb n="20099"/>
+          5.364077</geo></location><placeName>Marseilles</placeName></place>, of sunny trellisses and of Mercedes. Outside <place><location><geo>53.300907 -6.177049</geo></location><placeName>Black-
            rock</placeName></place>, on the road that led to the mountains, stood a small <lb n="20100"/>
           whitewashed house in the garden of which grew many rose- <lb n="20101"/>
           bushes: and in this house, he told himself, another Mercedes <lb n="20102"/>
@@ -2141,7 +2140,7 @@
           in their nostrils and the rank oils of the seawrack upon their <lb n="20123"/>
           hands and in their hair.<lb n="20124"/> </p>
           <p>  Aubrey and Stephen had a common milkman and often they <lb n="20125"/>
-          drove out in the milkcar to <place><location><geo>53.250224, -6.179926</geo></location><placeName>Carrickmines</placeName></place> where the cows were <lb n="20126"/>
+          drove out in the milkcar to <place><location><geo>53.250224 -6.179926</geo></location><placeName>Carrickmines</placeName></place> where the cows were <lb n="20126"/>
           at grass. While the men were milking the boys would take turns <lb n="20127"/>
           in riding the tractable mare round the field. But when autumn <lb n="20128"/>
           came the cows were driven home from the grass: and the first <lb n="20129"/>
@@ -2151,7 +2150,7 @@
           tiful in the country on sunny days revolted him and he could <lb n="20133"/>
           not even look at the milk they yielded.<lb n="20134"/> </p>
           <p>  The coming of September did not trouble him this year for <lb n="20135"/>
-          he knew he was not to be sent back to <place><location><geo>53.310770, -6.684719</geo></location><placeName>Clongowes</placeName></place>. The practice <lb n="20136"/>
+          he knew he was not to be sent back to <place><location><geo>53.310770 -6.684719</geo></location><placeName>Clongowes</placeName></place>. The practice <lb n="20136"/>
           in the park came to an end when Mike Flynn went into hospi- <lb n="20137"/>
           tal. Aubrey was at school and had only an hour or two free in <lb n="20138"/>
           the evening. The gang fell asunder and there were no more <lb n="20139"/>
@@ -2172,7 +2171,7 @@
           stubblecovered face as it bent heavily over his long stained <lb n="20154"/>
           fingers, dissipated any vision of the future. In a vague way he <lb n="20155"/>
           understood that his father was in trouble and that this was the <lb n="20156"/>
-          reason why he himself had not been sent back to <place><location><geo>53.310770, -6.684719</geo></location><placeName>Clongowes</placeName></place>. <lb n="20157"/>
+          reason why he himself had not been sent back to <place><location><geo>53.310770 -6.684719</geo></location><placeName>Clongowes</placeName></place>. <lb n="20157"/>
           For some time he had felt the slight changes in his house; and <lb n="20158"/>
           these changes in what he had deemed unchangeable were so <lb n="20159"/>
           many slight shocks to his boyish conception of the world. The <lb n="20160"/>
@@ -2188,7 +2187,7 @@
           kindly lights in the windows poured a tender influence into his <lb n="20170"/>
           restless heart. The noise of children at play annoyed him and <lb n="20171"/>
           their silly voices made him feel, even more keenly than he had <lb n="20172"/>
-          felt at <place><location><geo>53.310770, -6.684719</geo></location><placeName>Clongowes</placeName></place>, that he was different from others. He did <lb n="20173"/>
+          felt at <place><location><geo>53.310770 -6.684719</geo></location><placeName>Clongowes</placeName></place>, that he was different from others. He did <lb n="20173"/>
           not want to play. He wanted to meet in the real world the <lb n="20174"/>
           unsubstantial image which his soul so constantly beheld. He <lb n="20175"/>
           did not know where to seek it or how: but a premonition which <lb n="20176"/>
@@ -2225,7 +2224,7 @@
           and that some fight was going to take place. He felt, too, that <lb n="20204"/>
           he was being enlisted for the fight, that some duty was being <lb n="20205"/>
           laid upon his shoulders. The sudden flight from the comfort <lb n="20206"/>
-          and revery of <place><location><geo>53.300907, -6.177049</geo></location><placeName>Blackrock</placeName></place>, the passage through the gloomy foggy <lb n="20207"/>
+          and revery of <place><location><geo>53.300907 -6.177049</geo></location><placeName>Blackrock</placeName></place>, the passage through the gloomy foggy <lb n="20207"/>
           city, the thought of the bare cheerless house in which they were <lb n="20208"/>
           now to live made his heart heavy: and again an intuition or <lb n="20209"/>
           foreknowledge of the future came to him. He understood also <lb n="20210"/>
@@ -2237,10 +2236,10 @@
           said Mr Dedalus, poking at the dull fire with fierce energy. <lb n="20216"/>
           We're not dead yet, sonny. No, by the Lord Jesus (God forgive <lb n="20217"/>
           me) nor half dead. <lb n="20218"/></said> </p>
-          <p>  <place><location><geo>53.349307, -6.263654</geo></location><placeName>Dublin</placeName></place> was a new and complex sensation. Uncle Charles <lb n="20219"/>
+          <p>  <place><location><geo>53.349307 -6.263654</geo></location><placeName>Dublin</placeName></place> was a new and complex sensation. Uncle Charles <lb n="20219"/>
           had grown so witless that he could no longer be sent out on <lb n="20220"/>
           errands and the disorder in settling in the new house left Ste- <lb n="20221"/>
-          phen freer than he had been in <place><location><geo>53.300907, -6.177049</geo></location><placeName>Blackrock</placeName></place>. In the beginning he <lb n="20222"/>
+          phen freer than he had been in <place><location><geo>53.300907 -6.177049</geo></location><placeName>Blackrock</placeName></place>. In the beginning he <lb n="20222"/>
           contented himself with circling timidly round the neighbouring <lb n="20223"/>
           square or, at most, going half way down one of the side streets: <lb n="20224"/>
           but when he had made a skeleton map of the city in his mind he <lb n="20225"/>
@@ -2255,7 +2254,7 @@
           wakened again in him the unrest which had sent him wan- <lb n="20234"/>
           dering in the evening from garden to garden in search of <lb n="20235"/>
           Mercedes. And amid this new bustling life he might have <lb n="20236"/>
-          fancied himself in another <place><location><geo>43.295207, 5.364077</geo></location><placeName>Marseilles</placeName></place> but that he missed the <lb n="20237"/>
+          fancied himself in another <place><location><geo>43.295207 5.364077</geo></location><placeName>Marseilles</placeName></place> but that he missed the <lb n="20237"/>
           bright sky and the sunwarmed trellisses of the wineshops. A <lb n="20238"/>
           vague dissatisfaction grew up within him as he looked on the <lb n="20239"/>
           quays and on the river and on the lowering skies and yet he <lb n="20240"/>
@@ -2321,7 +2320,7 @@
            <said who="Ellen">―I thought it was Josephine. I thought you were Josephine, <lb n="20300"/>
           Stephen.<lb n="20301"/></said> </p>
           <p>  And, repeating this several times, she fell to laughing feebly.<lb n="20302"/> </p>
-          <p>  He was sitting in the midst of a children's party at <place><location><geo>53.324608, <lb n="20303"/>
+          <p>  He was sitting in the midst of a children's party at <place><location><geo>53.324608 <lb n="20303"/>
           -6.281580</geo></location><placeName>Harold's
            Cross</placeName></place>. His silent watchful manner had grown upon him and he <lb n="20304"/>
           took little part in the games. The children, wearing the spoils of <lb n="20305"/>
@@ -2416,7 +2415,7 @@
           his father's return for there had been mutton hash that day and <lb n="20394"/>
           he knew that his father would make him dip his bread in the <lb n="20395"/>
           gravy. But he did not relish the hash for the mention of <lb n="20396"/>
-           <place><location><geo>53.310770, -6.684719</geo></location><placeName>Clongowes</placeName></place> had coated his palate with a scum of disgust. <lb n="20397"/>
+           <place><location><geo>53.310770 -6.684719</geo></location><placeName>Clongowes</placeName></place> had coated his palate with a scum of disgust. <lb n="20397"/>
            <said who="Simon Dedalus">―I walked bang into him, said Mr Dedalus for the fourth <lb n="20398"/>
           time, just at the corner of the square.<lb n="20399"/> </said>
            <said who="Mary Dedalus">―Then I suppose, said Mrs Dedalus, he will be able to arrange <lb n="20400"/>
@@ -2432,7 +2431,7 @@
           position.<lb n="20410"/> </said>
            <said who="Mary Dedalus">―And they're a very rich order, aren't they, Simon? <lb n="20411"/> </said>
            <said who="Simon Dedalus">―Rather. They live well, I tell you. You saw their table at <lb n="20412"/>
-           <place><location><geo>53.310770, -6.684719</geo></location><placeName>Clongowes</placeName></place>. Fed up, by God, like gamecocks. <lb n="20413"/></said> </p>
+           <place><location><geo>53.310770 -6.684719</geo></location><placeName>Clongowes</placeName></place>. Fed up, by God, like gamecocks. <lb n="20413"/></said> </p>
           <p>  Mr Dedalus pushed his plate over to Stephen and bade him <lb n="20414"/>
           finish what was on it. <lb n="20415"/>
               <said who="Simon Dedalus">―Now then, Stephen,</said> he said. <said who="Simon Dedalus">You must put your shoulder to <lb n="20416"></lb>
@@ -2475,8 +2474,8 @@
           <p>  He reassumed the provincial's voice and repeated: <lb n="20453"/>
            <said who="Simon Dedalus">―<emph>I told them all at dinner about it and Father Dolan and I and <lb n="20454"/>
           all of us we all had a hearty laugh together over it. Ha! Ha! Ha!</emph><lb n="20455"/></said> </p>
-          <milestone unit="section" rend="asterixes"/> 
-        </div> <!-- 2.2 --> 
+          <milestone unit="section" rend="asterixes"/>
+        </div> <!-- 2.2 -->
         <div n="2.3" type="section">
           <p>  The night of the Whitsuntide play had come and Stephen <lb n="20456"/>
           from the window of the dressingroom looked out on  the small <lb n="20457"/>
@@ -2638,7 +2637,7 @@
           these indelicate allusions in the hearing of a stranger. For him <lb n="20611"/>
           there was nothing amusing in a girl's interest and regard. All <lb n="20612"/>
           day he had thought of nothing but their leavetaking on the <lb n="20613"/>
-          steps of the tram at <place><location><geo>53.324608, -6.281580</geo></location><placeName>Harold's Cross</placeName></place>, the stream of moody <lb n="20614"/>
+          steps of the tram at <place><location><geo>53.324608 -6.281580</geo></location><placeName>Harold's Cross</placeName></place>, the stream of moody <lb n="20614"/>
           emotions it had made to course through him and the poem he <lb n="20615"/>
           had written about it. All day he had imagined a new meeting <lb n="20616"/>
           with her for he knew that she was to come to the play. The old <lb n="20617"/>
@@ -2681,7 +2680,7 @@
           he was in number six. His sensitive nature was still smarting <lb n="20654"/>
           under the lashes of an undivined and squalid way of life. His <lb n="20655"/>
           soul was still disquieted and cast down by the dull phenom- <lb n="20656"/>
-          enon of <place><location><geo>53.349307, -6.263654</geo></location><placeName>Dublin</placeName></place>. He had emerged from a two years' spell of <lb n="20657"/>
+          enon of <place><location><geo>53.349307 -6.263654</geo></location><placeName>Dublin</placeName></place>. He had emerged from a two years' spell of <lb n="20657"/>
           revery to find himself in the midst of a new scene, every event <lb n="20658"/>
           and figure of which affected him intimately, disheartened him <lb n="20659"/>
           or allured him and, whether alluring or disheartening, filled <lb n="20660"/>
@@ -2725,7 +2724,7 @@
           spoke to him of the affair after class he could feel about him a <lb n="20698"/>
           vague general malignant joy.<lb n="20699"/> </p>
           <p>  A few nights after this public chiding  he was walking with a <lb n="20700"/>
-          letter along the <place><location><geo>53.36324, -6.25800</geo></location><placeName>Drumcondra Road</placeName></place> when he heard a voice cry: <lb n="20701"/>
+          letter along the <place><location><geo>53.36324 -6.25800</geo></location><placeName>Drumcondra Road</placeName></place> when he heard a voice cry: <lb n="20701"/>
            <said who="Heron">―Halt! <lb n="20702"/></said> </p>
           <p>  He turned and saw three boys of his own class coming to- <lb n="20703"/>
           wards him in the dusk. It was Heron who had called out and, <lb n="20704"/>
@@ -2734,7 +2733,7 @@
           his friend, marched beside him, a large grin on his face, while <lb n="20707"/>
           Nash came on a few steps behind, blowing from the pace and <lb n="20708"/>
           wagging his great red head.<lb n="20709"/> </p>
-          <p>  As soon as the boys had turned into <place><location><geo>53.362304, -6.249867</geo></location><placeName>Clonliffe Road</placeName></place>together <lb n="20710"/>
+          <p>  As soon as the boys had turned into <place><location><geo>53.362304 -6.249867</geo></location><placeName>Clonliffe Road</placeName></place>together <lb n="20710"/>
           they began to speak about books and writers, saying what <lb n="20711"/>
           books they were reading and how many books there were in <lb n="20712"/>
           their fathers' bookcases at home. Stephen listened to them in <lb n="20713"/>
@@ -2748,7 +2747,7 @@
            <said who="Stephen Dedalus">―Of prose, do you mean? <lb n="20721"/> </said>
            <said who="Heron">―Yes.<lb n="20722"/> </said>
            <said who="Stephen Dedalus">―Newman, I think. <lb n="20723"/> </said>
-           <said who="Boland">―Is it Cardinal Newman?</said> asked Boland. <lb n="20724"/> 
+           <said who="Boland">―Is it Cardinal Newman?</said> asked Boland. <lb n="20724"/>
            <said who="Stephen Dedalus">―Yes</said>, answered Stephen. <lb n="20725"/></p>
           <p>  The grin broadened on Nash's freckled face as he turned to <lb n="20726"/>
           Stephen and said: <lb n="20727"/>
@@ -2757,7 +2756,7 @@
           Heron said to the other two in explanation. <said who="Heron">Of course, he's not <lb n="20730"/>
           a poet. <lb n="20731"/> </said>
            <said who="Boland">―And who is the best poet, Heron?</said> asked Boland. <lb n="20732"/>
-           <said who="Heron">―Lord Tennyson, of course</said>, answered Heron. <lb n="20733"/> 
+           <said who="Heron">―Lord Tennyson, of course</said>, answered Heron. <lb n="20733"/>
            <said who="Nash">―O, yes, Lord Tennyson</said>, said Nash. <said who="Nash">We have all his poetry at <lb n="20734"/>
           home in a book. <lb n="20735"/></said> </p>
           <p>  At this Stephen forgot the silent vows he had been making <lb n="20736"/>
@@ -2815,7 +2814,7 @@
            <said who="Heron">―Admit.<lb n="20786"/> </said>
            <said who="Stephen Dedalus">―No. No. <lb n="20787"/></said> </p>
           <p>  At last after a fury of plunges he wrenched himself free. His <lb n="20788"/>
-          tormentors set off towards <place><location><geo>53.360891, -6.251230</geo></location><placeName>Jones's Road</placeName></place>, laughing and jeering <lb n="20789"/>
+          tormentors set off towards <place><location><geo>53.360891 -6.251230</geo></location><placeName>Jones's Road</placeName></place>, laughing and jeering <lb n="20789"/>
           at him, while he, }omit{ half blinded with tears, stumbled on, clench- <lb n="20790"/>
           ing his fists madly and sobbing.<lb n="20791"/> </p>
           <p>  While he was still repeating the <seg xml:lang="la">Confiteor</seg> amid the indul- <lb n="20792"/>
@@ -2826,7 +2825,7 @@
           cowardice and cruelty but the memory of it called forth no <lb n="20797"/>
           anger from him. All the descriptions of fierce love and hatred <lb n="20798"/>
           which he had met in books had  seemed to him therefore unreal. <lb n="20799"/>
-          Even that night as he stumbled homewards along <place><location><geo>53.360891, -6.251230</geo></location><placeName>Jones's Road</placeName></place> <lb n="20800"/>
+          Even that night as he stumbled homewards along <place><location><geo>53.360891 -6.251230</geo></location><placeName>Jones's Road</placeName></place> <lb n="20800"/>
           he had felt that some power was divesting him of that sudden- <lb n="20801"/>
           woven anger as easily as a fruit is divested of her soft ripe peel.<lb n="20802"/> </p>
           <p>  He remained standing with his two companions at the end <lb n="20803"/>
@@ -2899,7 +2898,7 @@
           <p>  As he watched this swaying form and tried to read for him- <lb n="20870"/>
           self the legend of the priest's mocking smile there came into <lb n="20871"/>
           Stephen's memory a saying which he had heard from his father <lb n="20872"/>
-          before he had been sent to <place><location><geo>53.310770, -6.684719</geo></location><placeName>Clongowes</placeName></place>, that you could always <lb n="20873"/>
+          before he had been sent to <place><location><geo>53.310770 -6.684719</geo></location><placeName>Clongowes</placeName></place>, that you could always <lb n="20873"/>
           tell a jesuit by the style of his clothes. At the same moment he <lb n="20874"/>
           thought he saw a likeness between his father's mind and that of <lb n="20875"/>
           this smiling welldressed priest: and he was aware of some des- <lb n="20876"/>
@@ -2972,14 +2971,14 @@
           <p> ―That is horse piss and rotted straw, he thought. It is a good <lb n="20943"/>
           odour to breathe. It will calm my heart. My heart is quite calm <lb n="20944"/>
           now. I will go back.<lb n="20945"/> </p>
-      <milestone unit="section" rend="asterixes"/> 
-      </div> <!-- 2.3 --> 
+      <milestone unit="section" rend="asterixes"/>
+      </div> <!-- 2.3 -->
       <div n="2.4" type="section">
           <p>  Stephen was once again seated beside his father in the corner <lb n="20946"/>
           of a railway carriage at Kingsbridge. He was travelling with his <lb n="20947"/>
           father by the night mail to Cork. As the train steamed out of <lb n="20948"/>
           the station he recalled his childish wonder of years before and <lb n="20949"/>
-          every event of his first day at <place><location><geo>53.310770, -6.684719</geo></location><placeName>Clongowes</placeName></place>. But he felt no wonder <lb n="20950"/>
+          every event of his first day at <place><location><geo>53.310770 -6.684719</geo></location><placeName>Clongowes</placeName></place>. But he felt no wonder <lb n="20950"/>
           now. He saw the darkening lands slipping past him, the silent <lb n="20951"/>
           telegraphpoles passing his window swiftly every four seconds, <lb n="20952"/>
           the little glimmering stations, manned by a few silent sentries, <lb n="20953"/>
@@ -3192,7 +3191,7 @@
           and Simon. Simon and Stephen and Victoria. Names.<lb n="21155"/> </p>
           <p>  The memory of his childhood suddenly grew dim. He tried <lb n="21156"/>
           to call forth some of its vivid moments but could not. He <lb n="21157"/>
-          recalled only names: Dante, Parnell, Clane, <place><location><geo>53.310770, -6.684719</geo></location><placeName>Clongowes</placeName></place>. A little <lb n="21158"/>
+          recalled only names: Dante, Parnell, Clane, <place><location><geo>53.310770 -6.684719</geo></location><placeName>Clongowes</placeName></place>. A little <lb n="21158"/>
           boy had been taught geography by an old woman who kept <lb n="21159"/>
           two brushes in her wardrobe. Then he had been sent away <lb n="21160"/>
           from home to a college. In the college he had made his first <lb n="21161"/>
@@ -3735,8 +3734,8 @@
           <p> In the silence their dark fire kindled the dusk into a tawny <lb n="30228"/>
           glow. Stephen's heart had withered up like a flower of the <lb n="30229"/>
           desert that feels the simoom  coming from afar.<lb n="30230"/> </p>
-        <milestone unit="section" rend="asterixes"/> 
-        </div> <!-- 3.1 --> 
+        <milestone unit="section" rend="asterixes"/>
+        </div> <!-- 3.1 -->
         <div n="3.2" type="section">
             <p> <said who="Father Arnall">―<emph>Remember only thy last things and thou shalt not sin for</emph> <lb n="30231"/>
             <emph>ever</emph> – words taken, my dear little brothers in Christ, from the <lb n="30232"/>
@@ -5715,7 +5714,7 @@
             <emph>giving utterance, like the voice of Nature herself, to that pain <lb n="40603"/>
             and weariness yet hope of better things which has been the <lb n="40604"/>
             experience of her children in every time.</emph><lb n="40605"/> </p>
-        <milestone unit="section" rend="asterixes"/> 
+        <milestone unit="section" rend="asterixes"/>
         </div> <!-- 4.2 -->
         <div n="4.3" type="section">
             <p> He could wait no longer.<lb n="40606"/> </p>
@@ -6534,8 +6533,8 @@
             reflector hung in a false focus. What lay behind it or within it? <lb n="50489"/>
             A dull torpor of the soul or the dullness of the thundercloud, <lb n="50490"/>
             charged with intellection and capable of the gloom of God? <lb n="50491"/>
-            <said who="Stephen Dedalus">―I meant a different kind of lamp, sir,</said> said Stephen.<lb n="50492"/> 
-            <said who="the dean">―Undoubtedly,</said> said the dean.<lb n="50493"/> 
+            <said who="Stephen Dedalus">―I meant a different kind of lamp, sir,</said> said Stephen.<lb n="50492"/>
+            <said who="the dean">―Undoubtedly,</said> said the dean.<lb n="50493"/>
             <said who="Stephen Dedalus">―One difficulty,</said> said Stephen, <said who="Stephen Dedalus">in esthetic discussion is to <lb n="50494"/>
             know whether words are being used according to the literary <lb n="50495"/>
             tradition or according to the tradition of the marketplace. I <lb n="50496"/>
@@ -7182,7 +7181,7 @@
             selfembittered. <lb n="51132"/>
             <said who="Stephen">―As for that,</said> Stephen said in polite parenthesis, <said who="Stephen">we are all <lb n="51133"></lb>
             animals. I also am an animal.<lb n="51134"></lb> </said>
-            <said who="Lynch">You are,</said> said Lynch.<lb n="51135"/> 
+            <said who="Lynch">You are,</said> said Lynch.<lb n="51135"/>
             <said who="Stephen Dedalus">―But we are just now in a mental world,</said> Stephen continued. <lb n="51136"/>
             <said who="Stephen Dedalus">The desire and loathing excited by improper esthetic means are <lb n="51137"/>
             really not esthetic emotions not only because they are kinetic <lb n="51138"/>
@@ -7200,7 +7199,7 @@
             or ought to induce, an esthetic stasis, an ideal pity or an ideal <lb n="51150"/>
             terror, a stasis called forth, prolonged and at last dissolved by <lb n="51151"/>
             what I call the rhythm of beauty.<lb n="51152"/> </said>
-            <said who="Lynch">―What is that exactly?</said> asked Lynch.<lb n="51153"/> 
+            <said who="Lynch">―What is that exactly?</said> asked Lynch.<lb n="51153"/>
             <said who="Stephen Dedalus">―Rhythm, said Stephen, is the first formal esthetic relation of <lb n="51154"/>
             part to part in any esthetic whole or of an esthetic whole to its <lb n="51155"/>
             part or parts or of any part to the esthetic whole of which it is a <lb n="51156"/>
@@ -7295,7 +7294,7 @@
             <said who="Lynch">―To wit?</said> said Lynch.<lb n="51245"/>
             <said who="Stephen Dedalus">―This hypothesis,</said> Stephen began.<lb n="51246"/></p>
             <p> A long dray laden with old iron came round the corner of <lb n="51247"/>
-            <place><location><geo>53.339029 -6.241523</geo></location><placeName>sir Patrick Dun's</placeName></place> hospital covering the end of Stephen's speech <lb n="51248"/>
+            <place><location><geo>53.339029 -6.241523</geo></location><placeName>sir Patrick Dun's hospital</placeName></place> covering the end of Stephen's speech <lb n="51248"/>
             with the harsh roar of jangled and rattling metal. Lynch closed <lb n="51249"/>
             his ears and gave out oath after oath till the dray had passed. <lb n="51250"/>
             Then he turned on his heel rudely. Stephen turned also and <lb n="51251"/>
@@ -7833,9 +7832,9 @@
               <l>With languorous look and lavish limb.</l> <lb n="51765"/>
               <l>Are you not weary of ardent ways?</l> <lb n="51766"/>
               <l>Tell no more of enchanted days.</l> <lb n="51767"/>
-          </lg> 
+          </lg>
         <milestone unit="section" rend="asterixes"/>
-        </div> <!-- 5.2 --> 
+        </div> <!-- 5.2 -->
         <div n="5.3" type="section">
               <p>What birds were they?<lb n="51768"/> </p>
               <p>He stood on the steps of the library to look at them, leaning <lb n="51769"/>
@@ -8028,7 +8027,7 @@
               <said who="Temple">―He had, faith,</said> Temple said. <said who="Temple">And he was a married man too. <lb n="51954"></lb>
               And all the priests used to be dining there. By hell, I think they <lb n="51955"></lb>
               all had a touch.<lb n="51956"></lb> </said>
-              <said who="Dixon">―We shall call it riding a hack to spare the hunter,</said> said Dixon.<lb n="51957"/> 
+              <said who="Dixon">―We shall call it riding a hack to spare the hunter,</said> said Dixon.<lb n="51957"/>
               <said who="O'Keeffe">―Tell us, Temple,</said> O'Keeffe said. <said who="O'Keeffe">How many quarts of porter <lb n="51958"/>
               have you in you?<lb n="51959"/> </said>
               <said who="Temple">―All your intellectual soul is in that phrase, O'Keeffe, said <lb n="51960"/>
@@ -8058,8 +8057,8 @@
               turning to Stephen. <said who="Temple">Do you know what Giraldus Cambrensis <lb n="51984"/>
               says about your family?<lb n="51985"/> </said>
               <said who="???">―Is he descended from Baldwin too?</said> asked a tall consumptive <lb n="51986"/>
-              student with dark eyes.<lb n="51987"/> 
-              <said who="Cranly">―Baldhead,</said> Cranly repeated, sucking at a crevice in his teeth.<lb n="51988"/> 
+              student with dark eyes.<lb n="51987"/>
+              <said who="Cranly">―Baldhead,</said> Cranly repeated, sucking at a crevice in his teeth.<lb n="51988"/>
               <said who="Temple">―<seg xml:lang="la">Pernobilis et pervetusta familia</seg>,</said> Temple said to Stephen.<lb n="51989"/></p>
               <p> The stout student who stood below them on the steps farted <lb n="51990"/>
               briefly. Dixon turned towards him saying in a soft voice: <lb n="51991"/>
@@ -8084,7 +8083,7 @@
               <said who="Temple">―Do you believe in the law of heredity?<lb n="52010"/> </said>
               <said who="Cranly">―Are you drunk or what are you or what are you trying to <lb n="52011"/>
               say?</said> asked Cranly, facing round on him with an expression of <lb n="52012"/>
-              wonder.<lb n="52013"/> 
+              wonder.<lb n="52013"/>
               <said who="Temple">―The most profound sentence ever written,</said> Temple said with <lb n="52014"/>
               enthusiasm, <said who="Temple">is the sentence at the end of the zoology. Repro- <lb n="52015"/>
               duction is the beginning of death.<lb n="52016"/></said> </p>
@@ -8367,8 +8366,8 @@
               duty.<lb n="52293"/> </said>
               <said who="Cranly">―And will you?<lb n="52294"/> </said>
               <said who="Stephen Dedalus">―I will not,</said> Stephen said.<lb n="52295"/>
-              <said who="Cranly">―Why not?</said> Cranly said.<lb n="52296"/> 
-              <said who="Stephen Dedalus">―I will not serve,</said> answered Stephen.<lb n="52297"/> 
+              <said who="Cranly">―Why not?</said> Cranly said.<lb n="52296"/>
+              <said who="Stephen Dedalus">―I will not serve,</said> answered Stephen.<lb n="52297"/>
               <said who="Cranly">―That remark was made before,</said> Cranly said calmly.<lb n="52298"/>
               <said who="Stephen Dedalus">―It is made behind now,</said> said Stephen hotly.<lb n="52299"/> </p>
               <p> Cranly pressed Stephen's arm, saying: <lb n="52300"/>
@@ -8381,9 +8380,9 @@
               <p> Their minds, lately estranged, seemed suddenly to have been <lb n="52307"/>
               drawn closer, one to the other. <lb n="52308"/>
               <said who="Cranly">―Do you believe in the eucharist?</said> Cranly asked.<lb n="52309"/>
-              <said who="Stephen Dedalus">―I do not,</said> Stephen said.<lb n="52310"/> 
+              <said who="Stephen Dedalus">―I do not,</said> Stephen said.<lb n="52310"/>
               <said who="Cranly">―Do you disbelieve then?<lb n="52311"/> </said>
-              <said who="Stephen Dedalus">―I neither believe in it nor disbelieve in it,</said> Stephen answered.<lb n="52312"/> 
+              <said who="Stephen Dedalus">―I neither believe in it nor disbelieve in it,</said> Stephen answered.<lb n="52312"/>
               <said who="Cranly">―Many persons have doubts, even religious persons, yet they <lb n="52313"/>
               overcome them or put them aside,</said> Cranly said. <said who="Cranly">Are your <lb n="52314"/>
               doubts on that point too strong?<lb n="52315"/> </said>
@@ -8506,7 +8505,7 @@
               smile which some force of will strove to make finely significant.<lb n="52432"/> </p>
               <p> Cranly asked suddenly in a plain sensible tone: <lb n="52433"/>
               <said who="Cranly">―Tell me the truth. Were you at all shocked by what I said?<lb n="52434"/> </said>
-              <said who="Stephen Dedalus">―Somewhat,</said> Stephen said.<lb n="52435"/> 
+              <said who="Stephen Dedalus">―Somewhat,</said> Stephen said.<lb n="52435"/>
               <said who="Cranly">―And why were you shocked,</said> Cranly pressed on in the same <lb n="52436"/>
               tone, <said who="Cranly">if you feel sure that our religion is false and that Jesus <lb n="52437"/>
               was not the son of God?<lb n="52438"/> </said>
@@ -8592,8 +8591,8 @@
               was coming to an end. Yes: he would go. He could not strive <lb n="52516"/>
               against another. He knew his part. <lb n="52517"/>
               <said who="Stephen Dedalus">―Probably I shall go away,</said> he said.<lb n="52518"/>
-              <said who="Cranly">―Where?</said> Cranly asked.<lb n="52519"/> 
-              <said who="Stephen Dedalus">―Where I can,</said> Stephen said.<lb n="52520"/> 
+              <said who="Cranly">―Where?</said> Cranly asked.<lb n="52519"/>
+              <said who="Stephen Dedalus">―Where I can,</said> Stephen said.<lb n="52520"/>
               <said who="Cranly">―Yes,</said> Cranly said. <said who="Cranly">It might be difficult for you to live here <lb n="52521"/>
               now. But is it that that makes you go?<lb n="52522"/> </said>
               <said who="Stephen Dedalus">―I have to go,</said> Stephen answered.<lb n="52523"/> </p>
@@ -8683,7 +8682,7 @@
               <said who="Stephen Dedalus">―Of whom are you speaking?</said> Stephen asked at length.<lb n="52607"/></p>
               <p> Cranly did not answer.<lb n="52608"/> </p>
             <milestone unit="section" rend="asterixes"/>
-        </div> <!-- 5.3 --> 
+        </div> <!-- 5.3 -->
         <div n="5.4" type="section">
               <p> <emph>20 March:</emph> Long talk with Cranly on the subject of my re- <lb n="52609"/>
               volt. He had his grand manner on. I supple and suave. Attacked <lb n="52610"/>


### PR DESCRIPTION
Most geotags contained latitude and longitude separated by a space, but a few were separated by comma. Standardized so all separated by space.

Fixed one errant line break between tags.

Fixed a few instances where placeName was in as placename and persName was in as persname.